### PR TITLE
chore(github): Add CODEOWNERS and refine CI merge gate job

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @wallentx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  make-all:
-    name: make all
+  make-check:
+    name: make check
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -52,5 +52,5 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run release gate
-        run: make all
+      - name: Run merge gate
+        run: make check


### PR DESCRIPTION
Fixes https://github.com/wallentx/jobscout/issues/8
This pull request updates the CI workflow configuration and project ownership settings. The main changes include renaming the CI job and its associated commands for clarity, and assigning a new code owner.

**CI workflow improvements:**

* Renamed the main CI job from `make-all` to `make-check` in `.github/workflows/ci.yml` for clearer intent.
* Updated the step name from "Run release gate" to "Run merge gate" and changed the command from `make all` to `make check` to better reflect the job's purpose.

**Project ownership:**

* Added a new code owner (`@wallentx`) for all files in `.github/CODEOWNERS`.