### PR TITLE
feat(tui): add health legend overlay

### DIFF
--- a/internal/tuiapp/health_flow.go
+++ b/internal/tuiapp/health_flow.go
@@ -19,20 +19,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func getHealthColor(score int) lipgloss.Color {
-	// Stricter Thresholds
-	if score >= 75 {
-		return lipgloss.Color("46") // Bright Green (Great)
-	} else if score >= 60 {
-		return lipgloss.Color("77") // Light Green (Okay)
-	} else if score >= 45 {
-		return lipgloss.Color("220") // Gold/Yellow (Warning)
-	} else if score >= 30 {
-		return lipgloss.Color("208") // Orange (Risk)
-	}
-	return lipgloss.Color("196") // Red (Critical)
-}
-
 func getStatusStyle(status string, text string) string {
 	switch status {
 	case "Rejected":

--- a/internal/tuiapp/health_legend.go
+++ b/internal/tuiapp/health_legend.go
@@ -20,11 +20,9 @@ func healthLegendMessage() string {
 	b.WriteString("  No symbol: no health data cached yet\n\n")
 
 	b.WriteString("Score colors\n")
-	b.WriteString(healthLegendScoreLine(80, "75-100", "Strong", "good stability signals"))
-	b.WriteString(healthLegendScoreLine(65, "60-74", "Stable", "mostly positive signals"))
-	b.WriteString(healthLegendScoreLine(50, "45-59", "Watch", "mixed or limited signals"))
-	b.WriteString(healthLegendScoreLine(35, "30-44", "Risk", "meaningful caution signals"))
-	b.WriteString(healthLegendScoreLine(15, "0-29", "Critical", "serious health concerns"))
+	for _, band := range healthScoreBands {
+		b.WriteString(healthLegendScoreLine(band))
+	}
 
 	b.WriteString("\nStatus overrides\n")
 	fmt.Fprintf(&b, "%s Rejected\n", renderToken(rejectedStyle, "●"))
@@ -33,7 +31,7 @@ func healthLegendMessage() string {
 	return b.String()
 }
 
-func healthLegendScoreLine(score int, band string, label string, description string) string {
-	dotStyle := lipgloss.NewStyle().Foreground(getHealthColor(score))
-	return fmt.Sprintf("%s %s: %s - %s\n", renderToken(dotStyle, "●"), band, label, description)
+func healthLegendScoreLine(band healthScoreBand) string {
+	dotStyle := lipgloss.NewStyle().Foreground(band.Color)
+	return fmt.Sprintf("%s %s: %s - %s\n", renderToken(dotStyle, "●"), band.Range, band.Label, band.Description)
 }

--- a/internal/tuiapp/health_legend.go
+++ b/internal/tuiapp/health_legend.go
@@ -1,0 +1,39 @@
+package tuiapp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func healthLegendMessage() string {
+	var b strings.Builder
+	b.WriteString("Company column marker\n\n")
+	b.WriteString("Shape shows confidence. Color shows score.\n\n")
+
+	b.WriteString("Confidence symbols\n")
+	symbolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	fmt.Fprintf(&b, "%s High confidence\n", renderToken(symbolStyle, "●"))
+	fmt.Fprintf(&b, "%s Medium confidence\n", renderToken(symbolStyle, "◉"))
+	fmt.Fprintf(&b, "%s Low confidence\n", renderToken(symbolStyle, "○"))
+	b.WriteString("  No symbol: no health data cached yet\n\n")
+
+	b.WriteString("Score colors\n")
+	b.WriteString(healthLegendScoreLine(80, "75-100", "Strong", "good stability signals"))
+	b.WriteString(healthLegendScoreLine(65, "60-74", "Stable", "mostly positive signals"))
+	b.WriteString(healthLegendScoreLine(50, "45-59", "Watch", "mixed or limited signals"))
+	b.WriteString(healthLegendScoreLine(35, "30-44", "Risk", "meaningful caution signals"))
+	b.WriteString(healthLegendScoreLine(15, "0-29", "Critical", "serious health concerns"))
+
+	b.WriteString("\nStatus overrides\n")
+	fmt.Fprintf(&b, "%s Rejected\n", renderToken(rejectedStyle, "●"))
+	fmt.Fprintf(&b, "%s Ignore\n", renderToken(ignoreStyle, "●"))
+	fmt.Fprintf(&b, "%s Expired\n", renderToken(expiredStyle, "●"))
+	return b.String()
+}
+
+func healthLegendScoreLine(score int, band string, label string, description string) string {
+	dotStyle := lipgloss.NewStyle().Foreground(getHealthColor(score))
+	return fmt.Sprintf("%s %s: %s - %s\n", renderToken(dotStyle, "●"), band, label, description)
+}

--- a/internal/tuiapp/health_legend_test.go
+++ b/internal/tuiapp/health_legend_test.go
@@ -1,0 +1,35 @@
+package tuiapp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestHealthLegendUsesSharedScoreBands(t *testing.T) {
+	previousBands := append([]healthScoreBand(nil), healthScoreBands...)
+	healthScoreBands = []healthScoreBand{
+		{Min: 42, Range: "42-100", Label: "Review", Description: "custom shared band", SampleScore: 50, Color: lipgloss.Color("46")},
+	}
+	t.Cleanup(func() {
+		healthScoreBands = previousBands
+	})
+
+	message := ansi.Strip(healthLegendMessage())
+
+	for _, band := range healthScoreBands {
+		want := fmt.Sprintf("%s: %s", band.Range, band.Label)
+		if !strings.Contains(message, want) {
+			t.Fatalf("health legend missing shared score band %q:\n%s", want, message)
+		}
+		if got := getHealthColor(band.SampleScore); got != band.Color {
+			t.Fatalf("getHealthColor(%d) = %q; want shared band color %q", band.SampleScore, got, band.Color)
+		}
+	}
+	if strings.Contains(message, "75-100") {
+		t.Fatalf("health legend used stale hard-coded score bands:\n%s", message)
+	}
+}

--- a/internal/tuiapp/health_score.go
+++ b/internal/tuiapp/health_score.go
@@ -1,0 +1,29 @@
+package tuiapp
+
+import "github.com/charmbracelet/lipgloss"
+
+type healthScoreBand struct {
+	Min         int
+	Range       string
+	Label       string
+	Description string
+	SampleScore int
+	Color       lipgloss.Color
+}
+
+var healthScoreBands = []healthScoreBand{
+	{Min: 75, Range: "75-100", Label: "Strong", Description: "good stability signals", SampleScore: 80, Color: lipgloss.Color("46")},
+	{Min: 60, Range: "60-74", Label: "Stable", Description: "mostly positive signals", SampleScore: 65, Color: lipgloss.Color("77")},
+	{Min: 45, Range: "45-59", Label: "Watch", Description: "mixed or limited signals", SampleScore: 50, Color: lipgloss.Color("220")},
+	{Min: 30, Range: "30-44", Label: "Risk", Description: "meaningful caution signals", SampleScore: 35, Color: lipgloss.Color("208")},
+	{Min: 0, Range: "0-29", Label: "Critical", Description: "serious health concerns", SampleScore: 15, Color: lipgloss.Color("196")},
+}
+
+func getHealthColor(score int) lipgloss.Color {
+	for _, band := range healthScoreBands {
+		if score >= band.Min {
+			return band.Color
+		}
+	}
+	return healthScoreBands[len(healthScoreBands)-1].Color
+}

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -363,6 +363,11 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// (Handled above in showHealth, but this is the main list view fallback if needed)
 		// No action defined for 'u' on main list currently.
 		return m, nil
+	case "l":
+		if mainListKeysAvailable {
+			m.showNotice("Health Legend", healthLegendMessage(), false)
+			return m, nil
+		}
 	case "U":
 		if mainListKeysAvailable && !m.fetchingJobs && !m.bulkHealthFetching && !m.backgroundTask.active && len(m.allJobs) > 0 {
 			jobs := jobsNeedingEnrichment(m.allJobs)

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -121,6 +121,7 @@ func (m model) View() string {
 			formatHelpItem("↑/↓", "Nav"),
 			formatHelpItem("Enter", "Details"),
 			formatHelpItem("h", "Health"),
+			formatHelpItem("l", "Legend"),
 			formatHelpItem("s", "Status"),
 			formatHelpItem("m", "Mark Viewed"),
 			formatHelpItem("r", "Fetch"),

--- a/internal/tuiapp/view_overlay_test.go
+++ b/internal/tuiapp/view_overlay_test.go
@@ -195,6 +195,60 @@ func TestBackgroundTaskRendersActivityAndLegendHotkey(t *testing.T) {
 	}
 }
 
+func TestMainListLegendKeyShowsHealthLegend(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatalf("Update(l) cmd = %v; want nil", cmd)
+	}
+	if got.overlay.kind != overlayNotice {
+		t.Fatalf("overlay.kind = %v; want health legend notice", got.overlay.kind)
+	}
+	if got.overlay.notice.title != "Health Legend" {
+		t.Fatalf("notice title = %q; want Health Legend", got.overlay.notice.title)
+	}
+	message := ansi.Strip(got.overlay.notice.message)
+	for _, want := range []string{
+		"● High confidence",
+		"◉ Medium confidence",
+		"○ Low confidence",
+		"75-100",
+		"60-74",
+		"45-59",
+		"30-44",
+		"0-29",
+		"Rejected",
+		"Ignore",
+		"Expired",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("health legend missing %q:\n%s", want, message)
+		}
+	}
+}
+
+func TestViewHelpIncludesHealthLegendHotkey(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+	}
+
+	rendered := ansi.Strip(m.View())
+	if !strings.Contains(rendered, "l: Legend") {
+		t.Fatalf("View() missing health legend hotkey:\n%s", rendered)
+	}
+}
+
 func TestViewRendersLogoWhenJobTableIsEmpty(t *testing.T) {
 	restoreRuntimePathsAfterTest(t)
 	runtimeBuildVersion = "v1.2.3-abcdef0"


### PR DESCRIPTION
This pull request adds a new "Health Legend" feature to the TUI application, making it easier for users to understand the meaning of health indicators in the main list view. It introduces a new help hotkey, displays a legend overlay when the user presses 'l', and includes comprehensive tests to ensure the feature works as intended.

**Health Legend Feature:**

* Added a new `healthLegendMessage()` function in `health_legend.go` to generate a formatted legend explaining confidence symbols, score colors, and status overrides for health indicators.
* Implemented the 'l' keybinding in the main list view to show the Health Legend overlay, using the new legend message.
* Updated the help bar to include the new 'l: Legend' hotkey for user guidance.

**Testing:**

* Added tests to verify that pressing 'l' displays the Health Legend overlay with correct content, and that the help bar includes the legend hotkey.