### PR TITLE
fix: Address CodeQL slice allocation alerts

### DIFF
--- a/internal/domain/title_terms.go
+++ b/internal/domain/title_terms.go
@@ -77,7 +77,7 @@ func normalizeTargetTitleName(value string, roleFamilies []RoleFamilyID) string 
 		return ""
 	}
 	tokens := strings.Fields(value)
-	normalized := make([]string, 0, len(tokens)+1)
+	normalized := make([]string, 0, len(tokens))
 	for _, token := range tokens {
 		token = strings.Trim(token, ".,;:()[]{}")
 		if token == "" {

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -667,7 +667,7 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 	case len(titles) == 0:
 		return prefixes
 	}
-	queries := make([]string, 0, len(prefixes)*len(titles))
+	var queries []string
 	seen := make(map[string]bool)
 	for _, prefix := range prefixes {
 		for _, title := range titles {

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -670,6 +671,7 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 	var queries []string
 	seen := make(map[string]bool)
 	for _, prefix := range prefixes {
+		queries = slices.Grow(queries, len(titles))
 		for _, title := range titles {
 			query := combinedTitleSearchQuery(prefix, title)
 			key := strings.ToLower(query)

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -139,7 +139,7 @@ func runFetchDryRun(options appruntime.Options, stores appruntime.Stores, jsonOu
 		if !jsonOutput {
 			fmt.Println("Running LLM job filtering on fetched jobs...")
 		}
-		notices := []string(nil)
+		var notices []string
 		filterCtx, filterCancel := context.WithTimeout(context.Background(), 180*time.Second)
 		newJobs, notices = llmpkg.FilterJobsWithLLM(filterCtx, appCfg, criteriaCfg, newJobs)
 		filterCancel()

--- a/internal/llm/llm_bench.go
+++ b/internal/llm/llm_bench.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/wallentx/jobscout/internal/cliui"
@@ -61,6 +62,7 @@ func runLLMBenchmarkCLI(args []string) {
 
 	var records []llmBenchmarkRunRecord
 	for _, modelName := range models {
+		records = slices.Grow(records, len(selected))
 		if !opts.JSON {
 			fmt.Printf("%s %s\n", cliui.Style("==>", cliui.Cyan, cliui.Bold), cliui.Style(provider+"/"+modelName, cliui.Bold))
 		}

--- a/internal/llm/llm_bench.go
+++ b/internal/llm/llm_bench.go
@@ -59,7 +59,7 @@ func runLLMBenchmarkCLI(args []string) {
 		os.Exit(1)
 	}
 
-	records := make([]llmBenchmarkRunRecord, 0, len(selected)*len(models))
+	var records []llmBenchmarkRunRecord
 	for _, modelName := range models {
 		if !opts.JSON {
 			fmt.Printf("%s %s\n", cliui.Style("==>", cliui.Cyan, cliui.Bold), cliui.Style(provider+"/"+modelName, cliui.Bold))


### PR DESCRIPTION
Fixes CodeQL alerts for overflow-prone slice capacity calculations and a useless slice assignment.

Changes:
- Removes overflow-prone len(a)*len(b) preallocation in benchmark and site-search paths while preserving incremental capacity growth.
- Removes the unnecessary +1 title-token capacity hint.
- Replaces a redundant nil slice literal with a var declaration.