### PR TITLE
feat(cli): Require file path for import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobscout                       # open the TUI
 jobscout --demo                # try the app with in-memory demo data
 jobscout --fetch-dry-run       # fetch without saving
 jobscout --export-json jobs.json
-jobscout --import < jobs.json
+jobscout --import jobs.json
 jobscout --help
 jobscout --version
 ```
@@ -127,7 +127,7 @@ Options:
 Commands:
   --fetch-dry-run [--json]       Fetch jobs without saving them
   --export-json [path|-]         Export saved jobs as JSON
-  --import, -i                   Import jobs from stdin or editor JSON
+  --import <path>, -i <path>     Import jobs from a JSON file
   --delete-db                    Delete the SQLite database and exit
   --repair-job-identity          Repair missing company identity data
   --bench-llm [options]          Run LLM benchmark cases

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"sort"
 	"strings"
 	"time"
@@ -19,13 +17,13 @@ import (
 	"github.com/wallentx/jobscout/internal/storage"
 )
 
-func runImportCLI(stores appruntime.Stores) int {
+func runImportCLI(stores appruntime.Stores, args []string) int {
 	jobs, err := loadJobsOrEmpty(stores)
 	if err != nil {
 		jobs = []domain.Job{}
 	}
 
-	data, err := readImportData()
+	data, err := readImportFile(args)
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return 1
@@ -43,43 +41,14 @@ func runImportCLI(stores appruntime.Stores) int {
 	return 0
 }
 
-func readImportData() ([]byte, error) {
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, fmt.Errorf("error reading stdin: %v", err)
-		}
-		return data, nil
+func readImportFile(args []string) ([]byte, error) {
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return nil, fmt.Errorf("--import requires a JSON file path")
 	}
-
-	file, err := os.CreateTemp("", "jobs_import_*.json")
+	path := args[0]
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("error creating temp file: %v", err)
-	}
-	tmpPath := file.Name()
-	if err := file.Close(); err != nil {
-		return nil, fmt.Errorf("error closing temp file: %v", err)
-	}
-	defer func() {
-		_ = os.Remove(tmpPath)
-	}()
-
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "nano"
-	}
-	cmd := exec.Command(editor, tmpPath)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("editor failed: %v", err)
-	}
-
-	data, err := os.ReadFile(tmpPath)
-	if err != nil {
-		return nil, fmt.Errorf("error reading temp file: %v", err)
+		return nil, fmt.Errorf("error reading import file %s: %v", path, err)
 	}
 	return data, nil
 }

--- a/internal/jobscout/cli_test.go
+++ b/internal/jobscout/cli_test.go
@@ -50,9 +50,9 @@ func TestRunImportCLISavesDuplicateImportEnrichment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
-	withImportStdin(t, imported)
+	importPath := writeImportFile(t, imported)
 
-	code := runImportCLI(appruntime.Stores{Jobs: store})
+	code := runImportCLI(appruntime.Stores{Jobs: store}, []string{importPath})
 	if code != 0 {
 		t.Fatalf("runImportCLI() = %d; want 0", code)
 	}
@@ -64,6 +64,19 @@ func TestRunImportCLISavesDuplicateImportEnrichment(t *testing.T) {
 	}
 	if store.saved[0].Compensation != "$180,000" {
 		t.Fatalf("saved compensation = %q; want imported enrichment", store.saved[0].Compensation)
+	}
+}
+
+func TestRunImportCLIRequiresFilePath(t *testing.T) {
+	store := &recordingJobStore{}
+	withImportStdin(t, []byte(`[{"company":"Acme","title":"Platform Engineer"}]`))
+
+	code := runImportCLI(appruntime.Stores{Jobs: store}, nil)
+	if code != 1 {
+		t.Fatalf("runImportCLI() = %d; want 1", code)
+	}
+	if store.saveCalls != 0 {
+		t.Fatalf("SaveJobs calls = %d; want 0", store.saveCalls)
 	}
 }
 
@@ -88,6 +101,7 @@ func TestPrintHelpDocumentsCommandLineOptions(t *testing.T) {
 		"--format <text|md|json>",
 		"--format=<text|md|json>",
 		"--json",
+		"--import <path>, -i <path>",
 	} {
 		if !strings.Contains(help, want) {
 			t.Fatalf("printHelp() missing %q in:\n%s", want, help)
@@ -152,4 +166,14 @@ func withImportStdin(t *testing.T, data []byte) {
 		os.Stdin = previous
 		_ = reader.Close()
 	})
+}
+
+func writeImportFile(t *testing.T, data []byte) string {
+	t.Helper()
+
+	path := t.TempDir() + "/jobs.json"
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	return path
 }

--- a/internal/jobscout/run.go
+++ b/internal/jobscout/run.go
@@ -71,7 +71,7 @@ func Run(args []string) int {
 
 	switch options.Command {
 	case appruntime.CommandImportShort, appruntime.CommandImport:
-		return runImportCLI(stores)
+		return runImportCLI(stores, options.CommandArgs)
 	case appruntime.CommandExportJSON:
 		outputPath := ""
 		if len(options.CommandArgs) > 0 {
@@ -179,7 +179,7 @@ func renderHelp() string {
 %s:
   --fetch-dry-run [--json]       Fetch jobs without saving them
   --export-json [path|-]         Export saved jobs as JSON
-  --import, -i                   Import jobs from stdin or editor JSON
+  --import <path>, -i <path>     Import jobs from a JSON file
   --delete-db                    Delete the SQLite database and exit
   --repair-job-identity          Repair missing company identity data
   --bench-llm [options]          Run LLM benchmark cases


### PR DESCRIPTION
This pull request updates the `--import` command for the JobScout CLI to require a JSON file path instead of reading from stdin or opening an editor. The documentation, CLI implementation, and tests have all been updated to reflect this change, simplifying the import workflow and making the command usage more explicit.

**CLI behavior and documentation updates:**

* Changed the `--import` command to require a file path argument, removing support for importing from stdin or an editor. The CLI now returns an error if a file path is not provided. (`internal/jobscout/cli.go`, `README.md`, `internal/jobscout/run.go`) [[1]](diffhunk://#diff-781f06270889b6b923fb59ff792a8cde8857e1ef1a02467ff164a982b33e2cbfL46-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R130) [[4]](diffhunk://#diff-41cd2aa378d4f347c31183bf795bd291fb1a3cbac835f6df4d12b8aeb0823188L182-R182)
* Updated help text and usage examples in both the CLI and `README.md` to document the new required file path argument for `--import`. (`README.md`, `internal/jobscout/run.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R130) [[2]](diffhunk://#diff-41cd2aa378d4f347c31183bf795bd291fb1a3cbac835f6df4d12b8aeb0823188L182-R182)

**Testing improvements:**

* Updated tests to use a temporary file for import, reflecting the new file-based import behavior. Added a new test to verify that omitting the file path results in an error and no jobs are saved. (`internal/jobscout/cli_test.go`) [[1]](diffhunk://#diff-5510b9e5b63670b294cbca285e25902f4e22748f5d3c46dd46373cf25e321f68L53-R55) [[2]](diffhunk://#diff-5510b9e5b63670b294cbca285e25902f4e22748f5d3c46dd46373cf25e321f68R70-R82) [[3]](diffhunk://#diff-5510b9e5b63670b294cbca285e25902f4e22748f5d3c46dd46373cf25e321f68R170-R179)
* Adjusted the CLI runner to accept and pass command arguments for the import command. (`internal/jobscout/run.go`)
* Verified that help output includes the updated import command syntax. (`internal/jobscout/cli_test.go`)