### PR TITLE
Update C4 diagram workflow and refine PR body instructions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+paths:
+  .github/workflows/**/*.{yaml,yml}:
+    # actionlint v1.7.12 has stale metadata for actions/create-github-app-token@v3.
+    # https://github.com/rhysd/actionlint/issues/648
+    ignore:
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,8 +47,8 @@ Use this shape by default, omitting sections that do not add useful information:
 
 ```md
 Summary:
-- What changed
-- Why it changed
+- Short outcome-focused change
+- Short outcome-focused change
 
 Verification:
 - `make all`
@@ -58,9 +58,16 @@ Notes:
 - Risks, follow-ups, or intentionally deferred work
 ```
 
-Keep bullets concrete and easy to read. Mention changed commands, workflows,
-config files, user-visible behavior, and test results. Do not restate every file
-that changed unless the file list itself is important.
+Keep PR bodies terse:
+
+- Do not write an introductory paragraph.
+- Use at most three `Summary` bullets.
+- Prefer outcomes over implementation narration. Say `Uses the app token output for C4 diagram PR creation`, not every intermediate variable or step rename.
+- Do not create extra category headings like `Workflow improvements` or `Actionlint configuration` unless the PR genuinely has separate large areas of work.
+- Do not restate every file that changed unless the file list itself is important.
+- Do not mention obvious mechanical edits such as renamed step IDs, removed env blocks, or moved values unless they explain user-visible behavior or risk.
+- Include `Verification` only for commands or checks that were actually run.
+- Keep each bullet to one concise line when possible.
 
 ## High-level architecture (big picture)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,8 +47,8 @@ Use this shape by default, omitting sections that do not add useful information:
 
 ```md
 Summary:
-- Short outcome-focused change
-- Short outcome-focused change
+- What changed
+- Why it changed
 
 Verification:
 - `make all`

--- a/.github/workflows/c4-diagram.yml
+++ b/.github/workflows/c4-diagram.yml
@@ -21,9 +21,6 @@ jobs:
     if: github.repository == 'wallentx/jobscout'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      APP_CLIENT_ID: ${{ vars.APP_CLIENT_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
     steps:
       - name: Check out repository
@@ -40,12 +37,11 @@ jobs:
           checkout: false
 
       - name: Create bot token
-        id: bot-token
-        if: env.APP_CLIENT_ID != '' && env.APP_PRIVATE_KEY != ''
+        id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ env.APP_CLIENT_ID }}
-          private-key: ${{ env.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
@@ -55,7 +51,7 @@ jobs:
 
       - name: Create C4 diagram update PR
         env:
-          GH_TOKEN: ${{ steps.bot-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: automation/update-c4-diagram
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Classify PR for release label
         id: classify
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHIB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Actions Toolbox
         uses: wallentx/gh-actions/composite/actions-toolbox@main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           checkout: false
 
@@ -105,14 +105,13 @@ jobs:
       - name: Classify PR for release label
         id: classify
         env:
-          GH_TOKEN: ${{ github.token }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHIB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           : "${GH_PR:?Actions Toolbox did not set GH_PR}"
           : "${GH_PR_TITLE:?Actions Toolbox did not set GH_PR_TITLE}"
           : "${GH_PR_URL:?Actions Toolbox did not set GH_PR_URL}"
-          : "${COPILOT_GITHUB_TOKEN:?Missing repository secret COPILOT_GITHUB_TOKEN}"
 
           pr_body="$(printf '%s\n' "${GH_PR_BODY_JSON:-\"\"}" | jq -r '.')"
           pr_files="$(gh pr view "$GH_PR" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path')"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -131,7 +131,6 @@ jobs:
             } | copilot \
               -s \
               --no-color \
-              --no-banner \
               --no-auto-update \
               --no-ask-user \
               --deny-tool=shell \


### PR DESCRIPTION
• Summary:
  - Uses the GitHub App token action inputs directly for C4 diagram PR creation.
  - Adds a narrow actionlint workaround for the known `create-github-app-token@v3`
  metadata false positive.