### PR TITLE
Potential fix for code scanning alert no. 1: Size computation for allocation may overflow

### DIFF
--- a/internal/domain/title_terms.go
+++ b/internal/domain/title_terms.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"math"
 	"strings"
 )
 
@@ -77,7 +78,11 @@ func normalizeTargetTitleName(value string, roleFamilies []RoleFamilyID) string 
 		return ""
 	}
 	tokens := strings.Fields(value)
-	normalized := make([]string, 0, len(tokens)+1)
+	normalizedCap := len(tokens)
+	if normalizedCap < math.MaxInt {
+		normalizedCap++
+	}
+	normalized := make([]string, 0, normalizedCap)
 	for _, token := range tokens {
 		token = strings.Trim(token, ".,;:()[]{}")
 		if token == "" {

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"regexp"
@@ -671,8 +672,7 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 	prefixCount := len(prefixes)
 	titleCount := len(titles)
 	queryCap := 0
-	maxInt := int(^uint(0) >> 1)
-	if titleCount > 0 && prefixCount <= maxInt/titleCount {
+	if titleCount > 0 && prefixCount <= math.MaxInt/titleCount {
 		queryCap = prefixCount * titleCount
 	}
 

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -667,7 +667,16 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 	case len(titles) == 0:
 		return prefixes
 	}
-	queries := make([]string, 0, len(prefixes)*len(titles))
+
+	prefixCount := len(prefixes)
+	titleCount := len(titles)
+	queryCap := 0
+	maxInt := int(^uint(0) >> 1)
+	if titleCount > 0 && prefixCount <= maxInt/titleCount {
+		queryCap = prefixCount * titleCount
+	}
+
+	queries := make([]string, 0, queryCap)
 	seen := make(map[string]bool)
 	for _, prefix := range prefixes {
 		for _, title := range titles {

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -668,6 +668,14 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 	case len(titles) == 0:
 		return prefixes
 	}
+	const maxTargetedQueryTerms = 10000
+	if len(prefixes) > maxTargetedQueryTerms {
+		prefixes = prefixes[:maxTargetedQueryTerms]
+	}
+	if len(titles) > maxTargetedQueryTerms {
+		titles = titles[:maxTargetedQueryTerms]
+	}
+
 
 	prefixCount := len(prefixes)
 	titleCount := len(titles)

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -140,7 +140,8 @@ func runFetchDryRun(options appruntime.Options, stores appruntime.Stores, jsonOu
 			fmt.Println("Running LLM job filtering on fetched jobs...")
 		}
 		filterCtx, filterCancel := context.WithTimeout(context.Background(), 180*time.Second)
-		newJobs, notices := llmpkg.FilterJobsWithLLM(filterCtx, appCfg, criteriaCfg, newJobs)
+		var notices []string
+		newJobs, notices = llmpkg.FilterJobsWithLLM(filterCtx, appCfg, criteriaCfg, newJobs)
 		filterCancel()
 		for _, notice := range notices {
 			if !jsonOutput {

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -139,9 +139,8 @@ func runFetchDryRun(options appruntime.Options, stores appruntime.Stores, jsonOu
 		if !jsonOutput {
 			fmt.Println("Running LLM job filtering on fetched jobs...")
 		}
-		notices := []string(nil)
 		filterCtx, filterCancel := context.WithTimeout(context.Background(), 180*time.Second)
-		newJobs, notices = llmpkg.FilterJobsWithLLM(filterCtx, appCfg, criteriaCfg, newJobs)
+		newJobs, notices := llmpkg.FilterJobsWithLLM(filterCtx, appCfg, criteriaCfg, newJobs)
 		filterCancel()
 		for _, notice := range notices {
 			if !jsonOutput {

--- a/internal/llm/llm_bench.go
+++ b/internal/llm/llm_bench.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -59,7 +60,14 @@ func runLLMBenchmarkCLI(args []string) {
 		os.Exit(1)
 	}
 
-	records := make([]llmBenchmarkRunRecord, 0, len(selected)*len(models))
+	selectedCount := len(selected)
+	modelCount := len(models)
+	if modelCount > 0 && selectedCount > math.MaxInt/modelCount {
+		fmt.Println("Benchmark error: too many benchmark records to allocate safely")
+		os.Exit(1)
+	}
+	recordCapacity := selectedCount * modelCount
+	records := make([]llmBenchmarkRunRecord, 0, recordCapacity)
 	for _, modelName := range models {
 		if !opts.JSON {
 			fmt.Printf("%s %s\n", cliui.Style("==>", cliui.Cyan, cliui.Bold), cliui.Style(provider+"/"+modelName, cliui.Bold))


### PR DESCRIPTION
Potential fix for [https://github.com/wallentx/jobscout/security/code-scanning/1](https://github.com/wallentx/jobscout/security/code-scanning/1)

Add an overflow guard before allocating `normalized` in `normalizeTargetTitleName` (file `internal/domain/title_terms.go`).  
Best fix: compute capacity safely by checking `len(tokens)` against `math.MaxInt-1` and, in the impossible/extreme case, fall back to `len(tokens)` (or return early). This avoids `len(tokens)+1` overflow while preserving behavior for normal inputs.

Changes needed:
- In `internal/domain/title_terms.go` imports, add `math`.
- In `normalizeTargetTitleName`, replace direct `len(tokens)+1` with guarded capacity calculation:
  - `normalizedCap := len(tokens)`
  - `if normalizedCap < math.MaxInt { normalizedCap++ }`
  - allocate with `normalizedCap`.

No functional behavior change for normal inputs; only overflow-safe hardening.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
