### PR TITLE
fix(tui): refresh stale company health data

### DIFF
--- a/internal/health/cache.go
+++ b/internal/health/cache.go
@@ -91,13 +91,6 @@ func CachedHealthForJob(cache storage.HealthCache, job domain.Job) *domain.Compa
 	return cachedHealth(cache, job.Company)
 }
 
-func StoredHealthForJob(cache storage.HealthCache, job domain.Job) *domain.CompanyHealthResult {
-	if stored := storedHealth(cache, CacheKeyForJob(job)); stored != nil {
-		return stored
-	}
-	return storedHealth(cache, job.Company)
-}
-
 func SetCachedHealth(cache storage.HealthCache, company string, result *domain.CompanyHealthResult) {
 	cache[company] = storage.HealthCacheEntry{Result: result, Timestamp: time.Now()}
 }
@@ -144,14 +137,6 @@ func healthResultHasVolatileSignals(result *domain.CompanyHealthResult) bool {
 func cachedHealth(cache storage.HealthCache, company string) *domain.CompanyHealthResult {
 	entry, ok := cache[company]
 	if !ok || !IsHealthCacheFresh(entry.Timestamp, entry.Result) {
-		return nil
-	}
-	return entry.Result
-}
-
-func storedHealth(cache storage.HealthCache, company string) *domain.CompanyHealthResult {
-	entry, ok := cache[company]
-	if !ok {
 		return nil
 	}
 	return entry.Result

--- a/internal/runtime/memory_stores.go
+++ b/internal/runtime/memory_stores.go
@@ -76,6 +76,15 @@ func (s *memoryHealthStore) SetHealth(company string, result *storage.CompanyHea
 	return nil
 }
 
+func (s *memoryHealthStore) DeleteHealth(company string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.cache, company)
+	delete(s.cache, strings.ToLower(strings.TrimSpace(company)))
+	return nil
+}
+
 func (s *memoryHealthStore) ClearHealthCache() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/storage/sqlite_store.go
+++ b/internal/storage/sqlite_store.go
@@ -527,6 +527,21 @@ func (s *SQLiteStore) SetHealth(company string, result *CompanyHealthResult, fet
 	return nil
 }
 
+func (s *SQLiteStore) DeleteHealth(company string) error {
+	key := normalizeCompanyKey(company)
+	if key == "" {
+		return nil
+	}
+	if _, err := s.db.Exec(`
+		DELETE FROM health_cache
+		WHERE company_key = ?
+			OR lower(trim(company_display)) = ?
+	`, key, key); err != nil {
+		return fmt.Errorf("delete health cache row for %s: %w", company, err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) ClearHealthCache() error {
 	if _, err := s.db.Exec(`DELETE FROM health_cache`); err != nil {
 		return fmt.Errorf("clear health cache: %w", err)

--- a/internal/storage/sqlite_store_test.go
+++ b/internal/storage/sqlite_store_test.go
@@ -142,3 +142,72 @@ func TestSQLiteStoreSkipsStaleHealthCacheSourceVersion(t *testing.T) {
 		t.Fatalf("GetHealth() = (%#v, %v), want stale row skipped", result, fetchedAt)
 	}
 }
+
+func TestSQLiteStoreDeleteHealth(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	fetchedAt := time.Now().Add(-time.Hour)
+
+	if err := store.SetHealth("Acme", &CompanyHealthResult{
+		Company: "Acme",
+		Score:   72,
+	}, fetchedAt); err != nil {
+		t.Fatalf("SetHealth(%q) error = %v", "Acme", err)
+	}
+	if err := store.SetHealth("domain:acme.example", &CompanyHealthResult{
+		Company: "Acme",
+		Score:   88,
+	}, fetchedAt); err != nil {
+		t.Fatalf("SetHealth(%q) error = %v", "domain:acme.example", err)
+	}
+
+	if err := store.DeleteHealth("Acme"); err != nil {
+		t.Fatalf("DeleteHealth(%q) error = %v", "Acme", err)
+	}
+	assertNoSQLiteHealth(t, store, "Acme")
+	assertSQLiteHealthScore(t, store, "domain:acme.example", 88)
+
+	if err := store.DeleteHealth("domain:acme.example"); err != nil {
+		t.Fatalf("DeleteHealth(%q) error = %v", "domain:acme.example", err)
+	}
+	assertNoSQLiteHealth(t, store, "domain:acme.example")
+
+	loadedCache, err := store.LoadHealthCache()
+	if err != nil {
+		t.Fatalf("LoadHealthCache() error = %v", err)
+	}
+	if len(loadedCache) != 0 {
+		t.Fatalf("LoadHealthCache() = %#v, want empty after DeleteHealth calls", loadedCache)
+	}
+}
+
+func assertSQLiteHealthScore(t *testing.T, store *SQLiteStore, company string, want int) {
+	t.Helper()
+
+	result, fetchedAt, err := store.GetHealth(company)
+	if err != nil {
+		t.Fatalf("GetHealth(%q) error = %v", company, err)
+	}
+	if result == nil || result.Score != want {
+		t.Fatalf("GetHealth(%q) = (%#v, %v), want score %d", company, result, fetchedAt, want)
+	}
+}
+
+func assertNoSQLiteHealth(t *testing.T, store *SQLiteStore, company string) {
+	t.Helper()
+
+	result, fetchedAt, err := store.GetHealth(company)
+	if err != nil {
+		t.Fatalf("GetHealth(%q) error = %v", company, err)
+	}
+	if result != nil || !fetchedAt.IsZero() {
+		t.Fatalf("GetHealth(%q) = (%#v, %v), want no health row", company, result, fetchedAt)
+	}
+
+	loadedCache, err := store.LoadHealthCache()
+	if err != nil {
+		t.Fatalf("LoadHealthCache() error = %v", err)
+	}
+	if _, ok := loadedCache[company]; ok {
+		t.Fatalf("LoadHealthCache()[%q] exists after DeleteHealth: %#v", company, loadedCache)
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -17,6 +17,7 @@ type HealthStore interface {
 	SaveHealthCache(cache HealthCache) error
 	GetHealth(company string) (*CompanyHealthResult, time.Time, error)
 	SetHealth(company string, result *CompanyHealthResult, fetchedAt time.Time) error
+	DeleteHealth(company string) error
 	ClearHealthCache() error
 }
 

--- a/internal/tuiapp/app_test_helpers_test.go
+++ b/internal/tuiapp/app_test_helpers_test.go
@@ -15,6 +15,7 @@ type fakeHealthStore struct {
 	getTime   time.Time
 	err       error
 	setCalls  int
+	deleted   []string
 }
 
 func (s *fakeHealthStore) LoadHealthCache() (HealthCache, error) {
@@ -45,6 +46,14 @@ func (s *fakeHealthStore) SetHealth(company string, result *CompanyHealthResult,
 		s.cache = make(HealthCache)
 	}
 	s.cache[company] = HealthCacheEntry{Result: result, Timestamp: fetchedAt}
+	return s.err
+}
+
+func (s *fakeHealthStore) DeleteHealth(company string) error {
+	s.deleted = append(s.deleted, company)
+	if s.cache != nil {
+		delete(s.cache, company)
+	}
 	return s.err
 }
 

--- a/internal/tuiapp/health_flow.go
+++ b/internal/tuiapp/health_flow.go
@@ -841,7 +841,7 @@ func (m model) buildHealthOverlaySpec() popupSpec {
 		lines := structuredPopupLines(fullReport, targetLineWidth)
 		viewport := renderPopupViewport(lines, targetLineWidth, maxHealthLines, m.overlay.health.scrollOffset, nil)
 		body = viewport.content
-		footerText := "u: Update • Esc: Return"
+		footerText := "h/u: Refresh • Esc: Return"
 		if viewport.maxOffset > 0 {
 			footerText = "↑/↓/PgUp/PgDn: Scroll • " + footerText
 		}

--- a/internal/tuiapp/health_overlay_test.go
+++ b/internal/tuiapp/health_overlay_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	healthpkg "github.com/wallentx/jobscout/internal/health"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -58,7 +60,74 @@ func TestLoadCompanyHealthForJobRequiresCompanyWebsite(t *testing.T) {
 	}
 }
 
-func TestMainListHealthKeyShowsCachedReportWithStockGraph(t *testing.T) {
+func TestMainListHealthKeyShowsFreshCachedReport(t *testing.T) {
+	prevStore := runtimeHealthStore
+	fakeStore := &fakeHealthStore{}
+	runtimeHealthStore = fakeStore
+	t.Cleanup(func() {
+		runtimeHealthStore = prevStore
+	})
+
+	job := Job{
+		Company:        "Acme",
+		Title:          "Backend Engineer",
+		CompanyWebsite: "https://www.acme.example",
+	}
+	cached := &CompanyHealthResult{
+		Company:    "Acme",
+		Score:      82,
+		Confidence: "high",
+		Sources: map[string]interface{}{
+			"stock_history": []interface{}{10.0, 12.0, 11.0, 14.0, 16.0, 15.0, 18.0, 20.0, 19.0, 21.0, 24.0, 23.0},
+		},
+	}
+	m := model{
+		termWidth:     120,
+		termHeight:    40,
+		tableHeight:   calculateTableHeight(40),
+		allJobs:       []Job{job},
+		filteredJobs:  []Job{job},
+		activeFilters: filterValuesFromStatuses(nil),
+		healthCache: HealthCache{
+			"domain:acme.example": {
+				Result:    cached,
+				Timestamp: time.Now(),
+			},
+		},
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	got := updated.(model)
+	if cmd != nil {
+		t.Fatalf("Update(h) cmd = %v; want nil when cached health is fresh", cmd)
+	}
+	if got.overlay.kind != overlayHealth {
+		t.Fatalf("overlay.kind = %v; want overlayHealth", got.overlay.kind)
+	}
+	if got.overlay.health.report != cached {
+		t.Fatalf("overlay.health.report = %#v; want cached report %#v", got.overlay.health.report, cached)
+	}
+	if gotCached := healthpkg.CachedHealthForJob(got.healthCache, job); gotCached != cached {
+		t.Fatalf("healthpkg.CachedHealthForJob(...) = %#v; want cached report %#v", gotCached, cached)
+	}
+	if len(fakeStore.deleted) != 0 {
+		t.Fatalf("deleted health keys = %#v; want none when showing fresh cached report", fakeStore.deleted)
+	}
+
+	rendered := ansi.Strip(got.buildHealthOverlaySpec().body.content)
+	if !strings.Contains(rendered, "1-Year Stock Chart") {
+		t.Fatalf("cached health popup missing stock chart:\n%s", rendered)
+	}
+}
+
+func TestMainListHealthKeyRefreshesStoredReportInsteadOfShowingOldInfo(t *testing.T) {
+	prevStore := runtimeHealthStore
+	fakeStore := &fakeHealthStore{}
+	runtimeHealthStore = fakeStore
+	t.Cleanup(func() {
+		runtimeHealthStore = prevStore
+	})
+
 	job := Job{
 		Company:        "Acme",
 		Title:          "Backend Engineer",
@@ -89,19 +158,75 @@ func TestMainListHealthKeyShowsCachedReportWithStockGraph(t *testing.T) {
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
 	got := updated.(model)
-	if cmd != nil {
-		t.Fatal("Update(h) cmd != nil for cached health report; want cached report shown without refresh")
+	if cmd == nil {
+		t.Fatal("Update(h) cmd = nil; want single health refresh command")
 	}
-	if got.singleHealthTasksActive() {
-		t.Fatal("single health task active after cached h; want no background refresh")
+	if !got.singleHealthTasksActive() {
+		t.Fatal("single health task active = false; want refresh in progress")
 	}
-	if got.overlay.kind != overlayHealth || got.overlay.health.report != cached {
-		t.Fatalf("overlay health report = %#v; want cached report", got.overlay.health.report)
+	if got.overlay.kind != overlayNone {
+		t.Fatalf("overlay.kind = %v; want overlayNone while refresh task owns progress", got.overlay.kind)
+	}
+	if cached := healthpkg.CachedHealthForJob(got.healthCache, job); cached != nil {
+		t.Fatalf("healthpkg.CachedHealthForJob(...) = %#v; want stale cached report ignored", cached)
+	}
+}
+
+func TestHealthOverlayHealthKeyDumpsExistingReportAndRefreshes(t *testing.T) {
+	prevStore := runtimeHealthStore
+	fakeStore := &fakeHealthStore{}
+	runtimeHealthStore = fakeStore
+	t.Cleanup(func() {
+		runtimeHealthStore = prevStore
+	})
+
+	job := Job{
+		Company:        "Acme",
+		Title:          "Backend Engineer",
+		CompanyWebsite: "https://www.acme.example",
+	}
+	report := &CompanyHealthResult{
+		Company:    "Acme",
+		Score:      82,
+		Confidence: "high",
+	}
+	m := model{
+		termWidth:     120,
+		termHeight:    40,
+		tableHeight:   calculateTableHeight(40),
+		allJobs:       []Job{job},
+		filteredJobs:  []Job{job},
+		activeFilters: filterValuesFromStatuses(nil),
+		overlay: overlayState{
+			kind: overlayHealth,
+			health: healthOverlayState{
+				report: report,
+			},
+		},
+		healthCache: HealthCache{
+			"domain:acme.example": {
+				Result:    report,
+				Timestamp: time.Now(),
+			},
+		},
 	}
 
-	rendered := ansi.Strip(got.buildHealthOverlaySpec().body.content)
-	if !strings.Contains(rendered, "1-Year Stock Chart") {
-		t.Fatalf("cached health popup missing stock chart:\n%s", rendered)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	got := updated.(model)
+	if cmd == nil {
+		t.Fatal("Update(h) cmd = nil; want forced health refresh command from health overlay")
+	}
+	if !got.singleHealthTasksActive() {
+		t.Fatal("single health task active = false; want forced refresh in progress")
+	}
+	if got.overlay.kind != overlayNone {
+		t.Fatalf("overlay.kind = %v; want old health overlay cleared before refresh", got.overlay.kind)
+	}
+	if cached := healthpkg.CachedHealthForJob(got.healthCache, job); cached != nil {
+		t.Fatalf("healthpkg.CachedHealthForJob(...) = %#v; want dumped report removed from memory cache", cached)
+	}
+	if len(fakeStore.deleted) == 0 || fakeStore.deleted[0] != "domain:acme.example" {
+		t.Fatalf("deleted health keys = %#v; want domain:acme.example first", fakeStore.deleted)
 	}
 }
 

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -3,6 +3,7 @@ package tuiapp
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/wallentx/jobscout/internal/domain"
 	healthpkg "github.com/wallentx/jobscout/internal/health"
@@ -266,8 +267,12 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.overlay.health.scrollOffset = 0
 		case "end":
 			m.overlay.health.scrollOffset = m.getMaxHealthScroll()
-		case "u":
+		case "h", "u":
+			if len(m.filteredJobs) == 0 || m.cursor < 0 || m.cursor >= len(m.filteredJobs) {
+				return m, nil
+			}
 			job := m.filteredJobs[m.cursor]
+			m.clearStoredHealthForJob(job)
 			cmd := m.startSingleHealthTask(job, true, true)
 			if cmd == nil {
 				return m, nil
@@ -448,7 +453,7 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "h":
 		if mainListKeysAvailable && len(m.filteredJobs) > 0 {
 			job := m.filteredJobs[m.cursor]
-			if cached := healthpkg.StoredHealthForJob(m.healthCache, job); cached != nil {
+			if cached := healthpkg.CachedHealthForJob(m.healthCache, job); cached != nil {
 				m.openHealthOverlay(false, "", cached, "")
 				return m, nil
 			}
@@ -581,5 +586,24 @@ func (m model) setupAcceptsTextInput() bool {
 		return len(m.currentSetupCriteriaChoiceOptions(field.Key)) == 0
 	default:
 		return false
+	}
+}
+
+func (m *model) clearStoredHealthForJob(job Job) {
+	keys := []string{
+		healthpkg.CacheKeyForJob(job),
+		strings.TrimSpace(job.Company),
+		strings.ToLower(strings.TrimSpace(job.Company)),
+	}
+	seen := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		delete(m.healthCache, key)
+		if err := runtimeHealthStore.DeleteHealth(key); err != nil {
+			logDebug("delete health cache failed key=%q error=%v", key, err)
+		}
 	}
 }


### PR DESCRIPTION
• Fixes company health refresh behavior in the TUI.

  - Shows fresh cached company health immediately when pressing `h`
  - Ignores stale cached health instead of showing old data
  - Lets `h` or `u` from the health window discard stored health data and refresh
  from scratch
  - Adds health-store delete support for memory and SQLite-backed stores
  - Updates tests for fresh cache display, stale refresh, and forced refresh from
  the health window