### PR TITLE
feat(tui): Allow Enter key to close detail and health overlays

### DIFF
--- a/internal/tuiapp/health_flow.go
+++ b/internal/tuiapp/health_flow.go
@@ -810,7 +810,7 @@ func (m model) buildHealthOverlaySpec() popupSpec {
 		viewport := renderScrollablePopupText(
 			renderLoadingBody(
 				m.overlay.health.loadingText,
-				"Loading company health data...\n\nPress Enter or Esc to close.",
+				"Loading company health data...\n\nPress Enter or Esc to return.",
 				m.loading.frame,
 				width-6,
 			),

--- a/internal/tuiapp/health_flow.go
+++ b/internal/tuiapp/health_flow.go
@@ -533,7 +533,7 @@ func renderHealthIdentityUnresolvedText(errText string) string {
 	}
 	content.WriteString("Next steps:\n")
 	content.WriteString("Edit the job to add the company website, or run identity repair after fetching richer job data.\n\n")
-	content.WriteString("Press Esc to return.")
+	content.WriteString("Press Enter or Esc to return.")
 	return content.String()
 }
 
@@ -810,7 +810,7 @@ func (m model) buildHealthOverlaySpec() popupSpec {
 		viewport := renderScrollablePopupText(
 			renderLoadingBody(
 				m.overlay.health.loadingText,
-				"Loading company health data...\n\nPress Esc to cancel.",
+				"Loading company health data...\n\nPress Enter or Esc to close.",
 				m.loading.frame,
 				width-6,
 			),
@@ -820,20 +820,20 @@ func (m model) buildHealthOverlaySpec() popupSpec {
 			nil,
 		)
 		body = viewport.content
-		footer = popupHintStyle.Render("Esc: Return")
+		footer = popupHintStyle.Render("Enter/Esc: Return")
 		if viewport.maxOffset > 0 {
-			footer = popupHintStyle.Render("↑/↓/PgUp/PgDn: Scroll • Esc: Return")
+			footer = popupHintStyle.Render("↑/↓/PgUp/PgDn: Scroll • Enter/Esc: Return")
 		}
 	} else if m.overlay.health.err != "" {
-		errBody := fmt.Sprintf("Error loading health data:\n%s\n\nPress Esc to return.", m.overlay.health.err)
+		errBody := fmt.Sprintf("Error loading health data:\n%s\n\nPress Enter or Esc to return.", m.overlay.health.err)
 		if isHealthIdentityUnresolvedText(m.overlay.health.err) {
 			errBody = renderHealthIdentityUnresolvedText(m.overlay.health.err)
 		}
 		viewport := renderScrollablePopupText(errBody, width-6, maxHealthLines, m.overlay.health.scrollOffset, nil)
 		body = viewport.content
-		footer = popupHintStyle.Render("Esc: Return")
+		footer = popupHintStyle.Render("Enter/Esc: Return")
 		if viewport.maxOffset > 0 {
-			footer = popupHintStyle.Render("↑/↓/PgUp/PgDn: Scroll • Esc: Return")
+			footer = popupHintStyle.Render("↑/↓/PgUp/PgDn: Scroll • Enter/Esc: Return")
 		}
 	} else if m.overlay.health.report != nil {
 		targetLineWidth := width - 6
@@ -841,7 +841,7 @@ func (m model) buildHealthOverlaySpec() popupSpec {
 		lines := structuredPopupLines(fullReport, targetLineWidth)
 		viewport := renderPopupViewport(lines, targetLineWidth, maxHealthLines, m.overlay.health.scrollOffset, nil)
 		body = viewport.content
-		footerText := "h/u: Refresh • Esc: Return"
+		footerText := "h/u: Refresh • Enter/Esc: Return"
 		if viewport.maxOffset > 0 {
 			footerText = "↑/↓/PgUp/PgDn: Scroll • " + footerText
 		}

--- a/internal/tuiapp/overlay_view.go
+++ b/internal/tuiapp/overlay_view.go
@@ -48,9 +48,9 @@ func (m model) buildDetailOverlaySpec() popupSpec {
 	maxDetailLines := popupMaxViewportLinesWithChrome(m.termHeight, 6, 8)
 	details := m.currentDetailText(innerW)
 	viewport := renderScrollablePopupText(details, innerW, maxDetailLines, m.overlay.detail.scrollOffset, nil)
-	footerText := "↑/↓: Prev/Next • u: Update • o: Open URL • Esc: Return"
+	footerText := "↑/↓: Prev/Next • u: Update • o: Open URL • Enter/Esc: Return"
 	if viewport.maxOffset > 0 {
-		footerText = "↑/↓: Prev/Next • u: Update • o: Open URL • j/k/PgUp/PgDn: Scroll • Esc: Return"
+		footerText = "↑/↓: Prev/Next • u: Update • o: Open URL • j/k/PgUp/PgDn: Scroll • Enter/Esc: Return"
 	}
 	return popupSpec{
 		width:  dialogWidth,

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -252,7 +252,7 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	if m.overlay.kind == overlayHealth && !m.overlay.health.minimized {
 		switch msg.String() {
-		case "esc":
+		case "enter", "esc":
 			m.clearOverlay()
 			return m, nil
 		case "up", "k":
@@ -286,7 +286,7 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	if m.overlay.kind == overlayDetail {
 		switch msg.String() {
-		case "esc":
+		case "enter", "esc":
 			m.clearOverlay()
 		case "up", "p":
 			if m.cursor > 0 {

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -253,6 +253,11 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.overlay.kind == overlayHealth && !m.overlay.health.minimized {
 		switch msg.String() {
 		case "enter", "esc":
+			if m.overlay.health.loading && m.singleHealthTasksActive() {
+				m.backgroundHealth.expanded = false
+				m.backgroundHealth.animating = false
+				m.backgroundHealth.progress = 0
+			}
 			m.clearOverlay()
 			return m, nil
 		case "up", "k":

--- a/internal/tuiapp/view_overlay_test.go
+++ b/internal/tuiapp/view_overlay_test.go
@@ -388,6 +388,54 @@ func TestHealthLoadingCompletionStaysBackgroundedWhenMinimized(t *testing.T) {
 	t.Fatal("buildMainOverlaySpec() rendered completed health popup; want background completion")
 }
 
+func TestDismissedHealthLoadingCompletionStaysDismissed(t *testing.T) {
+	keys := []tea.KeyType{tea.KeyEnter, tea.KeyEsc}
+	for _, key := range keys {
+		t.Run(key.String(), func(t *testing.T) {
+			m := model{
+				healthCache: make(HealthCache),
+				overlay: overlayState{
+					kind: overlayHealth,
+					health: healthOverlayState{
+						loading:     true,
+						loadingText: "Refreshing Acme",
+					},
+				},
+				backgroundHealth: backgroundHealthState{
+					expanded: true,
+					progress: 1,
+					tasks: map[string]singleHealthTaskState{
+						"acme.example": {company: "Acme"},
+					},
+				},
+				termWidth:  90,
+				termHeight: 30,
+			}
+
+			dismissed, _ := m.Update(tea.KeyMsg{Type: key})
+			got := dismissed.(model)
+			if got.overlay.kind != overlayNone {
+				t.Fatalf("overlay.kind after %s = %v; want overlayNone", key, got.overlay.kind)
+			}
+
+			completed, _ := got.Update(healthLoadedMsg{
+				company:   "Acme",
+				taskKey:   "acme.example",
+				result:    &CompanyHealthResult{Company: "Acme", Sources: map[string]any{}},
+				fetchedAt: time.Now(),
+			})
+			got = completed.(model)
+
+			if got.overlay.kind != overlayNone {
+				t.Fatalf("overlay.kind after dismissed health load completes = %v; want overlayNone", got.overlay.kind)
+			}
+			if cached := got.healthCache["Acme"].Result; cached == nil || cached.Company != "Acme" {
+				t.Fatalf("healthCache[Acme] = %#v; want completed result cached", got.healthCache["Acme"])
+			}
+		})
+	}
+}
+
 func TestBackgroundHealthActivityUsesOneGenericLoadingLabel(t *testing.T) {
 	m := model{
 		termWidth:  100,

--- a/internal/tuiapp/view_overlay_test.go
+++ b/internal/tuiapp/view_overlay_test.go
@@ -550,6 +550,46 @@ func TestDetailShowsPendingEnrichmentAndRefreshesAfterCompletion(t *testing.T) {
 	}
 }
 
+func TestEnterAndEscapeCloseDetailAndHealthOverlays(t *testing.T) {
+	tests := []struct {
+		name    string
+		overlay overlayState
+	}{
+		{
+			name:    "detail",
+			overlay: overlayState{kind: overlayDetail},
+		},
+		{
+			name: "health",
+			overlay: overlayState{
+				kind: overlayHealth,
+				health: healthOverlayState{
+					report: &CompanyHealthResult{Company: "Acme", Score: 82},
+				},
+			},
+		},
+	}
+
+	keys := []tea.KeyType{tea.KeyEnter, tea.KeyEsc}
+	for _, tt := range tests {
+		for _, key := range keys {
+			t.Run(tt.name+"/"+key.String(), func(t *testing.T) {
+				m := model{
+					allJobs:      []Job{{Company: "Acme", Title: "Backend Engineer"}},
+					filteredJobs: []Job{{Company: "Acme", Title: "Backend Engineer"}},
+					overlay:      tt.overlay,
+				}
+
+				updated, _ := m.Update(tea.KeyMsg{Type: key})
+				got := updated.(model)
+				if got.overlay.kind != overlayNone {
+					t.Fatalf("overlay.kind = %v; want overlayNone", got.overlay.kind)
+				}
+			})
+		}
+	}
+}
+
 func TestBackgroundHealthOverlayCyclesTasksWithLeftRight(t *testing.T) {
 	m := model{
 		termWidth:  100,


### PR DESCRIPTION
• Changes overlay close behavior in the TUI.

  - Allows `Enter` as well as `Esc` to close job detail overlays
  - Allows `Enter` as well as `Esc` to close company health overlays
  - Preserves the health refresh hint as `h/u: Refresh`
  - Updates overlay footer text and tests for the new close behavior