### PR TITLE
Update job details validation for active postings

### DIFF
--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -73,6 +73,25 @@ func TestValidateJobURL(t *testing.T) {
 	}
 }
 
+func TestVerifyJobPostingIgnoresLLMCompanyIdentity(t *testing.T) {
+	okServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer okServer.Close()
+
+	job := Job{
+		Company:  "Unknown",
+		Title:    "Platform Engineer",
+		ApplyURL: okServer.URL,
+		Source:   "llm:web_search",
+	}
+
+	got, reason := VerifyJobPosting(context.Background(), job)
+	if !got {
+		t.Fatalf("VerifyJobPosting(%#v) = false, %q; want true for reachable posting URL", job, reason)
+	}
+}
+
 func TestIsKnownNonJobApplyURLAllowsAggregatorJobDetails(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/fetcher/job_validation.go
+++ b/internal/fetcher/job_validation.go
@@ -48,12 +48,8 @@ func logJobValidationRejection(job Job, reason string) {
 }
 
 func unusableJobReason(job Job) string {
-	applyURL := strings.TrimSpace(job.ApplyURL)
-	if applyURL == "" {
-		return "empty URL"
-	}
-	if isKnownNonJobApplyURL(applyURL) {
-		return "not a direct job URL"
+	if reason := unusableJobURLReason(job); reason != "" {
+		return reason
 	}
 	if isLLMGeneratedJob(job) && !jobHasRequiredCompanyIdentity(job) {
 		return "missing company identity"
@@ -61,8 +57,26 @@ func unusableJobReason(job Job) string {
 	return ""
 }
 
+func unusableJobURLReason(job Job) string {
+	applyURL := strings.TrimSpace(job.ApplyURL)
+	if applyURL == "" {
+		return "empty URL"
+	}
+	if isKnownNonJobApplyURL(applyURL) {
+		return "not a direct job URL"
+	}
+	return ""
+}
+
 func UnusableJobReason(job Job) string {
 	return unusableJobReason(job)
+}
+
+func VerifyJobPosting(ctx context.Context, job Job) (bool, string) {
+	if reason := unusableJobURLReason(job); reason != "" {
+		return false, reason
+	}
+	return validateJobURL(ctx, job.ApplyURL)
 }
 
 func isLLMGeneratedJob(job Job) bool {

--- a/internal/tuiapp/background_task.go
+++ b/internal/tuiapp/background_task.go
@@ -98,6 +98,23 @@ func pendingFieldsForJobs(jobs []Job) map[string]map[string]bool {
 	return pending
 }
 
+func jobsNeedingEnrichment(jobs []Job) []Job {
+	targets := make([]Job, 0, len(jobs))
+	seen := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		if len(pendingEnrichmentFields(job)) == 0 {
+			continue
+		}
+		key := backgroundJobKey(job)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		targets = append(targets, job)
+	}
+	return targets
+}
+
 func (m model) pendingField(job Job, field string) bool {
 	if !m.backgroundTask.active || len(m.backgroundTask.pendingFields) == 0 {
 		return false

--- a/internal/tuiapp/posting_validation.go
+++ b/internal/tuiapp/posting_validation.go
@@ -1,0 +1,191 @@
+package tuiapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wallentx/jobscout/internal/fetcher"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type postingValidationTarget struct {
+	key string
+	job Job
+}
+
+type postingValidationResult struct {
+	key    string
+	active bool
+	reason string
+}
+
+type postingValidationCompleteMsg struct {
+	taskID  int
+	checked int
+	results []postingValidationResult
+	err     error
+}
+
+var verifyJobPosting = fetcher.VerifyJobPosting
+
+func postingValidationTargets(jobs []Job) []postingValidationTarget {
+	targets := make([]postingValidationTarget, 0, len(jobs))
+	seen := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		if !postingValidationStatus(job.Status) {
+			continue
+		}
+		key := backgroundJobKey(job)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		targets = append(targets, postingValidationTarget{
+			key: key,
+			job: job,
+		})
+	}
+	return targets
+}
+
+func postingValidationStatus(status string) bool {
+	status = strings.TrimSpace(status)
+	return strings.EqualFold(status, "Unopened") || strings.EqualFold(status, "Viewed")
+}
+
+func validatePostingsCmd(taskID int, targets []postingValidationTarget, progressCh chan<- string) tea.Cmd {
+	return func() tea.Msg {
+		if progressCh != nil {
+			defer close(progressCh)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		results := make([]postingValidationResult, 0, len(targets))
+		for i, target := range targets {
+			reportPostingValidationProgress(progressCh, "Checking active postings %d of %d: %s - %s", i+1, len(targets), target.job.Company, target.job.Title)
+			active, reason := verifyJobPosting(ctx, target.job)
+			if err := ctx.Err(); err != nil {
+				return postingValidationCompleteMsg{
+					taskID:  taskID,
+					checked: len(results),
+					results: results,
+					err:     err,
+				}
+			}
+			results = append(results, postingValidationResult{
+				key:    target.key,
+				active: active,
+				reason: reason,
+			})
+		}
+
+		return postingValidationCompleteMsg{
+			taskID:  taskID,
+			checked: len(results),
+			results: results,
+		}
+	}
+}
+
+func (m model) handlePostingValidationCompleteMsg(msg postingValidationCompleteMsg) (tea.Model, tea.Cmd) {
+	if !m.backgroundTask.active || msg.taskID != m.backgroundTask.id {
+		return m, nil
+	}
+
+	selectedKey := m.selectedJobKey()
+	expired := m.expireInactivePostings(msg.results)
+
+	m.backgroundTask.active = false
+	m.backgroundTask.expanded = false
+	m.backgroundTask.progress = ""
+	m.backgroundTask.pendingFields = nil
+
+	if expired > 0 {
+		if err := saveRuntimeJobs(m.allJobs); err != nil {
+			m.showNotice("Posting Check Save Failed", err.Error(), false)
+			return m, nil
+		}
+	}
+
+	m.applyFilterAndSort()
+	m.restoreCursorToJobKey(selectedKey)
+
+	title := "Posting Check Complete"
+	if msg.err != nil {
+		title = "Posting Check Stopped"
+	}
+	message := postingValidationSummary(msg.checked, expired, msg.err)
+	m.showNotice(title, message, false)
+	return m, nil
+}
+
+func (m *model) expireInactivePostings(results []postingValidationResult) int {
+	if len(results) == 0 {
+		return 0
+	}
+
+	inactive := make(map[string]string, len(results))
+	for _, result := range results {
+		if result.active {
+			continue
+		}
+		inactive[result.key] = result.reason
+	}
+	if len(inactive) == 0 {
+		return 0
+	}
+
+	expired := 0
+	for i := range m.allJobs {
+		job := m.allJobs[i]
+		if !postingValidationStatus(job.Status) {
+			continue
+		}
+		reason, ok := inactive[backgroundJobKey(job)]
+		if !ok {
+			continue
+		}
+		m.allJobs[i].Status = "Expired"
+		expired++
+		if reason != "" {
+			logDebug("posting validation expired company=%q title=%q apply_url=%q reason=%q", job.Company, job.Title, job.ApplyURL, reason)
+		}
+	}
+	return expired
+}
+
+func postingValidationSummary(checked int, expired int, err error) string {
+	lines := []string{
+		fmt.Sprintf("Checked %d active %s.", checked, pluralize(checked, "posting", "postings")),
+		fmt.Sprintf("Marked %d %s as Expired.", expired, pluralize(expired, "posting", "postings")),
+	}
+	if err != nil {
+		lines = append(lines, "", fmt.Sprintf("Stopped before finishing: %v", err))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func pluralize(count int, singular string, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func reportPostingValidationProgress(progressCh chan<- string, format string, args ...any) {
+	if progressCh == nil {
+		return
+	}
+	message := strings.TrimSpace(fmt.Sprintf(format, args...))
+	if message == "" {
+		return
+	}
+	select {
+	case progressCh <- message:
+	default:
+	}
+}

--- a/internal/tuiapp/posting_validation.go
+++ b/internal/tuiapp/posting_validation.go
@@ -29,7 +29,10 @@ type postingValidationCompleteMsg struct {
 	err     error
 }
 
-var verifyJobPosting = fetcher.VerifyJobPosting
+var (
+	verifyJobPosting               = fetcher.VerifyJobPosting
+	postingValidationPerJobTimeout = 20 * time.Second
+)
 
 func postingValidationTargets(jobs []Job) []postingValidationTarget {
 	targets := make([]postingValidationTarget, 0, len(jobs))
@@ -61,21 +64,18 @@ func validatePostingsCmd(taskID int, targets []postingValidationTarget, progress
 		if progressCh != nil {
 			defer close(progressCh)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
 
 		results := make([]postingValidationResult, 0, len(targets))
 		for i, target := range targets {
 			reportPostingValidationProgress(progressCh, "Checking active postings %d of %d: %s - %s", i+1, len(targets), target.job.Company, target.job.Title)
+			ctx, cancel := context.WithTimeout(context.Background(), postingValidationPerJobTimeout)
 			active, reason := verifyJobPosting(ctx, target.job)
 			if err := ctx.Err(); err != nil {
-				return postingValidationCompleteMsg{
-					taskID:  taskID,
-					checked: len(results),
-					results: results,
-					err:     err,
-				}
+				active = true
+				reason = ""
+				reportPostingValidationProgress(progressCh, "Skipped posting check after timeout: %s - %s", target.job.Company, target.job.Title)
 			}
+			cancel()
 			results = append(results, postingValidationResult{
 				key:    target.key,
 				active: active,

--- a/internal/tuiapp/posting_validation_test.go
+++ b/internal/tuiapp/posting_validation_test.go
@@ -1,8 +1,10 @@
 package tuiapp
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -104,5 +106,39 @@ func TestMainListPostingValidationKeyStartsBackgroundTask(t *testing.T) {
 	}
 	if !strings.Contains(got.backgroundTask.progress, "Checking 2 active postings") {
 		t.Fatalf("backgroundTask.progress = %q, want active posting count", got.backgroundTask.progress)
+	}
+}
+
+func TestPostingValidationTimeoutAppliesPerJob(t *testing.T) {
+	previousVerify := verifyJobPosting
+	previousTimeout := postingValidationPerJobTimeout
+	verifyJobPosting = func(ctx context.Context, _ Job) (bool, string) {
+		<-ctx.Done()
+		return false, ctx.Err().Error()
+	}
+	postingValidationPerJobTimeout = time.Millisecond
+	t.Cleanup(func() {
+		verifyJobPosting = previousVerify
+		postingValidationPerJobTimeout = previousTimeout
+	})
+
+	acme := Job{Company: "Acme", Title: "Engineer", ApplyURL: "https://example.com/one"}
+	beta := Job{Company: "Beta", Title: "Designer", ApplyURL: "https://example.com/two"}
+	targets := []postingValidationTarget{
+		{key: backgroundJobKey(acme), job: acme},
+		{key: backgroundJobKey(beta), job: beta},
+	}
+
+	msg := validatePostingsCmd(9, targets, nil)().(postingValidationCompleteMsg)
+	if msg.err != nil {
+		t.Fatalf("expected per-job timeout not to fail the batch, got %v", msg.err)
+	}
+	if msg.checked != len(targets) || len(msg.results) != len(targets) {
+		t.Fatalf("expected all targets checked, got checked=%d results=%d", msg.checked, len(msg.results))
+	}
+	for _, result := range msg.results {
+		if !result.active {
+			t.Fatalf("expected timed out validation to keep posting active, got inactive reason %q", result.reason)
+		}
 	}
 }

--- a/internal/tuiapp/posting_validation_test.go
+++ b/internal/tuiapp/posting_validation_test.go
@@ -1,0 +1,108 @@
+package tuiapp
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestPostingValidationTargetsOnlyUnopenedAndViewedJobs(t *testing.T) {
+	jobs := []Job{
+		{Company: "Acme", Title: "Unopened Role", ApplyURL: "https://jobs.example/acme", Status: "Unopened"},
+		{Company: "Bravo", Title: "Viewed Role", ApplyURL: "https://jobs.example/bravo", Status: "Viewed"},
+		{Company: "Charlie", Title: "Applied Role", ApplyURL: "https://jobs.example/charlie", Status: "Applied"},
+		{Company: "Delta", Title: "Expired Role", ApplyURL: "https://jobs.example/delta", Status: "Expired"},
+	}
+
+	targets := postingValidationTargets(jobs)
+
+	if len(targets) != 2 {
+		t.Fatalf("postingValidationTargets(%#v) len = %d, want 2", jobs, len(targets))
+	}
+	if targets[0].key != backgroundJobKey(jobs[0]) || targets[1].key != backgroundJobKey(jobs[1]) {
+		t.Fatalf("postingValidationTargets(%#v) keys = %#v, want first two jobs", jobs, targets)
+	}
+}
+
+func TestPostingValidationCompletionExpiresOnlyDeadUnopenedAndViewedJobs(t *testing.T) {
+	prevStore := runtimeJobStore
+	fakeStore := &fakeJobStore{}
+	runtimeJobStore = fakeStore
+	t.Cleanup(func() {
+		runtimeJobStore = prevStore
+	})
+
+	deadUnopened := Job{Company: "Acme", Title: "Unopened Role", ApplyURL: "https://jobs.example/acme", Status: "Unopened"}
+	liveViewed := Job{Company: "Bravo", Title: "Viewed Role", ApplyURL: "https://jobs.example/bravo", Status: "Viewed"}
+	appliedSameURL := Job{Company: "Acme", Title: "Applied Role", ApplyURL: deadUnopened.ApplyURL, Status: "Applied"}
+	m := model{
+		allJobs:       []Job{deadUnopened, liveViewed, appliedSameURL},
+		filteredJobs:  []Job{deadUnopened, liveViewed, appliedSameURL},
+		activeFilters: filterValuesFromStatuses(nil),
+		backgroundTask: backgroundTaskState{
+			active: true,
+			id:     7,
+		},
+	}
+
+	updated, cmd := m.Update(postingValidationCompleteMsg{
+		taskID:  7,
+		checked: 2,
+		results: []postingValidationResult{
+			{key: backgroundJobKey(deadUnopened), active: false, reason: "HTTP 404"},
+			{key: backgroundJobKey(liveViewed), active: true},
+		},
+	})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatalf("Update(postingValidationCompleteMsg) cmd = %v, want nil", cmd)
+	}
+	if got.allJobs[0].Status != "Expired" {
+		t.Fatalf("dead unopened status = %q, want Expired", got.allJobs[0].Status)
+	}
+	if got.allJobs[1].Status != "Viewed" {
+		t.Fatalf("live viewed status = %q, want Viewed", got.allJobs[1].Status)
+	}
+	if got.allJobs[2].Status != "Applied" {
+		t.Fatalf("applied same-url status = %q, want Applied", got.allJobs[2].Status)
+	}
+	if got.backgroundTask.active {
+		t.Fatal("backgroundTask.active = true after posting validation complete; want false")
+	}
+	if len(fakeStore.saved) != 3 || fakeStore.saved[0].Status != "Expired" {
+		t.Fatalf("saved jobs = %#v, want expired first job persisted", fakeStore.saved)
+	}
+	if got.overlay.kind != overlayNotice || !strings.Contains(got.overlay.notice.message, "Marked 1 posting as Expired") {
+		t.Fatalf("notice = kind %v message %q, want expired summary", got.overlay.kind, got.overlay.notice.message)
+	}
+}
+
+func TestMainListPostingValidationKeyStartsBackgroundTask(t *testing.T) {
+	jobs := []Job{
+		{Company: "Acme", Title: "Unopened Role", ApplyURL: "https://jobs.example/acme", Status: "Unopened"},
+		{Company: "Bravo", Title: "Viewed Role", ApplyURL: "https://jobs.example/bravo", Status: "Viewed"},
+	}
+	m := model{
+		allJobs:       jobs,
+		filteredJobs:  jobs,
+		activeFilters: filterValuesFromStatuses(nil),
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("V")})
+	got := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("Update(V) cmd = nil, want posting validation command")
+	}
+	if !got.backgroundTask.active || !got.backgroundTask.expanded {
+		t.Fatalf("backgroundTask = %#v, want active expanded validation task", got.backgroundTask)
+	}
+	if got.backgroundTask.title != "Checking Active Postings" {
+		t.Fatalf("backgroundTask.title = %q, want Checking Active Postings", got.backgroundTask.title)
+	}
+	if !strings.Contains(got.backgroundTask.progress, "Checking 2 active postings") {
+		t.Fatalf("backgroundTask.progress = %q, want active posting count", got.backgroundTask.progress)
+	}
+}

--- a/internal/tuiapp/update.go
+++ b/internal/tuiapp/update.go
@@ -34,6 +34,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleBackgroundTaskProgressMsg(msg)
 	case backgroundJobEnrichedMsg:
 		return m.handleBackgroundJobEnrichedMsg(msg)
+	case postingValidationCompleteMsg:
+		return m.handlePostingValidationCompleteMsg(msg)
 	case backgroundTaskAnimMsg:
 		return m.handleBackgroundTaskAnimMsg(msg)
 	case updateCheckMsg:

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -368,6 +368,7 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			jobs := jobsNeedingEnrichment(m.allJobs)
 			pendingFields := pendingFieldsForJobs(jobs)
 			if len(jobs) == 0 || len(pendingFields) == 0 {
+				m.showNotice("Update Missing", "No jobs need missing-field updates.", false)
 				return m, nil
 			}
 			m.nextBackgroundTask++

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -389,6 +389,30 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.restartLoadingIndicator(),
 			)
 		}
+	case "V":
+		if mainListKeysAvailable && !m.fetchingJobs && !m.bulkHealthFetching && !m.backgroundTask.active && len(m.allJobs) > 0 {
+			targets := postingValidationTargets(m.allJobs)
+			if len(targets) == 0 {
+				m.showNotice("Posting Check", "No Unopened or Viewed postings are available to check.", false)
+				return m, nil
+			}
+			m.nextBackgroundTask++
+			taskID := m.nextBackgroundTask
+			progressCh := make(chan string, 8)
+			m.backgroundTask = backgroundTaskState{
+				active:       true,
+				expanded:     true,
+				animProgress: 1,
+				id:           taskID,
+				title:        "Checking Active Postings",
+				progress:     fmt.Sprintf("Checking %d active postings in the background...", len(targets)),
+			}
+			return m, tea.Batch(
+				validatePostingsCmd(taskID, targets, progressCh),
+				waitForBackgroundTaskProgress(taskID, progressCh, nil),
+				m.restartLoadingIndicator(),
+			)
+		}
 	case "down", "j":
 		if m.cursor < len(m.filteredJobs)-1 {
 			m.cursor++

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -363,6 +363,32 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// (Handled above in showHealth, but this is the main list view fallback if needed)
 		// No action defined for 'u' on main list currently.
 		return m, nil
+	case "U":
+		if mainListKeysAvailable && !m.fetchingJobs && !m.bulkHealthFetching && !m.backgroundTask.active && len(m.allJobs) > 0 {
+			jobs := jobsNeedingEnrichment(m.allJobs)
+			pendingFields := pendingFieldsForJobs(jobs)
+			if len(jobs) == 0 || len(pendingFields) == 0 {
+				return m, nil
+			}
+			m.nextBackgroundTask++
+			taskID := m.nextBackgroundTask
+			progressCh := make(chan string, 8)
+			jobCh := make(chan Job, 16)
+			m.backgroundTask = backgroundTaskState{
+				active:        true,
+				expanded:      true,
+				animProgress:  1,
+				id:            taskID,
+				title:         "Updating Job Details",
+				progress:      fmt.Sprintf("Updating missing job and company fields for %d jobs in the background...", len(jobs)),
+				pendingFields: pendingFields,
+			}
+			return m, tea.Batch(
+				enrichAcceptedFetchCmd(taskID, m.sessionLLMDisabled, jobs, progressCh, jobCh),
+				waitForBackgroundTaskProgress(taskID, progressCh, jobCh),
+				m.restartLoadingIndicator(),
+			)
+		}
 	case "down", "j":
 		if m.cursor < len(m.filteredJobs)-1 {
 			m.cursor++

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -124,6 +124,7 @@ func (m model) View() string {
 			formatHelpItem("s", "Status"),
 			formatHelpItem("m", "Mark Viewed"),
 			formatHelpItem("r", "Fetch"),
+			formatHelpItem("U", "Update Missing"),
 			formatHelpItem("c", "Config"),
 			formatHelpItem("D", "Del"),
 			formatHelpItem("E", "Edit"),

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -125,6 +125,7 @@ func (m model) View() string {
 			formatHelpItem("m", "Mark Viewed"),
 			formatHelpItem("r", "Fetch"),
 			formatHelpItem("U", "Update Missing"),
+			formatHelpItem("V", "Check Active"),
 			formatHelpItem("c", "Config"),
 			formatHelpItem("D", "Del"),
 			formatHelpItem("E", "Edit"),

--- a/internal/tuiapp/view_overlay_test.go
+++ b/internal/tuiapp/view_overlay_test.go
@@ -829,6 +829,91 @@ func TestRealTimeJobEnrichmentUpdatesDetailView(t *testing.T) {
 	}
 }
 
+func TestMainListBulkUpdateTargetsOnlyJobsWithMissingEnrichment(t *testing.T) {
+	complete := Job{
+		Company:         "Complete",
+		Title:           "Platform Engineer",
+		ApplyURL:        "https://complete.example/jobs/platform-engineer",
+		CompanyWebsite:  "https://complete.example",
+		CompanySummary:  "Complete builds deployment software for infrastructure teams and platform operators.",
+		CompanyIndustry: "Developer Tools",
+		Compensation:    "$120,000 - $150,000",
+	}
+	missingWebsite := Job{
+		Company:         "NeedsWebsite",
+		Title:           "Site Reliability Engineer",
+		ApplyURL:        "https://jobs.example/needswebsite-sre",
+		CompanySummary:  "NeedsWebsite builds incident response tools for production engineering teams.",
+		CompanyIndustry: "Developer Tools",
+		Compensation:    "$130,000 - $160,000",
+	}
+	missingCompensation := Job{
+		Company:         "NeedsPay",
+		Title:           "Backend Engineer",
+		ApplyURL:        "https://needspay.example/jobs/backend-engineer",
+		CompanyWebsite:  "https://needspay.example",
+		CompanySummary:  "NeedsPay provides payroll automation software for distributed operations teams.",
+		CompanyIndustry: "HR Tech",
+		Compensation:    "Not listed",
+	}
+	m := model{
+		allJobs:      []Job{complete, missingWebsite, missingCompensation},
+		filteredJobs: []Job{complete, missingWebsite, missingCompensation},
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("U")})
+	got := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("Update(U) cmd = nil; want bulk enrichment command")
+	}
+	if !got.backgroundTask.active || !got.backgroundTask.expanded {
+		t.Fatalf("backgroundTask = %#v; want active expanded update task", got.backgroundTask)
+	}
+	if got.backgroundTask.title != "Updating Job Details" {
+		t.Fatalf("backgroundTask.title = %q; want Updating Job Details", got.backgroundTask.title)
+	}
+	if fields := got.backgroundTask.pendingFields[backgroundJobKey(complete)]; len(fields) != 0 {
+		t.Fatalf("pendingFields[%q] = %#v; want complete job skipped", backgroundJobKey(complete), fields)
+	}
+	websiteFields := got.backgroundTask.pendingFields[backgroundJobKey(missingWebsite)]
+	if !websiteFields["company_website"] {
+		t.Fatalf("pendingFields[%q] = %#v; want company_website pending", backgroundJobKey(missingWebsite), websiteFields)
+	}
+	compensationFields := got.backgroundTask.pendingFields[backgroundJobKey(missingCompensation)]
+	if !compensationFields["compensation"] {
+		t.Fatalf("pendingFields[%q] = %#v; want compensation pending", backgroundJobKey(missingCompensation), compensationFields)
+	}
+	if len(got.backgroundTask.pendingFields) != 2 {
+		t.Fatalf("pendingFields len = %d; want 2 incomplete jobs: %#v", len(got.backgroundTask.pendingFields), got.backgroundTask.pendingFields)
+	}
+}
+
+func TestMainListBulkUpdateNoopsWhenNoJobsNeedEnrichment(t *testing.T) {
+	jobs := []Job{
+		{
+			Company:         "Complete",
+			Title:           "Platform Engineer",
+			ApplyURL:        "https://complete.example/jobs/platform-engineer",
+			CompanyWebsite:  "https://complete.example",
+			CompanySummary:  "Complete builds deployment software for infrastructure teams and platform operators.",
+			CompanyIndustry: "Developer Tools",
+			Compensation:    "$120,000 - $150,000",
+		},
+	}
+	m := model{allJobs: jobs, filteredJobs: jobs}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("U")})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatalf("Update(U) cmd = %v; want nil when no jobs need enrichment", cmd)
+	}
+	if got.backgroundTask.active {
+		t.Fatalf("backgroundTask.active = true with no incomplete jobs; task = %#v", got.backgroundTask)
+	}
+}
+
 func TestBackgroundJobEnrichedMsgKeepsListeningForUpdates(t *testing.T) {
 	job := Job{Company: "TestCorp", Title: "Dev"}
 	progressCh := make(chan string)

--- a/internal/tuiapp/view_overlay_test.go
+++ b/internal/tuiapp/view_overlay_test.go
@@ -912,6 +912,12 @@ func TestMainListBulkUpdateNoopsWhenNoJobsNeedEnrichment(t *testing.T) {
 	if got.backgroundTask.active {
 		t.Fatalf("backgroundTask.active = true with no incomplete jobs; task = %#v", got.backgroundTask)
 	}
+	if got.overlay.kind != overlayNotice {
+		t.Fatalf("overlay.kind = %v; want notice when no jobs need enrichment", got.overlay.kind)
+	}
+	if !strings.Contains(got.overlay.notice.message, "No jobs need missing-field updates") {
+		t.Fatalf("overlay notice = %q; want no-op update message", got.overlay.notice.message)
+	}
 }
 
 func TestBackgroundJobEnrichedMsgKeepsListeningForUpdates(t *testing.T) {


### PR DESCRIPTION
• Adds saved-job maintenance actions to the TUI.

  - Adds `U` to update missing job and company fields only for jobs that need
  enrichment
  - Adds `V` to check active `Unopened` and `Viewed` postings in the background
  - Marks only definitely inactive postings as `Expired`
  - Keeps applied/interviewing/ignored jobs out of posting validation
  - Updates footer help text and tests for both actions