### PR TITLE
Add OpenRouter as an LLM provider

### DIFF
--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -60,7 +60,7 @@ func modelOptionsForProvider(provider string) []string {
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
 	case "openrouter":
-		return []string{"openai/gpt-4o", "anthropic/claude-sonnet-4", "deepseek/deepseek-chat"}
+		return []string{"anthropic/claude-sonnet-4", "deepseek/deepseek-chat", "openai/gpt-4o"}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -46,7 +46,7 @@ func joinOrFallback(items []string, fallback string) string {
 }
 
 func providerOptions() []string {
-	return []string{"gemini", "openai", "anthropic", "ollama"}
+	return []string{"gemini", "openai", "anthropic", "openrouter", "ollama"}
 }
 
 func ProviderOptions() []string {
@@ -59,6 +59,8 @@ func modelOptionsForProvider(provider string) []string {
 		return []string{"gpt-4.1", "gpt-4o-2024-11-20", "gpt-5.3-chat-latest", "gpt-5-chat-latest", "gpt-4.1-nano-2025-04-14", "gpt-4.1-mini", "gpt-5.4-mini"}
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
+	case "openrouter":
+		return []string{"openai/gpt-4o", "anthropic/claude-sonnet-4", "deepseek/deepseek-chat"}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:
@@ -84,6 +86,8 @@ func envVarForProvider(provider string) string {
 		return "OPENAI_API_KEY"
 	case "anthropic":
 		return "ANTHROPIC_API_KEY"
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
 	case "ollama":
 		return ""
 	default:

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -60,7 +60,7 @@ func modelOptionsForProvider(provider string) []string {
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
 	case "openrouter":
-		return []string{"anthropic/claude-sonnet-4", "deepseek/deepseek-chat", "openai/gpt-4o"}
+		return []string{"deepseek/deepseek-v4-flash"}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,15 +220,15 @@ func defaultLLMProviders() map[string]LLMProviderConfig {
 			},
 		},
 		"openrouter": {
-			Model:    "openai/gpt-4o",
+			Model:    "anthropic/claude-sonnet-4",
 			Endpoint: "https://openrouter.ai/api/v1",
 			Models: map[string]string{
-				llmTaskJobSearch:        "openai/gpt-4o",
-				llmTaskCompanyHealth:    "openai/gpt-4o",
-				llmTaskFiltering:        "openai/gpt-4o",
-				llmTaskJobIdentity:      "openai/gpt-4o",
-				llmTaskResumeCriteria:   "openai/gpt-4o",
-				llmTaskBenchmarkDefault: "openai/gpt-4o",
+				llmTaskJobSearch:        "anthropic/claude-sonnet-4",
+				llmTaskCompanyHealth:    "anthropic/claude-sonnet-4",
+				llmTaskFiltering:        "anthropic/claude-sonnet-4",
+				llmTaskJobIdentity:      "anthropic/claude-sonnet-4",
+				llmTaskResumeCriteria:   "anthropic/claude-sonnet-4",
+				llmTaskBenchmarkDefault: "anthropic/claude-sonnet-4",
 			},
 			Auth: LLMAuthConfig{
 				Mode:   llmAuthModeEnv,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,15 +220,15 @@ func defaultLLMProviders() map[string]LLMProviderConfig {
 			},
 		},
 		"openrouter": {
-			Model:    "anthropic/claude-sonnet-4",
+			Model:    "deepseek/deepseek-v4-flash",
 			Endpoint: "https://openrouter.ai/api/v1",
 			Models: map[string]string{
-				llmTaskJobSearch:        "anthropic/claude-sonnet-4",
-				llmTaskCompanyHealth:    "anthropic/claude-sonnet-4",
-				llmTaskFiltering:        "anthropic/claude-sonnet-4",
-				llmTaskJobIdentity:      "anthropic/claude-sonnet-4",
-				llmTaskResumeCriteria:   "anthropic/claude-sonnet-4",
-				llmTaskBenchmarkDefault: "anthropic/claude-sonnet-4",
+				llmTaskJobSearch:        "deepseek/deepseek-v4-flash",
+				llmTaskCompanyHealth:    "deepseek/deepseek-v4-flash",
+				llmTaskFiltering:        "deepseek/deepseek-v4-flash",
+				llmTaskJobIdentity:      "deepseek/deepseek-v4-flash",
+				llmTaskResumeCriteria:   "deepseek/deepseek-v4-flash",
+				llmTaskBenchmarkDefault: "deepseek/deepseek-v4-flash",
 			},
 			Auth: LLMAuthConfig{
 				Mode:   llmAuthModeEnv,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,7 +157,7 @@ func defaultAppConfig() AppConfig {
 	cfg.LLM.JobFiltering = true
 	cfg.LLM.CompanyHealth = true
 	cfg.LLM.FallbackToNonLLM = true
-	cfg.LLM.PreferredOrder = []string{"gemini", "openai", "anthropic", "ollama"}
+	cfg.LLM.PreferredOrder = []string{"gemini", "openai", "openrouter", "anthropic", "ollama"}
 	cfg.LLM.Auth.Mode = llmAuthModeEnv
 	cfg.LLM.Auth.EnvVar = envVarForProvider(cfg.LLM.Provider)
 	cfg.LLM.Providers = defaultLLMProviders()
@@ -217,6 +217,22 @@ func defaultLLMProviders() map[string]LLMProviderConfig {
 			Auth: LLMAuthConfig{
 				Mode:   llmAuthModeEnv,
 				EnvVar: "ANTHROPIC_API_KEY",
+			},
+		},
+		"openrouter": {
+			Model:    "openai/gpt-4o",
+			Endpoint: "https://openrouter.ai/api/v1",
+			Models: map[string]string{
+				llmTaskJobSearch:        "openai/gpt-4o",
+				llmTaskCompanyHealth:    "openai/gpt-4o",
+				llmTaskFiltering:        "openai/gpt-4o",
+				llmTaskJobIdentity:      "openai/gpt-4o",
+				llmTaskResumeCriteria:   "openai/gpt-4o",
+				llmTaskBenchmarkDefault: "openai/gpt-4o",
+			},
+			Auth: LLMAuthConfig{
+				Mode:   llmAuthModeEnv,
+				EnvVar: "OPENROUTER_API_KEY",
 			},
 		},
 		"ollama": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,8 +346,8 @@ func TestDefaultLLMProvidersIncludesOpenRouter(t *testing.T) {
 	if !ok {
 		t.Fatal("DefaultLLMProviders() does not contain openrouter")
 	}
-	if cfg.Model != "anthropic/claude-sonnet-4" {
-		t.Fatalf("DefaultLLMProviders()[openrouter].Model = %q, want anthropic/claude-sonnet-4", cfg.Model)
+	if cfg.Model != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("DefaultLLMProviders()[openrouter].Model = %q, want deepseek/deepseek-v4-flash", cfg.Model)
 	}
 	if cfg.Endpoint != "https://openrouter.ai/api/v1" {
 		t.Fatalf("DefaultLLMProviders()[openrouter].Endpoint = %q, want https://openrouter.ai/api/v1", cfg.Endpoint)
@@ -366,8 +366,8 @@ func TestEnvVarForProviderReturnsOpenRouterKey(t *testing.T) {
 
 func TestDefaultModelForProviderReturnsFirstForOpenRouter(t *testing.T) {
 	model := DefaultModelForProvider("openrouter")
-	if model != "anthropic/claude-sonnet-4" {
-		t.Fatalf("DefaultModelForProvider(openrouter) = %q, want anthropic/claude-sonnet-4", model)
+	if model != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("DefaultModelForProvider(openrouter) = %q, want deepseek/deepseek-v4-flash", model)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,8 +346,8 @@ func TestDefaultLLMProvidersIncludesOpenRouter(t *testing.T) {
 	if !ok {
 		t.Fatal("DefaultLLMProviders() does not contain openrouter")
 	}
-	if cfg.Model != "openai/gpt-4o" {
-		t.Fatalf("DefaultLLMProviders()[openrouter].Model = %q, want openai/gpt-4o", cfg.Model)
+	if cfg.Model != "anthropic/claude-sonnet-4" {
+		t.Fatalf("DefaultLLMProviders()[openrouter].Model = %q, want anthropic/claude-sonnet-4", cfg.Model)
 	}
 	if cfg.Endpoint != "https://openrouter.ai/api/v1" {
 		t.Fatalf("DefaultLLMProviders()[openrouter].Endpoint = %q, want https://openrouter.ai/api/v1", cfg.Endpoint)
@@ -366,8 +366,8 @@ func TestEnvVarForProviderReturnsOpenRouterKey(t *testing.T) {
 
 func TestDefaultModelForProviderReturnsFirstForOpenRouter(t *testing.T) {
 	model := DefaultModelForProvider("openrouter")
-	if model != "openai/gpt-4o" {
-		t.Fatalf("DefaultModelForProvider(openrouter) = %q, want openai/gpt-4o", model)
+	if model != "anthropic/claude-sonnet-4" {
+		t.Fatalf("DefaultModelForProvider(openrouter) = %q, want anthropic/claude-sonnet-4", model)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -340,6 +340,37 @@ func TestEvaluateCapabilitiesFlagsDisabledLLMWithFeatureToggles(t *testing.T) {
 	}
 }
 
+func TestDefaultLLMProvidersIncludesOpenRouter(t *testing.T) {
+	providers := DefaultLLMProviders()
+	cfg, ok := providers["openrouter"]
+	if !ok {
+		t.Fatal("DefaultLLMProviders() does not contain openrouter")
+	}
+	if cfg.Model != "openai/gpt-4o" {
+		t.Fatalf("DefaultLLMProviders()[openrouter].Model = %q, want openai/gpt-4o", cfg.Model)
+	}
+	if cfg.Endpoint != "https://openrouter.ai/api/v1" {
+		t.Fatalf("DefaultLLMProviders()[openrouter].Endpoint = %q, want https://openrouter.ai/api/v1", cfg.Endpoint)
+	}
+	if cfg.Auth.EnvVar != "OPENROUTER_API_KEY" {
+		t.Fatalf("DefaultLLMProviders()[openrouter].Auth.EnvVar = %q, want OPENROUTER_API_KEY", cfg.Auth.EnvVar)
+	}
+}
+
+func TestEnvVarForProviderReturnsOpenRouterKey(t *testing.T) {
+	envVar := EnvVarForProvider("openrouter")
+	if envVar != "OPENROUTER_API_KEY" {
+		t.Fatalf("EnvVarForProvider(openrouter) = %q, want OPENROUTER_API_KEY", envVar)
+	}
+}
+
+func TestDefaultModelForProviderReturnsFirstForOpenRouter(t *testing.T) {
+	model := DefaultModelForProvider("openrouter")
+	if model != "openai/gpt-4o" {
+		t.Fatalf("DefaultModelForProvider(openrouter) = %q, want openai/gpt-4o", model)
+	}
+}
+
 func TestEvaluateRuntimeCapabilitiesUsesConfiguredRuntimePath(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")

--- a/internal/config/llm_normalize.go
+++ b/internal/config/llm_normalize.go
@@ -6,7 +6,7 @@ import (
 )
 
 func defaultLLMPreferredOrder() []string {
-	return []string{"gemini", "openai", "anthropic", "ollama"}
+	return []string{"gemini", "openai", "openrouter", "anthropic", "ollama"}
 }
 
 func llmAuthConfigDefined(auth LLMAuthConfig) bool {

--- a/internal/llm/config_access.go
+++ b/internal/llm/config_access.go
@@ -61,6 +61,8 @@ func modelOptionsForProvider(provider string) []string {
 		return []string{"gpt-4.1", "gpt-4o-2024-11-20", "gpt-5.3-chat-latest", "gpt-5-chat-latest", "gpt-4.1-nano-2025-04-14", "gpt-4.1-mini", "gpt-5.4-mini"}
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
+	case "openrouter":
+		return []string{"openai/gpt-4o", "anthropic/claude-sonnet-4", "deepseek/deepseek-chat"}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:
@@ -82,6 +84,8 @@ func envVarForProvider(provider string) string {
 		return "OPENAI_API_KEY"
 	case "anthropic":
 		return "ANTHROPIC_API_KEY"
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
 	case "ollama":
 		return ""
 	default:

--- a/internal/llm/config_access.go
+++ b/internal/llm/config_access.go
@@ -62,7 +62,7 @@ func modelOptionsForProvider(provider string) []string {
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
 	case "openrouter":
-		return []string{"openai/gpt-4o", "anthropic/claude-sonnet-4", "deepseek/deepseek-chat"}
+		return []string{"anthropic/claude-sonnet-4", "deepseek/deepseek-chat", "openai/gpt-4o"}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:

--- a/internal/llm/config_access.go
+++ b/internal/llm/config_access.go
@@ -62,7 +62,7 @@ func modelOptionsForProvider(provider string) []string {
 	case "anthropic":
 		return []string{"claude-opus-4-1-20250805", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"}
 	case "openrouter":
-		return []string{"anthropic/claude-sonnet-4", "deepseek/deepseek-chat", "openai/gpt-4o"}
+		return []string{}
 	case "ollama":
 		return []string{"llama3", "mistral", "qwen2.5"}
 	default:

--- a/internal/llm/llm_enrichment.go
+++ b/internal/llm/llm_enrichment.go
@@ -105,6 +105,22 @@ func initLLM(ctx context.Context, provider string, providerCfg LLMProviderConfig
 			opts = append(opts, googleai.WithDefaultModel(modelName))
 		}
 		return googleai.New(ctx, opts...)
+	case "openrouter":
+		apiKey := os.Getenv("OPENROUTER_API_KEY")
+		if apiKey == "" {
+			return nil, fmt.Errorf("OPENROUTER_API_KEY environment variable is not set")
+		}
+		opts := []openai.Option{
+			openai.WithToken(apiKey),
+			openai.WithBaseURL("https://openrouter.ai/api/v1"),
+		}
+		if endpoint := strings.TrimSpace(providerCfg.Endpoint); endpoint != "" {
+			opts = append(opts, openai.WithBaseURL(endpoint))
+		}
+		if modelName != "" {
+			opts = append(opts, openai.WithModel(modelName))
+		}
+		return openai.New(opts...)
 	case "ollama":
 		opts := []ollama.Option{}
 		if modelName != "" {
@@ -115,7 +131,7 @@ func initLLM(ctx context.Context, provider string, providerCfg LLMProviderConfig
 		}
 		return ollama.New(opts...)
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider: %s. Supported providers: openai, anthropic, gemini, ollama", provider)
+		return nil, fmt.Errorf("unsupported LLM provider: %s. Supported providers: openai, anthropic, gemini, openrouter, ollama", provider)
 	}
 }
 

--- a/internal/llm/llm_models.go
+++ b/internal/llm/llm_models.go
@@ -62,6 +62,8 @@ func fetchAvailableLLMModels(ctx context.Context, cfg AppConfig) ([]string, erro
 		return fetchAnthropicModels(ctx, &cfg)
 	case "gemini", "googleai":
 		return fetchGeminiModels(ctx, &cfg)
+	case "openrouter":
+		return fetchOpenRouterModels(ctx, &cfg)
 	case "ollama":
 		return fetchOllamaModels(ctx, providerCfg)
 	default:
@@ -269,6 +271,62 @@ func fetchOllamaModels(ctx context.Context, providerCfg LLMProviderConfig) ([]st
 	}
 	sortModels(models)
 	return models, nil
+}
+
+func fetchOpenRouterModels(ctx context.Context, cfg *AppConfig) ([]string, error) {
+	apiKey, _, err := resolveLLMAuth(cfg)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	var resp struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Pricing struct {
+				Prompt string `json:"prompt"`
+			} `json:"pricing"`
+		} `json:"data"`
+	}
+	if err := doModelListRequest(req, &resp); err != nil {
+		return nil, err
+	}
+
+	models := make([]string, 0, len(resp.Data))
+	for _, model := range resp.Data {
+		id := strings.TrimSpace(model.ID)
+		if id == "" || !isOpenRouterChatModel(id) {
+			continue
+		}
+		models = appendUniqueString(models, id)
+	}
+	sortModels(models)
+	return models, nil
+}
+
+func isOpenRouterChatModel(id string) bool {
+	lower := strings.ToLower(id)
+	excluded := []string{
+		"embedding",
+		"moderation",
+		"whisper",
+		"tts",
+		"dall-e",
+		"veo",
+		"janus",
+		"/embed",
+	}
+	for _, token := range excluded {
+		if strings.Contains(lower, token) {
+			return false
+		}
+	}
+	return true
 }
 
 func doModelListRequest(req *http.Request, target any) error {

--- a/internal/llm/llm_models.go
+++ b/internal/llm/llm_models.go
@@ -278,7 +278,7 @@ func fetchOpenRouterModels(ctx context.Context, cfg *AppConfig) ([]string, error
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models/user", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func fetchOpenRouterModels(ctx context.Context, cfg *AppConfig) ([]string, error
 		}
 		models = appendUniqueString(models, id)
 	}
-	sortModels(models)
+	sort.Strings(models)
 	return models, nil
 }
 

--- a/internal/llm/llm_models.go
+++ b/internal/llm/llm_models.go
@@ -286,8 +286,8 @@ func fetchOpenRouterModels(ctx context.Context, cfg *AppConfig) ([]string, error
 
 	var resp struct {
 		Data []struct {
-			ID     string `json:"id"`
-			Name   string `json:"name"`
+			ID      string `json:"id"`
+			Name    string `json:"name"`
 			Pricing struct {
 				Prompt string `json:"prompt"`
 			} `json:"pricing"`

--- a/internal/llm/llm_models_test.go
+++ b/internal/llm/llm_models_test.go
@@ -118,7 +118,7 @@ func TestIsOpenRouterChatModelFiltersNonChatFamilies(t *testing.T) {
 		want bool
 	}{
 		{name: "openai chat model", id: "openai/gpt-4o", want: true},
-		{name: "anthropic chat model", id: "anthropic/claude-sonnet-4", want: true},
+		{name: "anthropic chat model", id: "deepseek/deepseek-v4-flash", want: true},
 		{name: "deepseek chat model", id: "deepseek/deepseek-chat", want: true},
 		{name: "meta chat model", id: "meta-llama/llama-3.3-70b-instruct", want: true},
 		{name: "google chat model", id: "google/gemini-2.5-flash", want: true},

--- a/internal/llm/llm_models_test.go
+++ b/internal/llm/llm_models_test.go
@@ -110,3 +110,33 @@ func TestIsGeminiTextModelFiltersNonTextFamilies(t *testing.T) {
 		})
 	}
 }
+
+func TestIsOpenRouterChatModelFiltersNonChatFamilies(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "openai chat model", id: "openai/gpt-4o", want: true},
+		{name: "anthropic chat model", id: "anthropic/claude-sonnet-4", want: true},
+		{name: "deepseek chat model", id: "deepseek/deepseek-chat", want: true},
+		{name: "meta chat model", id: "meta-llama/llama-3.3-70b-instruct", want: true},
+		{name: "google chat model", id: "google/gemini-2.5-flash", want: true},
+		{name: "embedding model", id: "openai/text-embedding-3-large", want: false},
+		{name: "moderation model", id: "openai/omni-moderation-latest", want: false},
+		{name: "image model", id: "openai/dall-e-3", want: false},
+		{name: "whisper model", id: "openai/whisper-1", want: false},
+		{name: "tts model", id: "openai/tts-1", want: false},
+		{name: "video model", id: "google/veo-3.1-generate-preview", want: false},
+		{name: "janus embed model", id: "deepseek/deepseek-ai/deepseek-janus-pro", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOpenRouterChatModel(tt.id)
+			if got != tt.want {
+				t.Fatalf("isOpenRouterChatModel(%q) = %t, want %t", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/setup/options.go
+++ b/internal/setup/options.go
@@ -29,6 +29,8 @@ func ProviderLabel(provider string) string {
 		return "Google"
 	case "openai":
 		return "OpenAI"
+	case "openrouter":
+		return "OpenRouter"
 	case "ollama":
 		return "Local"
 	default:

--- a/internal/tuiapp/setup_flow_test.go
+++ b/internal/tuiapp/setup_flow_test.go
@@ -149,6 +149,27 @@ func TestProviderOptionsIncludeOllama(t *testing.T) {
 	}
 }
 
+func TestProviderOptionsIncludeOpenRouter(t *testing.T) {
+	options := config.ProviderOptions()
+	found := false
+	for _, option := range options {
+		if option == "openrouter" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("config.ProviderOptions() = %#v, want openrouter included", options)
+	}
+}
+
+func TestProviderOptionsCountIsFive(t *testing.T) {
+	options := config.ProviderOptions()
+	if len(options) != 5 {
+		t.Fatalf("config.ProviderOptions() len = %d, want 5 (gemini, openai, anthropic, openrouter, ollama)", len(options))
+	}
+}
+
 func TestInitialModelOpensRepairMenuWhenOnlyPromptIsMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/tuiapp/setup_view.go
+++ b/internal/tuiapp/setup_view.go
@@ -453,6 +453,9 @@ func (m model) buildSetupOverlaySpec() popupSpec {
 		if maxModelLines < 4 {
 			maxModelLines = 4
 		}
+		if maxModelLines > 14 {
+			maxModelLines = 14
+		}
 		viewport := renderPopupMenuViewport(items, dialogWidth-6, maxModelLines, m.setup.choiceIdx)
 		content.WriteString("\n\n")
 		content.WriteString(viewport.content)
@@ -586,6 +589,9 @@ func (m model) buildSetupOverlaySpec() popupSpec {
 		maxModelLines := popupMaxViewportLines(m.termHeight, 4) - 5
 		if maxModelLines < 4 {
 			maxModelLines = 4
+		}
+		if maxModelLines > 14 {
+			maxModelLines = 14
 		}
 		viewport := renderPopupMenuViewport(items, dialogWidth-6, maxModelLines, m.setup.choiceIdx)
 		content.WriteString("\n\n")


### PR DESCRIPTION
This PR adds support for OpenRouter as an LLM provider. All relevant tests are included for it, and I've tested the whole user flow by hand with it.

One change was required which was to clamp the height of the model choice viewport. OpenRouter naturally has a huge number of options, so the viewport was getting stuck off the top and bottom of the screen. I clamped to 14 as that seems like reasonable number but we can change that if needed.

Thanks for the tool, this should be super helpful!