### PR TITLE
Add company health context and data inventory

### DIFF
--- a/docs/DATA_INVENTORY.md
+++ b/docs/DATA_INVENTORY.md
@@ -1,0 +1,276 @@
+# Data Inventory
+
+This is a working inventory of the data `jobscout` already renders, searches,
+scores, stores, or should preserve when it is cheaply available from a page the
+app already fetched.
+
+The goal is not to scrape every possible field. The goal is to avoid throwing
+away useful company, job, source, or evidence facts that can make later
+enrichment and Company Health checks cheaper and more accurate.
+
+## Capture Rule
+
+When a source adapter, browser pass, structured-data parser, or LLM result has
+already paid the cost to visit a URL, keep any fact that can later help one of
+these tasks:
+
+- render clearer job or company details
+- match, filter, sort, or deduplicate jobs
+- resolve company identity
+- narrow a search query
+- reject unrelated health evidence
+- score health or employment risk
+- explain why a result was accepted, rejected, or uncertain
+
+Do not preserve raw page noise as first-class fields. If the value is not useful
+for a task above, keep it out of the durable model.
+
+## Durable Shapes Today
+
+### Jobs
+
+Stored by `internal/domain/job.go` and `internal/storage/sqlite_store.go`.
+
+| Field | Used For | Notes |
+| --- | --- | --- |
+| `company` | table, details, dedupe, search, health identity | Required. |
+| `title` | table, details, dedupe, search, filtering | Required. |
+| `company_website` | details, health cache key, health evidence filtering, profile lookup | Most important company identity field. |
+| `company_summary` | details, health evidence filtering, LLM health context | Useful context, but can be polluted by bad source text. |
+| `company_industry` | details, deterministic filters, health evidence filtering | Currently a single string; many sources expose multiple industries. |
+| `company_identity` | identity evidence for website, summary, industry | Rigid typed buckets today. |
+| `remote` | table/detail text, deterministic filters | Source labels vary. |
+| `compensation` | details, minimum salary filter, enrichment target | Free-form string. |
+| `source` | details, fetch reporting, debugging | Human-readable source label. |
+| `apply_url` | details, open URL, posting validation, dedupe guard | Usually posting URL; external apply URL is not preserved separately. |
+| `why_matches` | details, LLM search/filter explanation | Optional. |
+| `status` | table, filters, status actions, posting validation scope | Values are fixed in TUI. |
+| `date_added` | table date, sorting | Often fetch/import time, not source posted date. |
+| `date_discovered` | import compatibility only | Not stored separately. |
+| `description` | filtering, enrichment, import/export | Often compressed source context, not full job text. |
+
+### Company Identity
+
+Stored by `internal/domain/company_identity.go` and the
+`company_identities` tables.
+
+| Field | Used For | Notes |
+| --- | --- | --- |
+| `key` | canonical identity key | Domain key when possible. |
+| `display_name` | canonical display | Can differ from job row company. |
+| `website` | cache key, health context, identity lookup | Should be official company domain only. |
+| `summary` | health context | Helps reject same-name companies. |
+| `industry` | health context | Should support multi-industry context. |
+| `identity_evidence` | raw JSON evidence | Flexible storage exists, but normal code usually reads only website/summary/industry evidence. |
+| `source_version` | invalidation/versioning | Useful when extraction rules change. |
+| `created_at`, `updated_at` | cache freshness/debugging | Not user-facing today. |
+| `name_aliases` | identity lookup, health searches | Loaded from lookup table. |
+| `domain_aliases` | identity lookup | Loaded from lookup table. |
+
+### Company Health
+
+Stored as `health_cache.payload_json`, so it can already retain rich structured
+data without schema changes.
+
+| Field | Used For | Notes |
+| --- | --- | --- |
+| `company` | health title/cache display | Input or resolved company name. |
+| `score`, `confidence` | table marker, health report, sorting | Score and confidence are separate. |
+| `public` | health report/scoring | Derived from SEC lookup. |
+| `founded_year`, `age_years` | health report/scoring | Wikipedia, Wikidata, domain age, company site, public profiles. |
+| `estimated_employees` | health report/scoring | Used to scale layoff risk. |
+| `signals_used` | debug/explainability | Not shown prominently. |
+| `flags`, `notes`, `notices` | health report | User-visible explanation. |
+| `discovered_ticker`, `discovered_name` | health report, SEC/stock lookup | Useful input for future health passes. |
+| `layoff_signals` | employment risk, report | Title, URL, date, employee count, percentage. |
+| `hn_signals` | sentiment/risk, report | Title, URL, points, comments, date. |
+| `employer_reviews` | score/risk, report | Source, rating, review count, recommend, CEO approval, snippet, URL. |
+| `employment_risk` | score cap, report | Level, score, factors, last layoff date. |
+| `llm_assessment` | health report | Summary, recommendation, risk level, positives, concerns, follow-up questions, token usage. |
+| `rejected_evidence` | debug/report explainability | Critical for showing why bad evidence was ignored. |
+| `sources` | raw structured source payloads | Flexible bucket for stock history, SEC, company site, public profiles, news titles, identity, etc. |
+| `field_assessments` | debug evidence | Tracks evidence candidates for facts such as employees and founded year. |
+
+## Data Used By Search And Scoring
+
+These are the inputs that determine how expensive downstream work is.
+
+| Input | Current Use | Current Gap |
+| --- | --- | --- |
+| company name | all source labels, health searches, SEC, Wikipedia, HN, layoffs | Same-name collisions are common. |
+| aliases | Google News filtering/search, health command input, identity cache | HN and layoff searches do not search aliases. |
+| official website/domain | cache key, identity resolution, public profile searches, evidence acceptance | Some adapters only keep it as evidence URL, not as reusable source context. |
+| summary | health context terms, LLM prompts | Bad summaries can poison matching. |
+| industry | filters, health conflict rejection, LLM prompts | Single-value field loses important context like fintech/payments/crypto. |
+| ticker | SEC and stock history | Jobs do not store it; health can rediscover it. |
+| public/private status | health report/scoring | Stored only in health result. |
+| founded year | age score, report | Stored only in health result. |
+| employee count/range | layoff scaling, report | Stored only in health result/public profile structs. |
+| review ratings/counts | health score/risk | Stored only in health result. |
+| source profile URL | profile enrichment, evidence trace | Often discarded or only embedded in evidence URL. |
+| source posted date | date sorting/freshness | Often discarded; `date_added` is not the same fact. |
+| source expiration/valid-through | posting validation/freshness | Structured JobPosting parser does not preserve it. |
+| external apply URL | opening the actual application page | Built In detail can see `howToApply`, but keeps Built In URL as `apply_url` and normalizes `howToApply` into website. |
+| location/workplace | filtering, display | Stored as `remote` string, not structured locations. |
+| skills | fit filtering, detail display | Built In listing compresses top skills into description. |
+| full job description | filtering, display, enrichment | Detail parsing does not replace a short listing description. |
+
+## Source Adapter Inventory
+
+### Built In
+
+Current listing extraction captures company, title, Built In job URL, work
+setting, compensation, short description, one industry, top skills in
+description text, company profile URL, and sometimes website evidence.
+
+Current detail extraction captures company name, title, structured JobPosting
+facts, compensation, industry, summary, and Built In `howToApply` as company
+website evidence.
+
+Useful facts Built In can expose but the durable job model currently loses or
+compresses:
+
+- full industry list
+- top skills as structured values
+- Built In company profile URL
+- external apply URL separate from source posting URL
+- source posted or reposted date
+- source location labels
+- employment type
+- structured `datePosted` and `validThrough`
+- structured `jobLocation` and applicant location requirements
+- company size or employee range from company/profile pages
+- headquarters from company/profile pages
+- founded year from company/profile pages
+- ticker or public-company hints when present
+- richer source evidence for each extracted fact
+
+### Generic Site Search
+
+The browser probe sees anchor text, href, parent/card context, image alt text,
+page title, page body text, and a score. The persisted job keeps only the
+minimal normalized job: company, title, URL, remote, source, and a small
+description. The discarded context could help explain confidence, extract
+location/posted-date/skills, or avoid later LLM/browser work.
+
+### RSS
+
+RSS extraction keeps title/company, link, description, remote inference, and
+default compensation. Feed `Published`, `Updated`, categories, and feed-specific
+metadata are not preserved.
+
+### Structured JobPosting
+
+The parser currently uses:
+
+- `hiringOrganization.name`
+- `hiringOrganization.sameAs` or `url`
+- `title`
+- `description`
+- `baseSalary`
+- `industry`
+
+Useful structured fields currently not preserved:
+
+- `datePosted`
+- `validThrough`
+- `employmentType`
+- `jobLocation`
+- `applicantLocationRequirements`
+- direct apply URL if present
+- richer organization fields beyond name/url
+
+### Public Profiles And Company Site
+
+The health/company-profile path already has richer structs for:
+
+- profile source, URL, title, snippet
+- industry
+- employee range and estimated employees
+- founded year
+- headquarters
+- revenue
+- employer rating, review count, recommend percent, CEO approval
+- website/about text and URLs
+
+These facts feed health today, but they do not feed back into the job or company
+identity model except for website, summary, and industry.
+
+## Health Query Gaps
+
+Current deterministic health checks do use some context, but several searches
+start too broadly:
+
+- Wikipedia searches only company name.
+- SEC lookup uses company and ticker, but not website/domain or aliases.
+- Google News searches company plus aliases, then filters with context.
+- Layoff news searches only `"Company" layoffs`, then filters with context.
+- Hacker News searches only company name, then filters with context.
+- Company-site discovery uses website first, otherwise only company-name
+  queries.
+- Public-profile search is the strongest query today because it includes both
+  company name and website domain.
+
+For ambiguous companies, search construction should prefer the resolved identity
+context we already have. For example, with company name, official domain, and
+industry known, layoff/news searches should include those terms instead of
+querying only the bare company name.
+
+## Persistence Pressure
+
+The current model has three different flexibility levels:
+
+- `health_cache.payload_json` is flexible and already stores rich health
+  evidence.
+- `company_identities.identity_evidence_json` is flexible, but most code treats
+  it like fixed website/summary/industry evidence.
+- `jobs.company_identity_json` is typed as fixed website/summary/industry
+  evidence, and the top-level `jobs` table has no general metadata column.
+
+This means source adapters can often discover useful facts with nowhere clean to
+put them. Before expanding adapters heavily, the data model should decide where
+opportunistic facts live.
+
+Candidate buckets:
+
+- job source facts: posting URL, external apply URL, posted date, expiry,
+  locations, skills, employment type, source profile URL, raw source labels
+- company facts: aliases, domains, industries, founded year, employee range,
+  estimated employees, headquarters, revenue, public profiles, ticker, exchange
+- evidence facts: source, URL, confidence, reason, accepted/rejected state,
+  observed-at timestamp
+
+## Suggested Implementation Split
+
+### Built In Adapter
+
+Improve Built In extraction without changing Company Health logic:
+
+- preserve full industry list instead of collapsing to one value
+- preserve top skills as structured metadata
+- preserve Built In company profile URL
+- preserve external apply URL separately from the Built In posting URL
+- extract structured `datePosted`, `validThrough`, `employmentType`, and
+  location fields when available
+- promote company profile facts such as employee range, founded year, HQ, and
+  ticker/public hints when available
+
+### Health Context
+
+Improve health query construction and evidence filtering without changing the
+Built In adapter:
+
+- include official domain and useful industry terms in ambiguous news/layoff
+  searches
+- search aliases for HN and layoff signals when available
+- use ticker and known public-company hints before broad SEC lookup
+- treat multi-industry context as signal, not as competing single labels
+- show rejected evidence clearly enough to debug false positives
+
+### Data Model
+
+Add a clean place for opportunistic facts before adding many more one-off
+columns. The model should make it easy for any adapter to attach structured
+facts with evidence while still preserving the simple job table fields used by
+the current UI.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ For task-specific details, see:
 - [LLM Features](LLM_FEATURES.md)
 - [Benchmark Reports](BENCHMARKS.md)
 - [Demo Mode](DEMO_MODE.md)
+- [Data Inventory](DATA_INVENTORY.md)
 
 ## Design Goals
 

--- a/internal/domain/company_health.go
+++ b/internal/domain/company_health.go
@@ -51,6 +51,7 @@ func CompanyHealthWithDataSources(identity CompanyHealthContext, ticker string, 
 	}
 	recordCompanyIdentitySource(result, identity)
 	initCompanyHealthAssessments(result)
+	applyCompanyHealthContextFacts(result, identity)
 	recordCompanySiteProfileFetchError(result, siteProfileErr)
 
 	// Wikipedia lookup
@@ -172,6 +173,9 @@ func CompanyHealthWithDataSources(identity CompanyHealthContext, ticker string, 
 	if strings.TrimSpace(secLookupTicker) == "" {
 		secLookupTicker = result.DiscoveredTicker
 	}
+	if strings.TrimSpace(secLookupTicker) == "" {
+		secLookupTicker = identity.Ticker
+	}
 	cik10, foundTicker, foundName, err := secLookupCIK(company, secLookupTicker)
 	secRiskTerms := 0
 	if err == nil {
@@ -263,6 +267,7 @@ func CompanyHealthWithDataSources(identity CompanyHealthContext, ticker string, 
 		if len(hnSignals) > 0 {
 			result.SignalsUsed = append(result.SignalsUsed, "hn_vibe_check")
 			result.HNSignals = hnSignals
+			result.ConcernStories = appendUniqueCompanyHealthConcernStories(result.ConcernStories, concernStoriesFromHNSignals(hnSignals)...)
 			result.Sources["hn"] = map[string]any{
 				"neg_hits": hnNeg,
 				"pos_hits": hnPos,
@@ -278,37 +283,38 @@ func CompanyHealthWithDataSources(identity CompanyHealthContext, ticker string, 
 			}
 		}
 
-		titles, neg, pos, rejectedNews, err := googleNewsSentimentForContext(identity)
-		result.RejectedEvidence = append(result.RejectedEvidence, rejectedNews...)
+		newsResult, err := googleNewsSentimentDetailsForContext(identity)
+		result.RejectedEvidence = append(result.RejectedEvidence, newsResult.Rejected...)
 		if err == nil {
 			result.SignalsUsed = append(result.SignalsUsed, "google_news_rss")
 			result.Sources["news"] = map[string]any{
-				"titles":   titles,
-				"neg_hits": neg,
-				"pos_hits": pos,
+				"titles":   newsResult.Titles,
+				"neg_hits": newsResult.NegHits,
+				"pos_hits": newsResult.PosHits,
 			}
-			negHits = neg
-			posHits = pos
-			if neg >= 3 && neg > pos {
+			result.ConcernStories = appendUniqueCompanyHealthConcernStories(result.ConcernStories, newsResult.ConcernStories...)
+			negHits = newsResult.NegHits
+			posHits = newsResult.PosHits
+			if newsResult.NegHits >= 3 && newsResult.NegHits > newsResult.PosHits {
 				result.Score -= 10
 				result.Flags = append(result.Flags, "negative_news_signal")
 				result.Notes = append(result.Notes, "News titles contain multiple negative-risk keywords.")
-			} else if neg >= 1 && neg > pos {
+			} else if newsResult.NegHits >= 1 && newsResult.NegHits > newsResult.PosHits {
 				result.Score -= 4
 				result.Notes = append(result.Notes, "News titles contain some negative-risk keywords.")
-			} else if neg == 0 && len(titles) > 5 {
+			} else if newsResult.NegHits == 0 && len(newsResult.Titles) > 5 {
 				// Bonus for clean record if we actually found news
 				result.Score += 5
 				result.Notes = append(result.Notes, "No negative news keywords detected in recent headlines.")
 			}
-			if pos >= 2 && pos > neg {
+			if newsResult.PosHits >= 2 && newsResult.PosHits > newsResult.NegHits {
 				result.Score += 4
 				result.Notes = append(result.Notes, "News titles contain multiple positive-momentum keywords.")
-			} else if pos >= 1 && pos > neg {
+			} else if newsResult.PosHits >= 1 && newsResult.PosHits > newsResult.NegHits {
 				result.Score += 2
 				result.Notes = append(result.Notes, "News titles contain some positive-momentum keywords.")
 			}
-			if result.Confidence == "low" && len(titles) > 0 {
+			if result.Confidence == "low" && len(newsResult.Titles) > 0 {
 				result.Confidence = "medium"
 			}
 		}
@@ -334,6 +340,7 @@ func CompanyHealthWithDataSources(identity CompanyHealthContext, ticker string, 
 			result.Flags = append(result.Flags, "layoff_news_detected")
 			result.Notes = append(result.Notes, fmt.Sprintf("Found %d recent layoff headlines (Contributing to Risk Score).", len(layoffSignals)))
 			result.LayoffSignals = layoffSignals
+			result.ConcernStories = appendUniqueCompanyHealthConcernStories(result.ConcernStories, concernStoriesFromLayoffSignals(layoffSignals)...)
 		}
 	}
 
@@ -410,6 +417,10 @@ func recordCompanyIdentitySource(result *CompanyHealthResult, identity CompanyHe
 	if strings.TrimSpace(identity.Website) == "" &&
 		strings.TrimSpace(identity.Summary) == "" &&
 		strings.TrimSpace(identity.Industry) == "" &&
+		len(identity.Industries) == 0 &&
+		strings.TrimSpace(identity.Ticker) == "" &&
+		identity.EstimatedEmployees == nil &&
+		identity.FoundedYear == nil &&
 		len(identity.Aliases) == 0 {
 		return
 	}
@@ -421,12 +432,42 @@ func recordCompanyIdentitySource(result *CompanyHealthResult, identity CompanyHe
 		"summary":  strings.TrimSpace(identity.Summary),
 		"industry": strings.TrimSpace(identity.Industry),
 	}
+	if len(identity.Industries) > 0 {
+		companyIdentity["industries"] = strings.Join(identity.Industries, ", ")
+	}
+	if strings.TrimSpace(identity.Ticker) != "" {
+		companyIdentity["ticker"] = strings.ToUpper(strings.TrimSpace(identity.Ticker))
+	}
+	if identity.EstimatedEmployees != nil {
+		companyIdentity["estimated_employees"] = fmt.Sprintf("%d", *identity.EstimatedEmployees)
+	}
+	if identity.FoundedYear != nil {
+		companyIdentity["founded_year"] = fmt.Sprintf("%d", *identity.FoundedYear)
+	}
 	if len(identity.Aliases) > 0 {
 		companyIdentity["aliases"] = strings.Join(identity.Aliases, ", ")
 	}
 	result.Sources["company_identity"] = companyIdentity
 	if !companyHealthSignalUsed(result.SignalsUsed, "job_company_identity") {
 		result.SignalsUsed = append(result.SignalsUsed, "job_company_identity")
+	}
+}
+
+func applyCompanyHealthContextFacts(result *CompanyHealthResult, identity CompanyHealthContext) {
+	if result == nil {
+		return
+	}
+	if identity.FoundedYear != nil {
+		observeFoundedYear(result, *identity.FoundedYear, "job_company_metadata", "", "medium", "Founded year came from stored company metadata.")
+	}
+	if identity.EstimatedEmployees != nil {
+		observeEmployeeCount(result, *identity.EstimatedEmployees, "job_company_metadata", "", "medium", "Employee count came from stored company metadata.")
+	}
+	if ticker := strings.ToUpper(strings.TrimSpace(identity.Ticker)); ticker != "" && result.DiscoveredTicker == "" {
+		result.DiscoveredTicker = ticker
+		if !companyHealthSignalUsed(result.SignalsUsed, "job_company_ticker") {
+			result.SignalsUsed = append(result.SignalsUsed, "job_company_ticker")
+		}
 	}
 }
 

--- a/internal/domain/company_health_concern_stories.go
+++ b/internal/domain/company_health_concern_stories.go
@@ -1,0 +1,124 @@
+package domain
+
+import (
+	"strings"
+	"time"
+)
+
+const companyHealthConcernStoryWindow = 365 * 24 * time.Hour
+
+func companyHealthConcernReason(title string, keywords []string) string {
+	for _, keyword := range keywords {
+		if wordHitCount(title, []string{keyword}) > 0 {
+			return "negative news keyword: " + keyword
+		}
+	}
+	return ""
+}
+
+func companyHealthConcernStoryRecent(date *time.Time) bool {
+	if date == nil {
+		return false
+	}
+	now := time.Now()
+	if date.After(now.Add(24 * time.Hour)) {
+		return false
+	}
+	return now.Sub(*date) <= companyHealthConcernStoryWindow
+}
+
+func companyHealthConcernStoryFromRSSItem(source string, item RSSItem, keywords []string) (CompanyHealthConcernStory, bool) {
+	concern := companyHealthConcernReason(item.Title, keywords)
+	if concern == "" {
+		return CompanyHealthConcernStory{}, false
+	}
+	date := parseRSSItemPubDate(item.PubDate)
+	if !companyHealthConcernStoryRecent(date) {
+		return CompanyHealthConcernStory{}, false
+	}
+	return CompanyHealthConcernStory{
+		Source:  source,
+		Title:   strings.TrimSpace(item.Title),
+		URL:     strings.TrimSpace(item.Link),
+		Date:    date,
+		Concern: concern,
+	}, true
+}
+
+func concernStoriesFromHNSignals(signals []HNSignal) []CompanyHealthConcernStory {
+	stories := make([]CompanyHealthConcernStory, 0)
+	for _, signal := range signals {
+		concern := companyHealthConcernReason(signal.Title, hnNegKeywords)
+		date := signal.Date
+		if concern == "" || !companyHealthConcernStoryRecent(&date) {
+			continue
+		}
+		stories = append(stories, CompanyHealthConcernStory{
+			Source:  "hacker_news",
+			Title:   strings.TrimSpace(signal.Title),
+			URL:     strings.TrimSpace(signal.URL),
+			Date:    &date,
+			Concern: concern,
+		})
+	}
+	return stories
+}
+
+func concernStoriesFromLayoffSignals(signals []LayoffSignal) []CompanyHealthConcernStory {
+	stories := make([]CompanyHealthConcernStory, 0, len(signals))
+	for _, signal := range signals {
+		if !companyHealthConcernStoryRecent(signal.Date) {
+			continue
+		}
+		stories = append(stories, CompanyHealthConcernStory{
+			Source:  "layoff_news",
+			Title:   strings.TrimSpace(signal.Title),
+			URL:     strings.TrimSpace(signal.URL),
+			Date:    signal.Date,
+			Concern: "layoff signal",
+		})
+	}
+	return stories
+}
+
+func appendUniqueCompanyHealthConcernStories(existing []CompanyHealthConcernStory, stories ...CompanyHealthConcernStory) []CompanyHealthConcernStory {
+	if len(stories) == 0 {
+		return existing
+	}
+	seen := make(map[string]bool, len(existing)+len(stories))
+	for _, story := range existing {
+		seen[companyHealthConcernStoryKey(story)] = true
+	}
+	for _, story := range stories {
+		key := companyHealthConcernStoryKey(story)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		existing = append(existing, story)
+	}
+	return existing
+}
+
+func companyHealthConcernStoryKey(story CompanyHealthConcernStory) string {
+	title := strings.ToLower(strings.TrimSpace(story.Title))
+	url := strings.ToLower(strings.TrimSpace(story.URL))
+	if title == "" && url == "" {
+		return ""
+	}
+	return title + "\x00" + url
+}
+
+func parseRSSItemPubDate(value string) *time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	for _, layout := range []string{time.RFC1123Z, time.RFC1123, time.RFC822Z, time.RFC822} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return &parsed
+		}
+	}
+	return nil
+}

--- a/internal/domain/company_health_evidence.go
+++ b/internal/domain/company_health_evidence.go
@@ -21,14 +21,6 @@ func healthEvidenceMatchesCompanyContext(title string, evidenceURL string, ident
 	if !healthEvidenceMatchesCompanyName(title, names) && !healthEvidenceMatchesIdentityContext(evidenceText, identity) {
 		return false, "company name not present"
 	}
-
-	industry := strings.ToLower(identity.Industry)
-	if industryLooksFinancial(industry) && containsAny(evidenceText, []string{"skate", "game", "gaming", "gamesindustry", "shacknews", "developer full circle", "video game", "publisher"}) {
-		return false, "evidence industry conflicts with company industry"
-	}
-	if containsAny(industry, []string{"healthcare", "medical", "clinical"}) && containsAny(evidenceText, []string{"game", "gaming", "crypto", "banking"}) {
-		return false, "evidence industry conflicts with company industry"
-	}
 	return true, ""
 }
 
@@ -87,7 +79,8 @@ func companyHealthContextTerms(identity CompanyHealthContext) []string {
 
 	seen := make(map[string]bool)
 	var terms []string
-	for _, text := range []string{identity.Summary, identity.Industry} {
+	texts := append([]string{identity.Summary, identity.Industry}, identity.Industries...)
+	for _, text := range texts {
 		if strings.Contains(strings.ToLower(text), "san antonio") && !seen["san_antonio"] {
 			seen["san_antonio"] = true
 			terms = append(terms, "san_antonio")
@@ -174,10 +167,6 @@ func companyHealthContextNames(identity CompanyHealthContext) []string {
 		names = append(names, name)
 	}
 	return names
-}
-
-func industryLooksFinancial(industry string) bool {
-	return containsAny(industry, []string{"financ", "fintech", "payments", "banking", "crypto", "stablecoin"})
 }
 
 func rejectedHealthEvidence(value string, source string, evidenceURL string, reason string) CompanyHealthEvidence {

--- a/internal/domain/company_health_facts_test.go
+++ b/internal/domain/company_health_facts_test.go
@@ -3,7 +3,12 @@ package domain
 import (
 	"strings"
 	"testing"
+	"time"
 )
+
+func intPtr(value int) *int {
+	return &value
+}
 
 func TestObserveFoundedYearMarksConflict(t *testing.T) {
 	result := &CompanyHealthResult{}
@@ -54,28 +59,6 @@ func TestFinalizeCompanyHealthAssessmentsMarksGap(t *testing.T) {
 		if assessment == nil || assessment.Status != fieldStatusGap {
 			t.Fatalf("%s assessment = %#v; want gap", field, assessment)
 		}
-	}
-}
-
-func TestHealthEvidenceRejectsCircleGamingFalsePositive(t *testing.T) {
-	identity := CompanyHealthContext{
-		Company:  "Circle",
-		Website:  "https://www.circle.com",
-		Summary:  "Circle provides financial technology for stablecoin payments.",
-		Industry: "Financial Technology",
-	}
-
-	ok, reason := healthEvidenceMatchesCompanyContext(
-		"Full Circle developer hit by layoffs at game publisher",
-		"https://www.gamesindustry.biz/full-circle-layoffs",
-		identity,
-	)
-
-	if ok {
-		t.Fatal("healthEvidenceMatchesCompanyContext() accepted gaming evidence for Circle fintech")
-	}
-	if reason == "" {
-		t.Fatal("healthEvidenceMatchesCompanyContext() reason is empty")
 	}
 }
 
@@ -244,9 +227,71 @@ func TestCompanyHealthContextDomainAcceptsBareDomain(t *testing.T) {
 	}
 }
 
-func TestGoogleNewsSentimentForContextSearchesAliases(t *testing.T) {
+func TestCompanyHealthContextForJobUsesOpportunisticMetadata(t *testing.T) {
+	job := Job{
+		Company:         "Circle",
+		CompanyWebsite:  "https://www.circle.com",
+		CompanySummary:  "Circle builds stablecoin payment infrastructure.",
+		CompanyIndustry: "Blockchain",
+		Metadata: &JobMetadata{
+			Source: &JobSourceMetadata{
+				Industries: []string{"Blockchain", "Fintech", "Payments", "Cryptocurrency"},
+			},
+			Company: &CompanyMetadata{
+				Industries:         []string{"Financial Services", "Cryptocurrency"},
+				EstimatedEmployees: intPtr(1200),
+				FoundedYear:        intPtr(2013),
+				Ticker:             "CRCL",
+			},
+		},
+	}
+
+	identity := CompanyHealthContextForJob(job)
+
+	if identity.Company != "Circle" || identity.Website != "https://www.circle.com" {
+		t.Fatalf("CompanyHealthContextForJob() = %#v; want job identity", identity)
+	}
+	if got := strings.Join(identity.Industries, ","); got != "Blockchain,Fintech,Payments,Cryptocurrency,Financial Services" {
+		t.Fatalf("identity.Industries = %#v; want combined unique industries", identity.Industries)
+	}
+	if identity.Ticker != "CRCL" {
+		t.Fatalf("identity.Ticker = %q; want CRCL", identity.Ticker)
+	}
+	if identity.EstimatedEmployees == nil || *identity.EstimatedEmployees != 1200 {
+		t.Fatalf("identity.EstimatedEmployees = %#v; want 1200", identity.EstimatedEmployees)
+	}
+	if identity.FoundedYear == nil || *identity.FoundedYear != 2013 {
+		t.Fatalf("identity.FoundedYear = %#v; want 2013", identity.FoundedYear)
+	}
+}
+
+func TestLayoffQueriesUseDomainAndIndustryContext(t *testing.T) {
 	identity := CompanyHealthContext{
-		Company: "Acme",
+		Company:    "Acme",
+		Aliases:    []string{"Acme Payments Group"},
+		Website:    "https://www.acme.example",
+		Industry:   "Payments",
+		Industries: []string{"Fintech", "Risk Management", "Banking"},
+	}
+
+	queries := companyHealthLayoffQueries(identity)
+
+	if len(queries) < 2 {
+		t.Fatalf("companyHealthLayoffQueries() = %#v; want primary company and alias queries", queries)
+	}
+	if queries[0] != `"Acme" acme.example payments fintech risk layoffs` {
+		t.Fatalf("queries[0] = %q; want domain and useful industry terms", queries[0])
+	}
+	if queries[1] != `"Acme Payments Group" acme.example payments fintech risk layoffs` {
+		t.Fatalf("queries[1] = %q; want alias query with same context", queries[1])
+	}
+}
+
+func TestGoogleNewsSentimentForContextSearchesAliasesWithContext(t *testing.T) {
+	identity := CompanyHealthContext{
+		Company:  "Acme",
+		Website:  "https://www.acme.example",
+		Industry: "Cloud Infrastructure",
 		Aliases: []string{
 			"Acme Cloud",
 		},
@@ -255,11 +300,11 @@ func TestGoogleNewsSentimentForContextSearchesAliases(t *testing.T) {
 	fetch := func(query string) ([]RSSItem, error) {
 		queries = append(queries, query)
 		switch query {
-		case "Acme":
+		case `"Acme" acme.example cloud infrastructure`:
 			return []RSSItem{
 				{Title: "Generic cloud market update", Link: "https://news.google.com/rss/articles/generic"},
 			}, nil
-		case "Acme Cloud":
+		case `"Acme Cloud" acme.example cloud infrastructure`:
 			return []RSSItem{
 				{Title: "Acme Cloud announces expansion and new hiring plans", Link: "https://news.example/acme-cloud-expansion"},
 			}, nil
@@ -272,8 +317,8 @@ func TestGoogleNewsSentimentForContextSearchesAliases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("googleNewsSentimentForContextWithFetcher() error = %v", err)
 	}
-	if strings.Join(queries, "\x00") != "Acme\x00Acme Cloud" {
-		t.Fatalf("queries = %#v, want primary company and alias", queries)
+	if strings.Join(queries, "\x00") != `"Acme" acme.example cloud infrastructure`+"\x00"+`"Acme Cloud" acme.example cloud infrastructure` {
+		t.Fatalf("queries = %#v, want primary company and alias with domain and industry context", queries)
 	}
 	if strings.Join(titles, "\x00") != "Acme Cloud announces expansion and new hiring plans" {
 		t.Fatalf("titles = %#v, want alias-matched title", titles)
@@ -283,22 +328,63 @@ func TestGoogleNewsSentimentForContextSearchesAliases(t *testing.T) {
 	}
 }
 
+func TestGoogleNewsSentimentCapturesRecentConcernStories(t *testing.T) {
+	pubDate := time.Now().AddDate(0, -2, 0).Format(time.RFC1123Z)
+	identity := CompanyHealthContext{
+		Company:  "Acme",
+		Website:  "https://acme.example",
+		Industry: "security software",
+	}
+	fetch := func(query string) ([]RSSItem, error) {
+		return []RSSItem{
+			{
+				Title:   "Acme security software faces regulatory investigation",
+				Link:    "https://news.example/acme-investigation",
+				PubDate: pubDate,
+			},
+			{
+				Title:   "Acme security software opens new office",
+				Link:    "https://news.example/acme-office",
+				PubDate: pubDate,
+			},
+		}, nil
+	}
+
+	result, err := googleNewsSentimentDetailsForContextWithFetcher(identity, fetch)
+	if err != nil {
+		t.Fatalf("googleNewsSentimentDetailsForContextWithFetcher() error = %v", err)
+	}
+	if len(result.ConcernStories) != 1 {
+		t.Fatalf("ConcernStories = %#v; want one high-concern story", result.ConcernStories)
+	}
+	story := result.ConcernStories[0]
+	if story.Source != "google_news_rss" || story.URL != "https://news.example/acme-investigation" {
+		t.Fatalf("ConcernStories[0] = %#v; want Google News investigation story", story)
+	}
+	if story.Date == nil {
+		t.Fatalf("ConcernStories[0].Date = nil; want parsed pubDate")
+	}
+	if story.Concern == "" {
+		t.Fatalf("ConcernStories[0].Concern = empty; want concern reason")
+	}
+}
+
 func TestFilterLayoffSignalsForContextReturnsRejectedEvidence(t *testing.T) {
 	identity := CompanyHealthContext{
-		Company:  "Circle",
-		Website:  "https://www.circle.com",
-		Summary:  "Circle provides financial technology for stablecoin payments.",
+		Company:  "Acme",
+		Website:  "https://www.acme.example",
+		Summary:  "Acme provides financial technology products.",
 		Industry: "Financial Technology",
 	}
 	signals := []LayoffSignal{
-		{Title: "Circle cuts 100 jobs", URL: "https://www.circle.com/news/jobs"},
-		{Title: "Full Circle studio hit by layoffs", URL: "https://www.gamesindustry.biz/full-circle-layoffs"},
+		{Title: "Acme cuts 100 jobs", URL: "https://www.acme.example/news/jobs"},
+		{Title: "OtherCo cuts 100 jobs", URL: "https://news.example/otherco-layoffs"},
 	}
 
 	filtered, rejected := filterLayoffSignalsForContext(signals, identity)
 
-	if len(filtered) != 1 || filtered[0].Title != "Circle cuts 100 jobs" {
-		t.Fatalf("filtered signals = %#v, want only Circle domain signal", filtered)
+	if len(filtered) != 1 || filtered[0].Title != "Acme cuts 100 jobs" {
+		t.Fatalf("filtered signals = %#v, want only Acme signal", filtered)
 	}
 	if len(rejected) != 1 {
 		t.Fatalf("rejected evidence = %#v, want one rejected signal", rejected)

--- a/internal/domain/company_health_facts_test.go
+++ b/internal/domain/company_health_facts_test.go
@@ -287,6 +287,18 @@ func TestLayoffQueriesUseDomainAndIndustryContext(t *testing.T) {
 	}
 }
 
+func TestGoogleNewsRSSQueryQuotesBareMultiWordCompanyNames(t *testing.T) {
+	if got, want := googleNewsRSSQuery("Acme Cloud"), `"Acme Cloud"`; got != want {
+		t.Fatalf("googleNewsRSSQuery() = %q; want %q", got, want)
+	}
+	if got, want := googleNewsRSSQuery(`"Acme Cloud" acme.example layoffs`), `"Acme Cloud" acme.example layoffs`; got != want {
+		t.Fatalf("googleNewsRSSQuery() = %q; want explicit query unchanged", got)
+	}
+	if got, want := googleNewsRSSQuery("site:acme.example layoffs"), "site:acme.example layoffs"; got != want {
+		t.Fatalf("googleNewsRSSQuery() = %q; want operator query unchanged", got)
+	}
+}
+
 func TestGoogleNewsSentimentForContextSearchesAliasesWithContext(t *testing.T) {
 	identity := CompanyHealthContext{
 		Company:  "Acme",

--- a/internal/domain/company_health_news.go
+++ b/internal/domain/company_health_news.go
@@ -67,10 +67,29 @@ func googleNewsRSSQuery(query string) string {
 	if query == "" {
 		return query
 	}
-	if strings.ContainsAny(query, `" `) {
+	if googleNewsQueryHasExplicitSyntax(query) {
 		return query
 	}
 	return fmt.Sprintf(`"%s"`, query)
+}
+
+func googleNewsQueryHasExplicitSyntax(query string) bool {
+	if strings.Contains(query, `"`) {
+		return true
+	}
+	for _, field := range strings.Fields(query) {
+		trimmed := strings.Trim(field, "()")
+		switch strings.ToUpper(trimmed) {
+		case "AND", "OR", "NOT":
+			return true
+		}
+		if strings.HasPrefix(field, "-") ||
+			strings.Contains(field, ":") ||
+			strings.ContainsAny(field, "()") {
+			return true
+		}
+	}
+	return false
 }
 
 func fetchLayoffSignalsForContextWithRejected(identity CompanyHealthContext) ([]LayoffSignal, []CompanyHealthEvidence) {

--- a/internal/domain/company_health_news.go
+++ b/internal/domain/company_health_news.go
@@ -24,11 +24,19 @@ type RSSItem struct {
 	PubDate string `xml:"pubDate"`
 }
 
+type googleNewsSentimentResult struct {
+	Titles         []string
+	ConcernStories []CompanyHealthConcernStory
+	NegHits        int
+	PosHits        int
+	Rejected       []CompanyHealthEvidence
+}
+
 // fetchGoogleNewsRSS fetches and parses Google News RSS feed.
 var fetchGoogleNewsRSS = defaultFetchGoogleNewsRSS
 
 func defaultFetchGoogleNewsRSS(query string) ([]RSSItem, error) {
-	rssURL := fmt.Sprintf(googleNewsRSSURL, url.QueryEscape(fmt.Sprintf(`"%s"`, query)))
+	rssURL := fmt.Sprintf(googleNewsRSSURL, url.QueryEscape(googleNewsRSSQuery(query)))
 
 	client := &http.Client{Timeout: requestTimeout}
 	req, err := http.NewRequest("GET", rssURL, nil)
@@ -54,25 +62,60 @@ func defaultFetchGoogleNewsRSS(query string) ([]RSSItem, error) {
 	return feed.Channel.Items, nil
 }
 
-// fetchLayoffSignals searches news specifically for layoff mentions
-func fetchLayoffSignals(company string) []LayoffSignal {
-	query := fmt.Sprintf(`"%s" layoffs`, company)
-	items, err := fetchGoogleNewsRSS(query)
-	if err != nil {
+func googleNewsRSSQuery(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return query
+	}
+	if strings.ContainsAny(query, `" `) {
+		return query
+	}
+	return fmt.Sprintf(`"%s"`, query)
+}
+
+func fetchLayoffSignalsForContextWithRejected(identity CompanyHealthContext) ([]LayoffSignal, []CompanyHealthEvidence) {
+	signals := fetchLayoffSignalsForQueries(companyHealthLayoffQueries(identity))
+	return filterLayoffSignalsForContext(signals, identity)
+}
+
+func fetchLayoffSignalsForQueries(queries []string) []LayoffSignal {
+	if len(queries) == 0 {
 		return nil
 	}
+	seen := make(map[string]bool)
+	var signals []LayoffSignal
+	for _, query := range queries {
+		items, err := fetchGoogleNewsRSS(query)
+		if err != nil {
+			continue
+		}
+		for _, signal := range layoffSignalsFromRSSItems(items, query) {
+			key := strings.TrimSpace(signal.Title) + "\x00" + strings.TrimSpace(signal.URL)
+			if key == "\x00" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			signals = append(signals, signal)
+			if len(signals) >= 5 {
+				return signals
+			}
+		}
+	}
+	return signals
+}
 
+func layoffSignalsFromRSSItems(items []RSSItem, company string) []LayoffSignal {
+	company = layoffCompanyNameFromQuery(company)
+	if company == "" {
+		return nil
+	}
 	signals := []LayoffSignal{}
 	layoffPattern := regexp.MustCompile(`(?i)(\b\d{1,3}(?:,\d{3})*|\d+%)\s+(?:jobs|employees|staff|workers|people|roles|positions|cuts|layoffs|reduction in force|rif)`)
-
-	// Exclusion patterns for "industry trend" headlines where the company is mentioned but not the one laying off
 	exclusionPattern := regexp.MustCompile(`(?i)(?:as layoffs sweep|amid layoffs|despite layoffs|industry layoffs|tech layoffs|layoffs sweep|market layoffs|sector layoffs)`)
 
 	for _, item := range items {
 		title := item.Title
 		titleLower := strings.ToLower(title)
-
-		// Skip if it matches an exclusion pattern (e.g. "Nvidia grows AS layoffs sweep")
 		if exclusionPattern.MatchString(title) {
 			continue
 		}
@@ -85,10 +128,6 @@ func fetchLayoffSignals(company string) []LayoffSignal {
 			strings.Contains(titleLower, "rif") ||
 			strings.Contains(titleLower, "reduction in force") ||
 			strings.Contains(titleLower, "restructuring") {
-
-			// Strict check: Ensure company name is actually in the title (Google sometimes returns loose matches)
-			// and treat it as a word boundary match.
-			// Use strictly case-sensitive matching to avoid dictionary word collisions.
 			pattern := fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(company))
 			companyRe := regexp.MustCompile(pattern)
 			if !companyRe.MatchString(title) {
@@ -99,15 +138,11 @@ func fetchLayoffSignals(company string) []LayoffSignal {
 				Title: title,
 				URL:   item.Link,
 			}
-
-			// Try to parse date
 			if item.PubDate != "" {
 				if t, err := time.Parse(time.RFC1123Z, item.PubDate); err == nil {
 					signal.Date = &t
 				}
 			}
-
-			// Extract employee count or percentage
 			matches := layoffPattern.FindStringSubmatch(title)
 			if len(matches) > 1 {
 				numStr := strings.ReplaceAll(matches[1], ",", "")
@@ -127,13 +162,86 @@ func fetchLayoffSignals(company string) []LayoffSignal {
 			}
 		}
 	}
-
 	return signals
 }
 
-func fetchLayoffSignalsForContextWithRejected(identity CompanyHealthContext) ([]LayoffSignal, []CompanyHealthEvidence) {
-	signals := fetchLayoffSignals(identity.Company)
-	return filterLayoffSignalsForContext(signals, identity)
+func layoffCompanyNameFromQuery(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return ""
+	}
+	if strings.HasPrefix(query, `"`) {
+		rest := query[1:]
+		if idx := strings.Index(rest, `"`); idx >= 0 {
+			return strings.TrimSpace(rest[:idx])
+		}
+	}
+	return strings.Trim(query, `" `)
+}
+
+func companyHealthLayoffQueries(identity CompanyHealthContext) []string {
+	return companyHealthNewsQueriesWithSuffix(identity, "layoffs")
+}
+
+func companyHealthNewsQueries(identity CompanyHealthContext) []string {
+	return companyHealthNewsQueriesWithSuffix(identity, "")
+}
+
+func companyHealthNewsQueriesWithSuffix(identity CompanyHealthContext, suffix string) []string {
+	names := companyHealthContextNames(identity)
+	if len(names) == 0 {
+		return nil
+	}
+	contextTerms := companyHealthSearchContextTerms(identity)
+	queries := make([]string, 0, len(names))
+	for _, name := range names {
+		var queryParts []string
+		if len(contextTerms) > 0 || strings.TrimSpace(suffix) != "" {
+			queryParts = append(queryParts, fmt.Sprintf(`"%s"`, name))
+		} else {
+			queryParts = append(queryParts, name)
+		}
+		queryParts = append(queryParts, contextTerms...)
+		if suffix = strings.TrimSpace(suffix); suffix != "" {
+			queryParts = append(queryParts, suffix)
+		}
+		queries = append(queries, strings.Join(queryParts, " "))
+	}
+	return queries
+}
+
+func companyHealthSearchContextTerms(identity CompanyHealthContext) []string {
+	var terms []string
+	if domain := companyHealthContextDomain(identity); domain != "" {
+		terms = append(terms, domain)
+	}
+	for _, text := range append([]string{identity.Industry}, identity.Industries...) {
+		for _, term := range tokenizeCompanyContext(text) {
+			if companyContextStopword(term) {
+				continue
+			}
+			terms = appendUniqueSearchTerm(terms, term)
+			if len(terms) >= 4 {
+				return terms
+			}
+		}
+	}
+	return terms
+}
+
+func appendUniqueSearchTerm(values []string, value string) []string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return values
+	}
+	valueRoot := strings.TrimSuffix(value, "s")
+	for _, existing := range values {
+		existingRoot := strings.TrimSuffix(existing, "s")
+		if existing == value || existingRoot == valueRoot {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func filterLayoffSignalsForContext(signals []LayoffSignal, identity CompanyHealthContext) ([]LayoffSignal, []CompanyHealthEvidence) {
@@ -152,17 +260,24 @@ func filterLayoffSignalsForContext(signals []LayoffSignal, identity CompanyHealt
 	return out, rejected
 }
 
-// googleNewsSentiment fetches news and counts positive/negative keywords
-func googleNewsSentimentForContext(identity CompanyHealthContext) (titles []string, negHits, posHits int, rejected []CompanyHealthEvidence, err error) {
-	return googleNewsSentimentForContextWithFetcher(identity, fetchGoogleNewsRSS)
+func googleNewsSentimentForContextWithFetcher(identity CompanyHealthContext, fetch func(string) ([]RSSItem, error)) (titles []string, negHits, posHits int, rejected []CompanyHealthEvidence, err error) {
+	result, err := googleNewsSentimentDetailsForContextWithFetcher(identity, fetch)
+	if err != nil {
+		return nil, 0, 0, nil, err
+	}
+	return result.Titles, result.NegHits, result.PosHits, result.Rejected, nil
 }
 
-func googleNewsSentimentForContextWithFetcher(identity CompanyHealthContext, fetch func(string) ([]RSSItem, error)) (titles []string, negHits, posHits int, rejected []CompanyHealthEvidence, err error) {
+func googleNewsSentimentDetailsForContext(identity CompanyHealthContext) (googleNewsSentimentResult, error) {
+	return googleNewsSentimentDetailsForContextWithFetcher(identity, fetchGoogleNewsRSS)
+}
+
+func googleNewsSentimentDetailsForContextWithFetcher(identity CompanyHealthContext, fetch func(string) ([]RSSItem, error)) (googleNewsSentimentResult, error) {
 	var items []RSSItem
 	seenItems := make(map[string]bool)
 	var firstErr error
-	for _, name := range companyHealthContextNames(identity) {
-		fetched, fetchErr := fetch(name)
+	for _, query := range companyHealthNewsQueries(identity) {
+		fetched, fetchErr := fetch(query)
 		if fetchErr != nil {
 			if firstErr == nil {
 				firstErr = fetchErr
@@ -179,25 +294,28 @@ func googleNewsSentimentForContextWithFetcher(identity CompanyHealthContext, fet
 		}
 	}
 	if len(items) == 0 && firstErr != nil {
-		return nil, 0, 0, nil, firstErr
+		return googleNewsSentimentResult{}, firstErr
 	}
 
-	titles = []string{}
+	result := googleNewsSentimentResult{Titles: []string{}}
 	for _, item := range items {
 		ok, reason := healthEvidenceMatchesCompanyContext(item.Title, item.Link, identity)
 		if !ok {
-			rejected = append(rejected, rejectedHealthEvidence(item.Title, "google_news_rss", item.Link, reason))
+			result.Rejected = append(result.Rejected, rejectedHealthEvidence(item.Title, "google_news_rss", item.Link, reason))
 			continue
 		}
-		titles = append(titles, item.Title)
-		if len(titles) >= 25 {
+		result.Titles = append(result.Titles, item.Title)
+		if story, ok := companyHealthConcernStoryFromRSSItem("google_news_rss", item, negNewsKeywords); ok {
+			result.ConcernStories = appendUniqueCompanyHealthConcernStories(result.ConcernStories, story)
+		}
+		if len(result.Titles) >= 25 {
 			break
 		}
 	}
 
-	blob := strings.Join(titles, " ")
-	negHits = wordHitCount(blob, negNewsKeywords)
-	posHits = wordHitCount(blob, posNewsKeywords)
+	blob := strings.Join(result.Titles, " ")
+	result.NegHits = wordHitCount(blob, negNewsKeywords)
+	result.PosHits = wordHitCount(blob, posNewsKeywords)
 
-	return titles, negHits, posHits, rejected, nil
+	return result, nil
 }

--- a/internal/domain/company_health_site_profile.go
+++ b/internal/domain/company_health_site_profile.go
@@ -199,6 +199,9 @@ func EnrichCompanyHealthContextFromSiteProfile(identity CompanyHealthContext, pr
 	if strings.TrimSpace(identity.Industry) == "" {
 		identity.Industry = strings.TrimSpace(profile.Industry)
 	}
+	if strings.TrimSpace(profile.Industry) != "" {
+		identity.Industries = appendUniqueNonEmptyStrings(identity.Industries, profile.Industry)
+	}
 	return identity
 }
 

--- a/internal/domain/company_health_text.go
+++ b/internal/domain/company_health_text.go
@@ -105,12 +105,3 @@ func wordHitCount(text string, keywords []string) int {
 	}
 	return count
 }
-
-func containsAny(text string, needles []string) bool {
-	for _, needle := range needles {
-		if strings.Contains(text, needle) {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/domain/company_health_types.go
+++ b/internal/domain/company_health_types.go
@@ -22,6 +22,25 @@ type HNSignal struct {
 	Date        time.Time `json:"date"`
 }
 
+// CompanyHealthConcernStory is a recent accepted news/HN story worth deeper review.
+type CompanyHealthConcernStory struct {
+	Source  string     `json:"source"`
+	Title   string     `json:"title"`
+	URL     string     `json:"url,omitempty"`
+	Date    *time.Time `json:"date,omitempty"`
+	Concern string     `json:"concern,omitempty"`
+}
+
+// CompanyHealthConcernArticle is transient page text fetched for LLM review.
+type CompanyHealthConcernArticle struct {
+	Source  string     `json:"source"`
+	Title   string     `json:"title"`
+	URL     string     `json:"url,omitempty"`
+	Date    *time.Time `json:"date,omitempty"`
+	Concern string     `json:"concern,omitempty"`
+	Text    string     `json:"text,omitempty"`
+}
+
 // EmployerReviewSignal represents browser-discovered employer review evidence
 type EmployerReviewSignal struct {
 	Source             string   `json:"source"`
@@ -45,27 +64,29 @@ type EmploymentRisk struct {
 
 // CompanyHealthResult contains the full health assessment
 type CompanyHealthResult struct {
-	Company            string                                   `json:"company"`
-	Score              int                                      `json:"score"`
-	Confidence         string                                   `json:"confidence"` // high, medium, low
-	Public             *bool                                    `json:"public,omitempty"`
-	FoundedYear        *int                                     `json:"founded_year,omitempty"`
-	AgeYears           *int                                     `json:"age_years,omitempty"`
-	EstimatedEmployees *int                                     `json:"estimated_employees,omitempty"`
-	SignalsUsed        []string                                 `json:"signals_used"`
-	Flags              []string                                 `json:"flags"`
-	Notes              []string                                 `json:"notes"`
-	DiscoveredTicker   string                                   `json:"discovered_ticker,omitempty"`
-	DiscoveredName     string                                   `json:"discovered_name,omitempty"`
-	LayoffSignals      []LayoffSignal                           `json:"layoff_signals,omitempty"`
-	HNSignals          []HNSignal                               `json:"hn_signals,omitempty"`
-	EmployerReviews    []EmployerReviewSignal                   `json:"employer_reviews,omitempty"`
-	EmploymentRisk     *EmploymentRisk                          `json:"employment_risk,omitempty"`
-	LLMAssessment      *LLMCompanyHealthAssessment              `json:"llm_assessment,omitempty"`
-	RejectedEvidence   []CompanyHealthEvidence                  `json:"rejected_evidence,omitempty"`
-	Sources            map[string]any                           `json:"sources"`
-	FieldAssessments   map[string]*CompanyHealthFieldAssessment `json:"field_assessments,omitempty"`
-	Notices            []string                                 `json:"notices,omitempty"`
+	Company              string                                   `json:"company"`
+	Score                int                                      `json:"score"`
+	Confidence           string                                   `json:"confidence"` // high, medium, low
+	Public               *bool                                    `json:"public,omitempty"`
+	FoundedYear          *int                                     `json:"founded_year,omitempty"`
+	AgeYears             *int                                     `json:"age_years,omitempty"`
+	EstimatedEmployees   *int                                     `json:"estimated_employees,omitempty"`
+	SignalsUsed          []string                                 `json:"signals_used"`
+	Flags                []string                                 `json:"flags"`
+	Notes                []string                                 `json:"notes"`
+	DiscoveredTicker     string                                   `json:"discovered_ticker,omitempty"`
+	DiscoveredName       string                                   `json:"discovered_name,omitempty"`
+	LayoffSignals        []LayoffSignal                           `json:"layoff_signals,omitempty"`
+	HNSignals            []HNSignal                               `json:"hn_signals,omitempty"`
+	ConcernStories       []CompanyHealthConcernStory              `json:"concern_stories,omitempty"`
+	ConcernStoryArticles []CompanyHealthConcernArticle            `json:"-"`
+	EmployerReviews      []EmployerReviewSignal                   `json:"employer_reviews,omitempty"`
+	EmploymentRisk       *EmploymentRisk                          `json:"employment_risk,omitempty"`
+	LLMAssessment        *LLMCompanyHealthAssessment              `json:"llm_assessment,omitempty"`
+	RejectedEvidence     []CompanyHealthEvidence                  `json:"rejected_evidence,omitempty"`
+	Sources              map[string]any                           `json:"sources"`
+	FieldAssessments     map[string]*CompanyHealthFieldAssessment `json:"field_assessments,omitempty"`
+	Notices              []string                                 `json:"notices,omitempty"`
 }
 
 // LLMTokenUsage is the normalized token accounting surfaced by LLM providers.
@@ -89,13 +110,27 @@ func (u LLMTokenUsage) Available() bool {
 }
 
 type LLMCompanyHealthAssessment struct {
-	Summary           string         `json:"summary"`
-	Recommendation    string         `json:"recommendation"`
-	RiskLevel         string         `json:"risk_level"`
-	PositiveSignals   []string       `json:"positive_signals"`
-	Concerns          []string       `json:"concerns"`
-	FollowUpQuestions []string       `json:"follow_up_questions"`
-	TokenUsage        *LLMTokenUsage `json:"token_usage,omitempty"`
+	Summary                string                          `json:"summary"`
+	Recommendation         string                          `json:"recommendation"`
+	RiskLevel              string                          `json:"risk_level"`
+	PositiveSignals        []string                        `json:"positive_signals"`
+	Concerns               []string                        `json:"concerns"`
+	FollowUpQuestions      []string                        `json:"follow_up_questions"`
+	ArticleReviews         []LLMCompanyHealthArticleReview `json:"article_reviews,omitempty"`
+	StoryInsight           string                          `json:"story_insight,omitempty"`
+	ScoreModifier          *int                            `json:"score_modifier,omitempty"`
+	ScoreModifierReason    string                          `json:"score_modifier_reason,omitempty"`
+	ScoreModifierNovelFact string                          `json:"score_modifier_novel_fact,omitempty"`
+	ScoreModifierSources   []string                        `json:"score_modifier_sources,omitempty"`
+	TokenUsage             *LLMTokenUsage                  `json:"token_usage,omitempty"`
+}
+
+type LLMCompanyHealthArticleReview struct {
+	URL             string `json:"url"`
+	Source          string `json:"source,omitempty"`
+	Related         bool   `json:"related"`
+	RelevanceReason string `json:"relevance_reason,omitempty"`
+	NovelFact       string `json:"novel_fact,omitempty"`
 }
 
 type CompanyHealthEvidence struct {
@@ -122,5 +157,9 @@ type CompanyHealthContext struct {
 	Website                 string
 	Summary                 string
 	Industry                string
+	Industries              []string
+	Ticker                  string
+	EstimatedEmployees      *int
+	FoundedYear             *int
 	RequireResolvedIdentity bool
 }

--- a/internal/domain/job.go
+++ b/internal/domain/job.go
@@ -13,6 +13,7 @@ type Job struct {
 	CompanySummary  string               `json:"company_summary,omitempty"`
 	CompanyIndustry string               `json:"company_industry,omitempty"`
 	CompanyIdentity *JobIdentityMetadata `json:"company_identity,omitempty"`
+	Metadata        *JobMetadata         `json:"metadata,omitempty"`
 	Title           string               `json:"title"`
 	Remote          string               `json:"remote"`
 	Compensation    string               `json:"compensation"`
@@ -92,6 +93,8 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 		CompanyIndustry string          `json:"company_industry"`
 		Industry        string          `json:"industry"`
 		CompanyIdentity json.RawMessage `json:"company_identity"`
+		Metadata        *JobMetadata    `json:"metadata"`
+		JobMetadata     *JobMetadata    `json:"job_metadata"`
 		Title           string          `json:"title"`
 		JobTitle        string          `json:"job_title"`
 		Remote          json.RawMessage `json:"remote"`
@@ -121,6 +124,7 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 	j.CompanySummary = firstNonEmpty(raw.CompanySummary, raw.AboutCompany)
 	j.CompanyIndustry = firstNonEmpty(raw.CompanyIndustry, raw.Industry)
 	j.CompanyIdentity = parseJobIdentityMetadata(raw.CompanyIdentity)
+	j.Metadata = NormalizeJobMetadata(firstNonNilJobMetadata(raw.Metadata, raw.JobMetadata))
 	if j.CompanyIdentity != nil {
 		if j.CompanyWebsite == "" && j.CompanyIdentity.Website != nil {
 			j.CompanyWebsite = strings.TrimSpace(j.CompanyIdentity.Website.Value)
@@ -243,6 +247,7 @@ func (j Job) MarshalJSON() ([]byte, error) {
 		CompanySummary  string               `json:"company_summary,omitempty"`
 		CompanyIndustry string               `json:"company_industry,omitempty"`
 		CompanyIdentity *JobIdentityMetadata `json:"company_identity,omitempty"`
+		Metadata        *JobMetadata         `json:"metadata,omitempty"`
 		Title           string               `json:"title"`
 		Remote          string               `json:"remote"`
 		Compensation    string               `json:"compensation"`
@@ -260,6 +265,7 @@ func (j Job) MarshalJSON() ([]byte, error) {
 		CompanySummary:  j.CompanySummary,
 		CompanyIndustry: j.CompanyIndustry,
 		CompanyIdentity: j.CompanyIdentity,
+		Metadata:        NormalizeJobMetadata(CloneJobMetadata(j.Metadata)),
 		Title:           j.Title,
 		Remote:          j.Remote,
 		Compensation:    j.Compensation,
@@ -270,6 +276,15 @@ func (j Job) MarshalJSON() ([]byte, error) {
 		DateAdded:       j.DateAdded,
 		Description:     j.Description,
 	})
+}
+
+func firstNonNilJobMetadata(values ...*JobMetadata) *JobMetadata {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/domain/job_merge.go
+++ b/internal/domain/job_merge.go
@@ -52,6 +52,7 @@ func MergeJobIdentityFields(existing *Job, incoming Job) {
 	if strings.TrimSpace(existing.Description) == "" && strings.TrimSpace(incoming.Description) != "" {
 		existing.Description = incoming.Description
 	}
+	MergeJobMetadataFields(existing, incoming)
 }
 
 func JobCompanyWebsiteMissingOrInvalid(website string) bool {

--- a/internal/domain/job_metadata.go
+++ b/internal/domain/job_metadata.go
@@ -1,0 +1,300 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type JobMetadata struct {
+	Source  *JobSourceMetadata `json:"source,omitempty"`
+	Company *CompanyMetadata   `json:"company,omitempty"`
+}
+
+type JobSourceMetadata struct {
+	PostingURL        string   `json:"posting_url,omitempty"`
+	ExternalApplyURL  string   `json:"external_apply_url,omitempty"`
+	CompanyProfileURL string   `json:"company_profile_url,omitempty"`
+	PostedLabel       string   `json:"posted_label,omitempty"`
+	DatePosted        string   `json:"date_posted,omitempty"`
+	ValidThrough      string   `json:"valid_through,omitempty"`
+	EmploymentTypes   []string `json:"employment_types,omitempty"`
+	Locations         []string `json:"locations,omitempty"`
+	Industries        []string `json:"industries,omitempty"`
+	Skills            []string `json:"skills,omitempty"`
+}
+
+type CompanyMetadata struct {
+	Industries         []string `json:"industries,omitempty"`
+	EmployeeRange      string   `json:"employee_range,omitempty"`
+	EstimatedEmployees *int     `json:"estimated_employees,omitempty"`
+	FoundedYear        *int     `json:"founded_year,omitempty"`
+	Headquarters       string   `json:"headquarters,omitempty"`
+	Revenue            string   `json:"revenue,omitempty"`
+	Ticker             string   `json:"ticker,omitempty"`
+	Exchange           string   `json:"exchange,omitempty"`
+	Public             *bool    `json:"public,omitempty"`
+}
+
+func (m *JobSourceMetadata) UnmarshalJSON(data []byte) error {
+	type sourceAlias JobSourceMetadata
+	var raw struct {
+		sourceAlias
+		EmploymentType  json.RawMessage `json:"employment_type"`
+		EmploymentTypes json.RawMessage `json:"employment_types"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*m = JobSourceMetadata(raw.sourceAlias)
+	if values := metadataStringList(raw.EmploymentTypes); len(values) > 0 {
+		m.EmploymentTypes = values
+	} else if values := metadataStringList(raw.EmploymentType); len(values) > 0 {
+		m.EmploymentTypes = values
+	}
+	NormalizeJobSourceMetadata(m)
+	return nil
+}
+
+func (j *Job) EnsureSourceMetadata() *JobSourceMetadata {
+	if j == nil {
+		return nil
+	}
+	if j.Metadata == nil {
+		j.Metadata = &JobMetadata{}
+	}
+	if j.Metadata.Source == nil {
+		j.Metadata.Source = &JobSourceMetadata{}
+	}
+	return j.Metadata.Source
+}
+
+func (j *Job) EnsureCompanyMetadata() *CompanyMetadata {
+	if j == nil {
+		return nil
+	}
+	if j.Metadata == nil {
+		j.Metadata = &JobMetadata{}
+	}
+	if j.Metadata.Company == nil {
+		j.Metadata.Company = &CompanyMetadata{}
+	}
+	return j.Metadata.Company
+}
+
+func NormalizeJobMetadata(metadata *JobMetadata) *JobMetadata {
+	if metadata == nil {
+		return nil
+	}
+	metadata.Source = NormalizeJobSourceMetadata(metadata.Source)
+	metadata.Company = NormalizeCompanyMetadata(metadata.Company)
+	if metadata.Source == nil && metadata.Company == nil {
+		return nil
+	}
+	return metadata
+}
+
+func NormalizeJobSourceMetadata(metadata *JobSourceMetadata) *JobSourceMetadata {
+	if metadata == nil {
+		return nil
+	}
+	metadata.PostingURL = strings.TrimSpace(metadata.PostingURL)
+	metadata.ExternalApplyURL = strings.TrimSpace(metadata.ExternalApplyURL)
+	metadata.CompanyProfileURL = strings.TrimSpace(metadata.CompanyProfileURL)
+	metadata.PostedLabel = strings.TrimSpace(metadata.PostedLabel)
+	metadata.DatePosted = strings.TrimSpace(metadata.DatePosted)
+	metadata.ValidThrough = strings.TrimSpace(metadata.ValidThrough)
+	metadata.EmploymentTypes = compactUniqueStrings(metadata.EmploymentTypes)
+	metadata.Locations = compactUniqueStrings(metadata.Locations)
+	metadata.Industries = compactUniqueStrings(metadata.Industries)
+	metadata.Skills = compactUniqueStrings(metadata.Skills)
+	if metadata.PostingURL == "" &&
+		metadata.ExternalApplyURL == "" &&
+		metadata.CompanyProfileURL == "" &&
+		metadata.PostedLabel == "" &&
+		metadata.DatePosted == "" &&
+		metadata.ValidThrough == "" &&
+		len(metadata.EmploymentTypes) == 0 &&
+		len(metadata.Locations) == 0 &&
+		len(metadata.Industries) == 0 &&
+		len(metadata.Skills) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func NormalizeCompanyMetadata(metadata *CompanyMetadata) *CompanyMetadata {
+	if metadata == nil {
+		return nil
+	}
+	metadata.Industries = compactUniqueStrings(metadata.Industries)
+	metadata.EmployeeRange = strings.TrimSpace(metadata.EmployeeRange)
+	metadata.Headquarters = strings.TrimSpace(metadata.Headquarters)
+	metadata.Revenue = strings.TrimSpace(metadata.Revenue)
+	metadata.Ticker = strings.ToUpper(strings.TrimSpace(metadata.Ticker))
+	metadata.Exchange = strings.ToUpper(strings.TrimSpace(metadata.Exchange))
+	if len(metadata.Industries) == 0 &&
+		metadata.EmployeeRange == "" &&
+		metadata.EstimatedEmployees == nil &&
+		metadata.FoundedYear == nil &&
+		metadata.Headquarters == "" &&
+		metadata.Revenue == "" &&
+		metadata.Ticker == "" &&
+		metadata.Exchange == "" &&
+		metadata.Public == nil {
+		return nil
+	}
+	return metadata
+}
+
+func CloneJobMetadata(metadata *JobMetadata) *JobMetadata {
+	if metadata == nil {
+		return nil
+	}
+	clone := &JobMetadata{}
+	if metadata.Source != nil {
+		source := *metadata.Source
+		source.EmploymentTypes = append([]string(nil), metadata.Source.EmploymentTypes...)
+		source.Locations = append([]string(nil), metadata.Source.Locations...)
+		source.Industries = append([]string(nil), metadata.Source.Industries...)
+		source.Skills = append([]string(nil), metadata.Source.Skills...)
+		clone.Source = &source
+	}
+	if metadata.Company != nil {
+		company := *metadata.Company
+		company.Industries = append([]string(nil), metadata.Company.Industries...)
+		if metadata.Company.EstimatedEmployees != nil {
+			company.EstimatedEmployees = new(int)
+			*company.EstimatedEmployees = *metadata.Company.EstimatedEmployees
+		}
+		if metadata.Company.FoundedYear != nil {
+			company.FoundedYear = new(int)
+			*company.FoundedYear = *metadata.Company.FoundedYear
+		}
+		if metadata.Company.Public != nil {
+			company.Public = new(bool)
+			*company.Public = *metadata.Company.Public
+		}
+		clone.Company = &company
+	}
+	return NormalizeJobMetadata(clone)
+}
+
+func MergeJobMetadataFields(existing *Job, incoming Job) {
+	if existing == nil || incoming.Metadata == nil {
+		return
+	}
+	source := incoming.Metadata.Source
+	if source != nil {
+		target := existing.EnsureSourceMetadata()
+		mergeStringField(&target.PostingURL, source.PostingURL)
+		mergeStringField(&target.ExternalApplyURL, source.ExternalApplyURL)
+		mergeStringField(&target.CompanyProfileURL, source.CompanyProfileURL)
+		mergeStringField(&target.PostedLabel, source.PostedLabel)
+		mergeStringField(&target.DatePosted, source.DatePosted)
+		mergeStringField(&target.ValidThrough, source.ValidThrough)
+		target.EmploymentTypes = appendUniqueNonEmptyStrings(target.EmploymentTypes, source.EmploymentTypes...)
+		target.Locations = appendUniqueNonEmptyStrings(target.Locations, source.Locations...)
+		target.Industries = appendUniqueNonEmptyStrings(target.Industries, source.Industries...)
+		target.Skills = appendUniqueNonEmptyStrings(target.Skills, source.Skills...)
+	}
+	company := incoming.Metadata.Company
+	if company != nil {
+		target := existing.EnsureCompanyMetadata()
+		target.Industries = appendUniqueNonEmptyStrings(target.Industries, company.Industries...)
+		mergeStringField(&target.EmployeeRange, company.EmployeeRange)
+		mergeStringField(&target.Headquarters, company.Headquarters)
+		mergeStringField(&target.Revenue, company.Revenue)
+		mergeStringField(&target.Ticker, company.Ticker)
+		mergeStringField(&target.Exchange, company.Exchange)
+		if target.EstimatedEmployees == nil && company.EstimatedEmployees != nil {
+			target.EstimatedEmployees = new(int)
+			*target.EstimatedEmployees = *company.EstimatedEmployees
+		}
+		if target.FoundedYear == nil && company.FoundedYear != nil {
+			target.FoundedYear = new(int)
+			*target.FoundedYear = *company.FoundedYear
+		}
+		if target.Public == nil && company.Public != nil {
+			target.Public = new(bool)
+			*target.Public = *company.Public
+		}
+	}
+	existing.Metadata = NormalizeJobMetadata(existing.Metadata)
+}
+
+func CompanyHealthContextForJob(job Job) CompanyHealthContext {
+	identity := CompanyHealthContext{
+		Company:  strings.TrimSpace(job.Company),
+		Website:  strings.TrimSpace(job.CompanyWebsite),
+		Summary:  strings.TrimSpace(job.CompanySummary),
+		Industry: strings.TrimSpace(job.CompanyIndustry),
+	}
+	if job.Metadata != nil {
+		if job.Metadata.Source != nil {
+			identity.Industries = appendUniqueNonEmptyStrings(identity.Industries, job.Metadata.Source.Industries...)
+		}
+		if job.Metadata.Company != nil {
+			identity.Industries = appendUniqueNonEmptyStrings(identity.Industries, job.Metadata.Company.Industries...)
+			identity.Ticker = strings.ToUpper(strings.TrimSpace(job.Metadata.Company.Ticker))
+			if job.Metadata.Company.EstimatedEmployees != nil {
+				identity.EstimatedEmployees = new(int)
+				*identity.EstimatedEmployees = *job.Metadata.Company.EstimatedEmployees
+			}
+			if job.Metadata.Company.FoundedYear != nil {
+				identity.FoundedYear = new(int)
+				*identity.FoundedYear = *job.Metadata.Company.FoundedYear
+			}
+		}
+	}
+	if identity.Industry != "" {
+		identity.Industries = appendUniqueNonEmptyStrings([]string{identity.Industry}, identity.Industries...)
+	}
+	return identity
+}
+
+func appendUniqueNonEmptyStrings(values []string, more ...string) []string {
+	seen := make(map[string]bool, len(values)+len(more))
+	out := make([]string, 0, len(values)+len(more))
+	for _, value := range append(values, more...) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func compactUniqueStrings(values []string) []string {
+	return appendUniqueNonEmptyStrings(nil, values...)
+}
+
+func mergeStringField(target *string, value string) {
+	if target == nil || strings.TrimSpace(*target) != "" {
+		return
+	}
+	*target = strings.TrimSpace(value)
+}
+
+func metadataStringList(raw json.RawMessage) []string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		if strings.TrimSpace(single) == "" {
+			return nil
+		}
+		return []string{single}
+	}
+	var values []string
+	if err := json.Unmarshal(raw, &values); err == nil {
+		return compactUniqueStrings(values)
+	}
+	return nil
+}

--- a/internal/domain/job_test.go
+++ b/internal/domain/job_test.go
@@ -126,6 +126,71 @@ func TestJobJSONAcceptsSimpleCompanyIdentityMap(t *testing.T) {
 	}
 }
 
+func TestJobJSONPreservesOpportunisticMetadata(t *testing.T) {
+	input := []byte(`{
+		"company": "Acme",
+		"title": "Staff Engineer",
+		"remote": "Remote",
+		"compensation": "$200,000",
+		"apply_url": "https://builtin.com/job/staff-engineer/123",
+		"metadata": {
+			"source": {
+				"posting_url": "https://builtin.com/job/staff-engineer/123",
+				"external_apply_url": "https://acme.example/careers/123",
+				"company_profile_url": "https://builtin.com/company/acme",
+				"date_posted": "2026-05-01",
+				"valid_through": "2026-06-01",
+				"employment_type": "FULL_TIME",
+				"locations": ["Austin, TX", "Remote"],
+				"industries": ["Fintech", "Payments"],
+				"skills": ["Go", "Kubernetes"]
+			},
+			"company": {
+				"industries": ["Fintech", "Payments"],
+				"employee_range": "501-1,000 employees",
+				"estimated_employees": 750,
+				"founded_year": 2018,
+				"headquarters": "Austin, TX",
+				"revenue": "$100M-$500M",
+				"ticker": "ACME",
+				"exchange": "NYSE",
+				"public": true
+			}
+		}
+	}`)
+
+	var job Job
+	if err := json.Unmarshal(input, &job); err != nil {
+		t.Fatalf("json.Unmarshal(Job) error = %v", err)
+	}
+	if job.Metadata == nil || job.Metadata.Source == nil || job.Metadata.Company == nil {
+		t.Fatalf("Job.Metadata = %#v; want source and company metadata", job.Metadata)
+	}
+	if got := job.Metadata.Source.ExternalApplyURL; got != "https://acme.example/careers/123" {
+		t.Fatalf("ExternalApplyURL = %q; want external apply URL", got)
+	}
+	if got := strings.Join(job.Metadata.Source.Skills, ","); got != "Go,Kubernetes" {
+		t.Fatalf("Source.Skills = %#v; want Go,Kubernetes", job.Metadata.Source.Skills)
+	}
+	if job.Metadata.Company.EstimatedEmployees == nil || *job.Metadata.Company.EstimatedEmployees != 750 {
+		t.Fatalf("EstimatedEmployees = %#v; want 750", job.Metadata.Company.EstimatedEmployees)
+	}
+	if job.Metadata.Company.Public == nil || !*job.Metadata.Company.Public {
+		t.Fatalf("Public = %#v; want true", job.Metadata.Company.Public)
+	}
+
+	encoded, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("json.Marshal(Job) error = %v", err)
+	}
+	out := string(encoded)
+	for _, want := range []string{`"metadata"`, `"external_apply_url":"https://acme.example/careers/123"`, `"estimated_employees":750`, `"public":true`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("json.Marshal(Job) = %s; want %s", out, want)
+		}
+	}
+}
+
 func TestLooksLikeCompanyWebsiteRejectsDeepLinkAndTrackingHosts(t *testing.T) {
 	tests := []string{
 		"https://sofi.app.link/open",

--- a/internal/fetcher/apply_page_enrichment.go
+++ b/internal/fetcher/apply_page_enrichment.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func enrichJobFromApplyPageWithLLM(ctx context.Context, job *Job, llmEnrich jobIdentityPageEnrichFunc) {
@@ -148,6 +150,7 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 					Summary:  jobs[idx].CompanySummary,
 					Industry: jobs[idx].CompanyIndustry,
 					Identity: CloneJobIdentityMetadata(jobs[idx].CompanyIdentity),
+					Metadata: domain.CloneJobMetadata(jobs[idx].Metadata),
 				})
 			}
 			persistCompanyIdentityToStore(ctx, jobs[idx], identityStore, stats)

--- a/internal/fetcher/builtin_listing.go
+++ b/internal/fetcher/builtin_listing.go
@@ -75,6 +75,7 @@ func builtInJobFromListingCard(card *goquery.Selection, pageURL string, sourceNa
 		return Job{}, "", false
 	}
 
+	industries := builtInListingCardIndustries(card)
 	job := Job{
 		Company:         strings.TrimSpace(company),
 		Title:           strings.TrimSpace(title),
@@ -84,7 +85,17 @@ func builtInJobFromListingCard(card *goquery.Selection, pageURL string, sourceNa
 		ApplyURL:        applyURL,
 		Status:          "Unopened",
 		Description:     builtInListingCardDescription(card),
-		CompanyIndustry: builtInListingCardIndustry(card),
+		CompanyIndustry: firstString(industries),
+	}
+	sourceMetadata := job.EnsureSourceMetadata()
+	sourceMetadata.PostingURL = applyURL
+	sourceMetadata.CompanyProfileURL = companyProfileURL
+	sourceMetadata.PostedLabel = builtInListingCardPostedLabel(card)
+	sourceMetadata.Industries = append(sourceMetadata.Industries, industries...)
+	sourceMetadata.Skills = builtInListingCardSkills(card)
+	sourceMetadata.Locations = builtInListingCardLocations(card)
+	if len(industries) > 0 {
+		job.EnsureCompanyMetadata().Industries = append(job.EnsureCompanyMetadata().Industries, industries...)
 	}
 	job.SetDateAdded(time.Now().Unix())
 	if website := builtInListingCardCompanyWebsite(company); website != "" {
@@ -180,20 +191,80 @@ func builtInListingCardCompensation(card *goquery.Selection) string {
 	return compensation
 }
 
-func builtInListingCardIndustry(card *goquery.Selection) string {
+func builtInListingCardIndustries(card *goquery.Selection) []string {
 	text := normalizeWhitespace(selectionTextWithSpaces(card.Find(".mb-md.fs-xs.fw-bold").First()))
 	if text == "" {
-		return ""
+		return nil
 	}
+	var industries []string
 	for _, part := range splitBuiltInBulletList(text) {
 		if looksLikeCompanyIndustry(part) {
-			return part
+			industries = appendUniqueString(industries, part)
 		}
 	}
-	if looksLikeCompanyIndustry(text) {
-		return text
+	if len(industries) > 0 {
+		return industries
 	}
-	return ""
+	if looksLikeCompanyIndustry(text) {
+		return []string{text}
+	}
+	return nil
+}
+
+func builtInListingCardPostedLabel(card *goquery.Selection) string {
+	if card == nil || card.Length() == 0 {
+		return ""
+	}
+	var posted string
+	card.Find("span").EachWithBreak(func(_ int, selection *goquery.Selection) bool {
+		text := normalizeWhitespace(selectionTextWithSpaces(selection))
+		lower := strings.ToLower(text)
+		if strings.Contains(lower, "posted") || strings.Contains(lower, "reposted") || strings.Contains(lower, "days ago") || strings.Contains(lower, "hours ago") {
+			posted = text
+			return false
+		}
+		return true
+	})
+	return posted
+}
+
+func builtInListingCardLocations(card *goquery.Selection) []string {
+	if card == nil || card.Length() == 0 {
+		return nil
+	}
+	var locations []string
+	card.Find("span").Each(func(_ int, selection *goquery.Selection) {
+		text := normalizeWhitespace(selectionTextWithSpaces(selection))
+		if !looksLikeBuiltInListingLocation(text) {
+			return
+		}
+		locations = appendUniqueString(locations, text)
+	})
+	return locations
+}
+
+func looksLikeBuiltInListingLocation(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	if builtInWorkSettingLabel(text) != "" {
+		return false
+	}
+	if strings.Contains(lower, "annually") || strings.Contains(lower, "hourly") || strings.Contains(lower, "salary") {
+		return false
+	}
+	if strings.Contains(lower, "posted") || strings.Contains(lower, "reposted") || strings.Contains(lower, "days ago") || strings.Contains(lower, "hours ago") {
+		return false
+	}
+	switch lower {
+	case "senior level", "mid level", "entry level", "top skills:":
+		return false
+	}
+	if strings.Contains(lower, "united states") || strings.Contains(lower, "remote,") || strings.Contains(lower, ", ") {
+		return true
+	}
+	return strings.HasPrefix(lower, "hiring in ")
 }
 
 func builtInListingCardDescription(card *goquery.Selection) string {
@@ -253,4 +324,11 @@ func builtInListingCardCompanyWebsite(company string) string {
 		return ""
 	}
 	return website
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
 }

--- a/internal/fetcher/builtin_listing_test.go
+++ b/internal/fetcher/builtin_listing_test.go
@@ -80,6 +80,21 @@ func TestExtractBuiltInJobsFromListingParsesExpandedCards(t *testing.T) {
 	if first.CompanyIdentity == nil || first.CompanyIdentity.Industry == nil || first.CompanyIdentity.Industry.URL != "https://builtin.com/company/cadence-care" {
 		t.Fatalf("jobs[0].CompanyIdentity.Industry = %#v; want Built In company profile evidence URL", first.CompanyIdentity)
 	}
+	if first.Metadata == nil || first.Metadata.Source == nil {
+		t.Fatalf("jobs[0].Metadata = %#v; want Built In source metadata", first.Metadata)
+	}
+	if got := strings.Join(first.Metadata.Source.Industries, ","); got != "Artificial Intelligence,Healthtech,Machine Learning,Software,Telehealth" {
+		t.Fatalf("jobs[0].Metadata.Source.Industries = %#v; want full Built In industry list", first.Metadata.Source.Industries)
+	}
+	if got := strings.Join(first.Metadata.Source.Skills, ","); got != "AWS,Kubernetes,Terraform" {
+		t.Fatalf("jobs[0].Metadata.Source.Skills = %#v; want structured skills", first.Metadata.Source.Skills)
+	}
+	if got := first.Metadata.Source.CompanyProfileURL; got != "https://builtin.com/company/cadence-care" {
+		t.Fatalf("jobs[0].Metadata.Source.CompanyProfileURL = %q; want Built In profile URL", got)
+	}
+	if got := strings.Join(first.Metadata.Source.Locations, ","); got != "United States" {
+		t.Fatalf("jobs[0].Metadata.Source.Locations = %#v; want United States", first.Metadata.Source.Locations)
+	}
 	if !strings.Contains(first.Description, "Top skills: AWS, Kubernetes, Terraform") {
 		t.Fatalf("jobs[0].Description = %q; want top skills included", first.Description)
 	}

--- a/internal/fetcher/company_health_browser.go
+++ b/internal/fetcher/company_health_browser.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +40,7 @@ type pageLink struct {
 }
 
 var employerReviewRatingPattern = regexp.MustCompile(`(?i)\b([1-5](?:\.\d)?)\s*(?:out of|/)\s*5\b`)
+var indeedCategoryRatingPattern = regexp.MustCompile(`(?i)\b([1-5](?:\.\d)?)\s+(?:work[- ]?life balance|pay\s*&\s*benefits|job security(?:\s*&\s*advancement)?|management|culture)\b`)
 
 var reusableBrowserPools = struct {
 	sync.Mutex
@@ -147,6 +149,31 @@ func FetchBrowserEmployerReviewSignals(company string) ([]domain.EmployerReviewS
 	defer cancel()
 
 	return discoverEmployerReviewSignals(ctx, browser, company), nil
+}
+
+func FetchBrowserArticleText(ctx context.Context, rawURL string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", nil
+	}
+	if FindSiteSearchBrowserBinary() == "" {
+		return "", ErrBrowserNotInstalled
+	}
+
+	browser, cleanup, err := NewSiteSearchBrowser()
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, companyProfileBrowserTimeout)
+	defer cancel()
+
+	text, _, err := extractBrowserPageContent(ctx, browser, rawURL)
+	return text, err
 }
 
 func discoverCompanySiteProfile(ctx context.Context, browser *rod.Browser, company string) *domain.CompanySiteProfile {
@@ -702,10 +729,30 @@ func employerReviewSnippet(pageText string, title string, source string) string 
 
 func extractEmployerReviewRating(text string) string {
 	match := employerReviewRatingPattern.FindStringSubmatch(text)
-	if len(match) != 2 {
+	if len(match) == 2 {
+		return match[1] + "/5"
+	}
+	matches := indeedCategoryRatingPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
 		return ""
 	}
-	return match[1] + "/5"
+	total := 0.0
+	count := 0
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		value, err := strconv.ParseFloat(match[1], 64)
+		if err != nil || value <= 0 || value > 5 {
+			continue
+		}
+		total += value
+		count++
+	}
+	if count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f/5", total/float64(count))
 }
 
 func employerReviewFlags(text string) []string {

--- a/internal/fetcher/company_health_browser_test.go
+++ b/internal/fetcher/company_health_browser_test.go
@@ -92,6 +92,15 @@ func TestEmployerReviewSignalFromSearchResultExtractsRatingAndFlags(t *testing.T
 	if len(withSnippet.Flags) == 0 {
 		t.Fatalf("employerReviewSignalFromSearchResult().Flags = %v; want extracted flags", withSnippet.Flags)
 	}
+
+	withCategoryRatings := employerReviewSignalFromSearchResult(
+		"indeed",
+		"Acme Employee Reviews 3.8 Work-Life Balance 3.2 Pay & Benefits 3.4 Management 3.6 Culture",
+		pageLink{Text: "Acme Employee Reviews", URL: "https://www.indeed.com/cmp/Acme/reviews"},
+	)
+	if withCategoryRatings.Rating != "3.5/5" {
+		t.Fatalf("employerReviewSignalFromSearchResult().Rating = %q; want averaged category rating", withCategoryRatings.Rating)
+	}
 }
 
 func TestEmployerReviewSourceRecognizesReviewHosts(t *testing.T) {

--- a/internal/fetcher/company_identity_cache.go
+++ b/internal/fetcher/company_identity_cache.go
@@ -14,6 +14,7 @@ type CompanyIdentityRecord struct {
 	Summary  string
 	Industry string
 	Identity *domain.JobIdentityMetadata
+	Metadata *domain.JobMetadata
 }
 
 type PersistentCompanyIdentityStore interface {
@@ -102,6 +103,7 @@ func ApplyCachedIdentity(job *Job, record CompanyIdentityRecord) {
 		job.CompanyIndustry = record.Industry
 		setCachedIdentityEvidence(job, "industry", record.Industry, copiedEvidence(record.Identity, "industry"))
 	}
+	domain.MergeJobMetadataFields(job, domain.Job{Metadata: record.Metadata})
 }
 
 func seedCompanyIdentityFromTrustedJobs(jobs []Job, cache *CompanyIdentityCache) int {
@@ -118,6 +120,7 @@ func seedCompanyIdentityFromTrustedJobs(jobs []Job, cache *CompanyIdentityCache)
 			Summary:  jobs[i].CompanySummary,
 			Industry: jobs[i].CompanyIndustry,
 			Identity: CloneJobIdentityMetadata(jobs[i].CompanyIdentity),
+			Metadata: domain.CloneJobMetadata(jobs[i].Metadata),
 		})
 	}
 	return copied
@@ -211,6 +214,7 @@ func trustedIdentityRecordFromJob(job Job) (CompanyIdentityRecord, int, int, int
 	if identity.Website != nil || identity.Summary != nil || identity.Industry != nil {
 		record.Identity = &identity
 	}
+	record.Metadata = domain.CloneJobMetadata(job.Metadata)
 	return record, websiteRank, summaryRank, industryRank
 }
 

--- a/internal/fetcher/company_identity_cache_test.go
+++ b/internal/fetcher/company_identity_cache_test.go
@@ -192,6 +192,23 @@ func TestApplyCachedIdentity(t *testing.T) {
 	}
 }
 
+func TestRecordHasIdentityTreatsMetadataAsUseful(t *testing.T) {
+	record := CompanyIdentityRecord{
+		Metadata: &domain.JobMetadata{
+			Company: &domain.CompanyMetadata{
+				EmployeeRange: "501-1,000 employees",
+			},
+		},
+	}
+
+	if !recordHasIdentity(record) {
+		t.Fatal("recordHasIdentity() = false; want metadata-only record to be useful")
+	}
+	if recordHasIdentity(CompanyIdentityRecord{Metadata: &domain.JobMetadata{Company: &domain.CompanyMetadata{EmployeeRange: " "}}}) {
+		t.Fatal("recordHasIdentity() = true; want empty metadata ignored")
+	}
+}
+
 func TestCompanyIdentityCache_Concurrency(t *testing.T) {
 	cache := NewCompanyIdentityCache()
 	var wg sync.WaitGroup

--- a/internal/fetcher/company_identity_extract.go
+++ b/internal/fetcher/company_identity_extract.go
@@ -403,7 +403,7 @@ func extractExplicitCompanyIndustryFromHTML(rawHTML string) string {
 			continue
 		}
 		industry := strings.TrimSpace(match[1])
-		for _, stop := range []string{" Company website", " Website", " Headquarters", " About", " Salary", " Job type", " Location", " Skills"} {
+		for _, stop := range []string{" Company website", " Company size", " Website", " Headquarters", " Founded", " Size", " About", " Salary", " Job type", " Location", " Skills"} {
 			if idx := strings.Index(strings.ToLower(industry), strings.ToLower(stop)); idx >= 0 {
 				industry = industry[:idx]
 			}

--- a/internal/fetcher/company_profile_extract.go
+++ b/internal/fetcher/company_profile_extract.go
@@ -37,6 +37,9 @@ func enrichJobFromCompanyProfileHTML(job *Job, rawHTML string, profileURL string
 	if job == nil || strings.TrimSpace(rawHTML) == "" {
 		return
 	}
+	if source := job.EnsureSourceMetadata(); strings.TrimSpace(profileURL) != "" {
+		source.CompanyProfileURL = strings.TrimSpace(profileURL)
+	}
 	if website := extractCompanyWebsiteFromHTML(rawHTML, profileURL, job.Company); website != "" {
 		job.CompanyWebsite = website
 		setJobIdentityEvidence(job, "website", website, "company_profile", profileURL, "high", false, "Website extracted from source company profile.")
@@ -48,6 +51,43 @@ func enrichJobFromCompanyProfileHTML(job *Job, rawHTML string, profileURL string
 	if industry := extractCompanyProfileIndustry(rawHTML); industry != "" {
 		job.CompanyIndustry = industry
 		setJobIdentityEvidence(job, "industry", industry, "company_profile", profileURL, "high", false, "Industry extracted from source company profile.")
+	}
+	applyCompanyProfileMetadata(job, rawHTML, profileURL)
+}
+
+func applyCompanyProfileMetadata(job *Job, rawHTML string, profileURL string) {
+	if job == nil {
+		return
+	}
+	text := normalizeHTMLText(rawHTML)
+	evidence := companyPublicProfileEvidenceFromText("builtin", profileURL, "", text)
+	if !companyPublicProfileEvidenceUseful(evidence) && strings.TrimSpace(job.CompanyIndustry) == "" {
+		return
+	}
+	companyMetadata := job.EnsureCompanyMetadata()
+	if strings.TrimSpace(evidence.Industry) != "" {
+		companyMetadata.Industries = appendUniqueString(companyMetadata.Industries, evidence.Industry)
+	}
+	if strings.TrimSpace(job.CompanyIndustry) != "" {
+		companyMetadata.Industries = appendUniqueString(companyMetadata.Industries, job.CompanyIndustry)
+	}
+	if strings.TrimSpace(evidence.EmployeeRange) != "" {
+		companyMetadata.EmployeeRange = evidence.EmployeeRange
+	}
+	if evidence.EstimatedEmployees != nil {
+		companyMetadata.EstimatedEmployees = evidence.EstimatedEmployees
+	}
+	if evidence.FoundedYear != nil {
+		companyMetadata.FoundedYear = evidence.FoundedYear
+	}
+	if strings.TrimSpace(evidence.Headquarters) != "" {
+		companyMetadata.Headquarters = evidence.Headquarters
+	}
+	if strings.TrimSpace(evidence.Revenue) != "" {
+		companyMetadata.Revenue = evidence.Revenue
+	}
+	if strings.TrimSpace(evidence.Industry) != "" {
+		job.EnsureSourceMetadata().Industries = appendUniqueString(job.EnsureSourceMetadata().Industries, evidence.Industry)
 	}
 }
 

--- a/internal/fetcher/job_board_identity.go
+++ b/internal/fetcher/job_board_identity.go
@@ -30,11 +30,13 @@ func enrichJobFromBuiltInJobHTML(job *Job, rawHTML string, pageURL string) {
 	if strings.TrimSpace(job.Title) == "" {
 		job.Title = extractQuotedJSField(rawHTML, "title")
 	}
-	if !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
-		return
-	}
 	applyURL := extractQuotedJSField(rawHTML, "howToApply")
 	if applyURL == "" {
+		return
+	}
+	applyURL = strings.TrimSpace(html.UnescapeString(applyURL))
+	job.EnsureSourceMetadata().ExternalApplyURL = applyURL
+	if !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		return
 	}
 	website := normalizeCompanyWebsiteURL(applyURL)

--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -1506,6 +1506,13 @@ func TestEnrichJobFromHTMLExtractsStructuredJobPosting(t *testing.T) {
 				"unitText":"YEAR"
 			}
 		},
+		"datePosted":"2026-05-01",
+		"validThrough":"2026-06-01T00:00:00Z",
+		"employmentType":["FULL_TIME","REMOTE"],
+		"jobLocation":[
+			{"@type":"Place","address":{"addressLocality":"Austin","addressRegion":"TX","addressCountry":"US"}},
+			{"@type":"Place","address":{"addressLocality":"Remote","addressCountry":"US"}}
+		],
 		"industry":["Database","Cloud"]
 	}</script>`
 
@@ -1531,6 +1538,24 @@ func TestEnrichJobFromHTMLExtractsStructuredJobPosting(t *testing.T) {
 	}
 	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil || job.CompanyIdentity.Website.Source != "structured_job_posting" {
 		t.Fatalf("CompanyIdentity.Website = %#v; want structured_job_posting evidence", job.CompanyIdentity)
+	}
+	if job.Metadata == nil || job.Metadata.Source == nil {
+		t.Fatalf("Metadata = %#v; want structured source metadata", job.Metadata)
+	}
+	if got := strings.Join(job.Metadata.Source.Industries, ","); got != "Database,Cloud" {
+		t.Fatalf("Metadata.Source.Industries = %#v; want Database,Cloud", job.Metadata.Source.Industries)
+	}
+	if job.Metadata.Source.DatePosted != "2026-05-01" {
+		t.Fatalf("Metadata.Source.DatePosted = %q; want 2026-05-01", job.Metadata.Source.DatePosted)
+	}
+	if job.Metadata.Source.ValidThrough != "2026-06-01T00:00:00Z" {
+		t.Fatalf("Metadata.Source.ValidThrough = %q; want valid-through timestamp", job.Metadata.Source.ValidThrough)
+	}
+	if got := strings.Join(job.Metadata.Source.EmploymentTypes, ","); got != "FULL_TIME,REMOTE" {
+		t.Fatalf("Metadata.Source.EmploymentTypes = %#v; want FULL_TIME,REMOTE", job.Metadata.Source.EmploymentTypes)
+	}
+	if got := strings.Join(job.Metadata.Source.Locations, "|"); got != "Austin, TX, US|Remote, US" {
+		t.Fatalf("Metadata.Source.Locations = %#v; want structured locations", job.Metadata.Source.Locations)
 	}
 }
 
@@ -1562,6 +1587,9 @@ func TestEnrichJobFromHTMLExtractsBuiltInHowToApplyWebsite(t *testing.T) {
 	}
 	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil || job.CompanyIdentity.Website.Source != "builtin_how_to_apply" {
 		t.Fatalf("CompanyIdentity.Website = %#v; want builtin_how_to_apply evidence", job.CompanyIdentity)
+	}
+	if job.Metadata == nil || job.Metadata.Source == nil || job.Metadata.Source.ExternalApplyURL != "https://www.mongodb.com/careers/job/?gh_jid=7727920&gh_src=abc" {
+		t.Fatalf("Metadata.Source = %#v; want Built In external apply URL", job.Metadata)
 	}
 }
 

--- a/internal/fetcher/reusable_health_browser.go
+++ b/internal/fetcher/reusable_health_browser.go
@@ -56,6 +56,24 @@ func (s *ReusableHealthBrowser) FetchEmployerReviewSignals(ctx context.Context, 
 	return discoverEmployerReviewSignals(ctx, browser, company), nil
 }
 
+func (s *ReusableHealthBrowser) FetchArticleText(ctx context.Context, rawURL string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", nil
+	}
+	browser, err := s.getBrowser()
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, companyProfileBrowserTimeout)
+	defer cancel()
+	text, _, err := extractBrowserPageContent(ctx, browser, rawURL)
+	return text, err
+}
+
 func (s *ReusableHealthBrowser) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/fetcher/source_profile_enrichment.go
+++ b/internal/fetcher/source_profile_enrichment.go
@@ -278,5 +278,6 @@ func recordHasIdentity(record CompanyIdentityRecord) bool {
 	return strings.TrimSpace(record.Website) != "" ||
 		strings.TrimSpace(record.Summary) != "" ||
 		strings.TrimSpace(record.Industry) != "" ||
-		record.Identity != nil
+		record.Identity != nil ||
+		domain.CloneJobMetadata(record.Metadata) != nil
 }

--- a/internal/fetcher/source_profile_enrichment.go
+++ b/internal/fetcher/source_profile_enrichment.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 var (
@@ -132,6 +134,7 @@ func (entry *sourceProfileEntry) applyCached(ctx context.Context, job *Job, prof
 		Summary:  job.CompanySummary,
 		Industry: job.CompanyIndustry,
 		Identity: CloneJobIdentityMetadata(job.CompanyIdentity),
+		Metadata: domain.CloneJobMetadata(job.Metadata),
 	}) {
 		return
 	}
@@ -141,6 +144,7 @@ func (entry *sourceProfileEntry) applyCached(ctx context.Context, job *Job, prof
 		Summary:  job.CompanySummary,
 		Industry: job.CompanyIndustry,
 		Identity: CloneJobIdentityMetadata(job.CompanyIdentity),
+		Metadata: domain.CloneJobMetadata(job.Metadata),
 	}
 	entry.mu.Unlock()
 }
@@ -184,6 +188,7 @@ func (e *sourceProfileEnricher) fetchAndApply(ctx context.Context, job *Job, pro
 		Summary:  job.CompanySummary,
 		Industry: job.CompanyIndustry,
 		Identity: CloneJobIdentityMetadata(job.CompanyIdentity),
+		Metadata: domain.CloneJobMetadata(job.Metadata),
 	}
 	return recordHasIdentity(record), record, profileHTML
 }

--- a/internal/fetcher/source_profile_enrichment_test.go
+++ b/internal/fetcher/source_profile_enrichment_test.go
@@ -77,6 +77,24 @@ func TestSourceProfileEnricherSkipsLLMWhenDeterministicProfileCompletesIdentity(
 	if job.CompanyIndustry != "Fintech" {
 		t.Fatalf("CompanyIndustry = %q; want deterministic profile industry", job.CompanyIndustry)
 	}
+	if job.Metadata == nil || job.Metadata.Source == nil || job.Metadata.Company == nil {
+		t.Fatalf("Metadata = %#v; want profile metadata", job.Metadata)
+	}
+	if job.Metadata.Source.CompanyProfileURL != "https://builtin.com/company/affirm" {
+		t.Fatalf("Metadata.Source.CompanyProfileURL = %q; want profile URL", job.Metadata.Source.CompanyProfileURL)
+	}
+	if job.Metadata.Company.EmployeeRange != "501-1,000 employees" {
+		t.Fatalf("Metadata.Company.EmployeeRange = %q; want company size", job.Metadata.Company.EmployeeRange)
+	}
+	if job.Metadata.Company.EstimatedEmployees == nil || *job.Metadata.Company.EstimatedEmployees != 750 {
+		t.Fatalf("Metadata.Company.EstimatedEmployees = %#v; want 750", job.Metadata.Company.EstimatedEmployees)
+	}
+	if job.Metadata.Company.FoundedYear == nil || *job.Metadata.Company.FoundedYear != 2012 {
+		t.Fatalf("Metadata.Company.FoundedYear = %#v; want 2012", job.Metadata.Company.FoundedYear)
+	}
+	if job.Metadata.Company.Headquarters != "San Francisco, CA" {
+		t.Fatalf("Metadata.Company.Headquarters = %q; want headquarters", job.Metadata.Company.Headquarters)
+	}
 }
 
 func TestSourceProfileEnricherUsesCachedHTMLForLaterLLMWithoutRefetch(t *testing.T) {
@@ -453,7 +471,7 @@ func affirmBuiltInProfileHTML() string {
 	return `<html><body>
 		<h1>Affirm</h1>
 		<a href="https://www.affirm.com">Website</a>
-		<div>Industry: Fintech Website Headquarters</div>
+		<div>Industry: Fintech Company size 501-1,000 employees Headquarters San Francisco, CA Founded 2012 Website</div>
 		<h2>What We Do</h2>
 		<p>Affirm builds pay-over-time financial products for consumers and merchants.</p>
 		<h2>Why Work With Us</h2>

--- a/internal/fetcher/structured_job_posting.go
+++ b/internal/fetcher/structured_job_posting.go
@@ -15,6 +15,20 @@ func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string)
 		return
 	}
 	for _, posting := range extractStructuredJobPostings(rawHTML) {
+		sourceMetadata := job.EnsureSourceMetadata()
+		if strings.TrimSpace(sourceMetadata.PostingURL) == "" {
+			sourceMetadata.PostingURL = strings.TrimSpace(pageURL)
+		}
+		sourceMetadata.DatePosted = firstNonEmptyString(sourceMetadata.DatePosted, structuredStringField(posting, "datePosted"))
+		sourceMetadata.ValidThrough = firstNonEmptyString(sourceMetadata.ValidThrough, structuredStringField(posting, "validThrough"))
+		sourceMetadata.EmploymentTypes = appendUniqueStrings(sourceMetadata.EmploymentTypes, structuredStringValues(posting["employmentType"])...)
+		sourceMetadata.Locations = appendUniqueStrings(sourceMetadata.Locations, structuredJobPostingLocations(posting["jobLocation"])...)
+		industries := structuredJobPostingIndustries(posting)
+		sourceMetadata.Industries = appendUniqueStrings(sourceMetadata.Industries, industries...)
+		if len(industries) > 0 {
+			job.EnsureCompanyMetadata().Industries = appendUniqueStrings(job.EnsureCompanyMetadata().Industries, industries...)
+		}
+
 		company := structuredHiringOrganizationName(posting)
 		if company != "" && jobCompanyMissingOrUnknown(job.Company) {
 			job.Company = company
@@ -50,7 +64,7 @@ func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string)
 		}
 
 		if jobCompanyIndustryNeedsEnrichment(*job) {
-			if industry := structuredJobPostingIndustry(posting); industry != "" {
+			if industry := firstString(industries); industry != "" {
 				job.CompanyIndustry = industry
 				setJobIdentityEvidence(job, "industry", industry, "structured_job_posting", pageURL, "high", false, "Industry extracted from JobPosting structured data.")
 			}
@@ -155,19 +169,20 @@ func structuredJobPostingCompensation(posting map[string]any) string {
 	}
 }
 
-func structuredJobPostingIndustry(posting map[string]any) string {
+func structuredJobPostingIndustries(posting map[string]any) []string {
 	raw, ok := posting["industry"]
 	if !ok {
-		return ""
+		return nil
 	}
 	values := structuredStringValues(raw)
+	industries := make([]string, 0, len(values))
 	for _, value := range values {
 		value = normalizeHTMLText(value)
 		if looksLikeCompanyIndustry(value) {
-			return truncateAtSentence(value, 80)
+			industries = appendUniqueStrings(industries, truncateAtSentence(value, 80))
 		}
 	}
-	return ""
+	return industries
 }
 
 func structuredStringValues(value any) []string {
@@ -186,6 +201,52 @@ func structuredStringValues(value any) []string {
 	default:
 		return nil
 	}
+}
+
+func structuredJobPostingLocations(value any) []string {
+	switch typed := value.(type) {
+	case []any:
+		locations := make([]string, 0, len(typed))
+		for _, item := range typed {
+			locations = appendUniqueStrings(locations, structuredJobPostingLocations(item)...)
+		}
+		return locations
+	case map[string]any:
+		if address, ok := typed["address"]; ok {
+			if location := structuredAddressLocation(address); location != "" {
+				return []string{location}
+			}
+		}
+		if name := structuredStringField(typed, "name"); name != "" {
+			return []string{name}
+		}
+	case string:
+		if text := strings.TrimSpace(typed); text != "" {
+			return []string{text}
+		}
+	}
+	return nil
+}
+
+func structuredAddressLocation(value any) string {
+	address, ok := value.(map[string]any)
+	if !ok {
+		return structuredStringField(map[string]any{"value": value}, "value")
+	}
+	parts := make([]string, 0, 3)
+	for _, key := range []string{"addressLocality", "addressRegion", "addressCountry"} {
+		if part := structuredStringField(address, key); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func appendUniqueStrings(values []string, more ...string) []string {
+	for _, value := range more {
+		values = appendUniqueString(values, value)
+	}
+	return values
 }
 
 func structuredNumberField(value map[string]any, key string) (float64, bool) {

--- a/internal/health/browser_session.go
+++ b/internal/health/browser_session.go
@@ -9,6 +9,7 @@ import (
 type BrowserSession interface {
 	FetchCompanySiteProfile(context.Context, domain.CompanyHealthContext) (*domain.CompanySiteProfile, error)
 	FetchEmployerReviewSignals(context.Context, string) ([]domain.EmployerReviewSignal, error)
+	FetchArticleText(context.Context, string) (string, error)
 }
 
 type browserSessionContextKey struct{}

--- a/internal/health/browser_session_test.go
+++ b/internal/health/browser_session_test.go
@@ -2,7 +2,9 @@ package health
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/wallentx/jobscout/internal/config"
@@ -12,8 +14,10 @@ import (
 type fakeBrowserSession struct {
 	profileCalls int
 	reviewCalls  int
+	articleCalls int
 	profile      *domain.CompanySiteProfile
 	reviews      []domain.EmployerReviewSignal
+	articleText  string
 }
 
 func (s *fakeBrowserSession) FetchCompanySiteProfile(ctx context.Context, identity domain.CompanyHealthContext) (*domain.CompanySiteProfile, error) {
@@ -24,6 +28,11 @@ func (s *fakeBrowserSession) FetchCompanySiteProfile(ctx context.Context, identi
 func (s *fakeBrowserSession) FetchEmployerReviewSignals(ctx context.Context, company string) ([]domain.EmployerReviewSignal, error) {
 	s.reviewCalls++
 	return s.reviews, nil
+}
+
+func (s *fakeBrowserSession) FetchArticleText(ctx context.Context, rawURL string) (string, error) {
+	s.articleCalls++
+	return s.articleText, nil
 }
 
 func TestBrowserFetchesUseContextBrowserSession(t *testing.T) {
@@ -167,5 +176,88 @@ func TestApplyOptionalLLMCompanyHealthFetchesEmployerReviewsForWeakResult(t *tes
 	}
 	if len(result.EmployerReviews) != 1 {
 		t.Fatalf("EmployerReviews = %#v, want one review", result.EmployerReviews)
+	}
+}
+
+func TestApplyOptionalLLMCompanyHealthFetchesConcernArticlesAndAppliesNovelModifier(t *testing.T) {
+	originalInit := initConfiguredLLMForTask
+	originalEvaluate := evaluateCompanyHealthWithLLM
+	defer func() {
+		initConfiguredLLMForTask = originalInit
+		evaluateCompanyHealthWithLLM = originalEvaluate
+	}()
+
+	initConfiguredLLMForTask = func(ctx context.Context, appCfg *config.AppConfig, task string) (llms.Model, func(), error) {
+		return fakeHealthLLM{}, func() {}, nil
+	}
+	storyURL := "https://news.example/acme-investigation"
+	evaluateCompanyHealthWithLLM = func(ctx context.Context, model llms.Model, result *domain.CompanyHealthResult) (*domain.LLMCompanyHealthAssessment, error) {
+		if len(result.ConcernStoryArticles) != 1 {
+			t.Fatalf("len(ConcernStoryArticles) = %d, want 1", len(result.ConcernStoryArticles))
+		}
+		if !strings.Contains(result.ConcernStoryArticles[0].Text, "credit line was suspended") {
+			t.Fatalf("ConcernStoryArticles[0].Text = %q; want fetched page text", result.ConcernStoryArticles[0].Text)
+		}
+		delta := -6
+		return &domain.LLMCompanyHealthAssessment{
+			StoryInsight: "Recent coverage describes a credit-line suspension not visible in headline scoring.",
+			ArticleReviews: []domain.LLMCompanyHealthArticleReview{
+				{
+					URL:       storyURL,
+					Source:    "google_news_rss",
+					Related:   true,
+					NovelFact: "The article says Acme's credit line was suspended after regulatory review.",
+				},
+			},
+			ScoreModifier:          &delta,
+			ScoreModifierReason:    "The page adds a concrete financing concern.",
+			ScoreModifierNovelFact: "The article says Acme's credit line was suspended after regulatory review.",
+			ScoreModifierSources:   []string{storyURL},
+			FollowUpQuestions:      []string{"Ask whether financing has been restored."},
+			PositiveSignals:        []string{},
+			Concerns:               []string{"Financing risk needs follow-up."},
+			RiskLevel:              "medium",
+			Recommendation:         "Ask about the financing issue before applying.",
+		}, nil
+	}
+
+	published := time.Now().AddDate(0, -1, 0)
+	session := &fakeBrowserSession{
+		articleText: "Acme's credit line was suspended after a regulatory review of its lending controls.",
+	}
+	ctx := ContextWithBrowserSession(context.Background(), session)
+	result := &domain.CompanyHealthResult{
+		Company:        "Acme",
+		Score:          70,
+		Confidence:     "medium",
+		Sources:        map[string]any{},
+		EmploymentRisk: &domain.EmploymentRisk{Level: "Low", Score: 5},
+		ConcernStories: []domain.CompanyHealthConcernStory{
+			{
+				Source:  "google_news_rss",
+				Title:   "Acme faces regulatory investigation",
+				URL:     storyURL,
+				Date:    &published,
+				Concern: "negative news keyword: investigation",
+			},
+		},
+	}
+
+	ApplyOptionalLLMCompanyHealth(ctx, &config.AppConfig{
+		LLM: config.LLMConfig{
+			Enabled:       true,
+			CompanyHealth: true,
+			Provider:      "openai",
+		},
+	}, result)
+
+	if session.articleCalls != 1 {
+		t.Fatalf("article calls = %d, want 1", session.articleCalls)
+	}
+	if result.Score != 64 {
+		t.Fatalf("Score = %d, want 64 after LLM modifier", result.Score)
+	}
+	if result.LLMAssessment == nil || result.LLMAssessment.StoryInsight == "" {
+		t.Fatalf("LLMAssessment = %#v; want story insight", result.LLMAssessment)
 	}
 }

--- a/internal/health/llm.go
+++ b/internal/health/llm.go
@@ -19,6 +19,8 @@ var (
 	evaluateCompanyHealthWithLLM       = llmpkg.EvaluateCompanyHealthWithLLM
 )
 
+const maxCompanyHealthLLMConcernStories = 3
+
 func LLMCompanyHealthEnabled(appCfg *config.AppConfig) bool {
 	return appCfg != nil && appCfg.LLM.Enabled && appCfg.LLM.CompanyHealth
 }
@@ -137,6 +139,12 @@ func ApplyOptionalLLMCompanyHealth(ctx context.Context, appCfg *config.AppConfig
 		logDebug("timing company=%q step=browser_employer_reviews duration=%s signals=%d", result.Company, time.Since(reviewStart).Round(time.Millisecond), len(result.EmployerReviews))
 	}
 
+	articleStart := time.Now()
+	attachConcernStoryArticles(ctx, result)
+	if len(result.ConcernStoryArticles) > 0 {
+		logDebug("timing company=%q step=browser_concern_articles duration=%s articles=%d", result.Company, time.Since(articleStart).Round(time.Millisecond), len(result.ConcernStoryArticles))
+	}
+
 	assessmentStart := time.Now()
 	logDebug("llm company health assessment start company=%q signals=%d rejected_evidence=%d", result.Company, len(result.SignalsUsed), len(result.RejectedEvidence))
 	var assessment *domain.LLMCompanyHealthAssessment
@@ -149,6 +157,7 @@ func ApplyOptionalLLMCompanyHealth(ctx context.Context, appCfg *config.AppConfig
 		logDebug("llm company health assessment failed company=%q duration=%s error=%v", result.Company, time.Since(assessmentStart).Round(time.Millisecond), err)
 		return
 	}
+	applyLLMCompanyHealthScoreModifier(result, assessment)
 	result.LLMAssessment = assessment
 	logDebug("timing company=%q step=llm_assessment duration=%s token_usage=%s", result.Company, time.Since(assessmentStart).Round(time.Millisecond), debugLLMHealthTokenUsage(assessment.TokenUsage))
 	logDebug(
@@ -161,6 +170,189 @@ func ApplyOptionalLLMCompanyHealth(ctx context.Context, appCfg *config.AppConfig
 		len(assessment.Recommendation),
 		time.Since(assessmentStart).Round(time.Millisecond),
 	)
+}
+
+func attachConcernStoryArticles(ctx context.Context, result *domain.CompanyHealthResult) {
+	if result == nil || len(result.ConcernStories) == 0 {
+		return
+	}
+	stories := selectConcernStoriesForLLM(result.ConcernStories, maxCompanyHealthLLMConcernStories)
+	if len(stories) == 0 {
+		return
+	}
+	articles := make([]domain.CompanyHealthConcernArticle, 0, len(stories))
+	for _, story := range stories {
+		if strings.TrimSpace(story.URL) == "" {
+			continue
+		}
+		text, err := fetchBrowserConcernStoryTextThrottled(ctx, result.Company, story.URL)
+		if err != nil {
+			logDebug("browser concern article fetch failed company=%q url=%q error=%v", result.Company, story.URL, err)
+			continue
+		}
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		articles = append(articles, domain.CompanyHealthConcernArticle{
+			Source:  story.Source,
+			Title:   story.Title,
+			URL:     story.URL,
+			Date:    story.Date,
+			Concern: story.Concern,
+			Text:    text,
+		})
+	}
+	result.ConcernStoryArticles = articles
+}
+
+func selectConcernStoriesForLLM(stories []domain.CompanyHealthConcernStory, limit int) []domain.CompanyHealthConcernStory {
+	if limit <= 0 || len(stories) == 0 {
+		return nil
+	}
+	selected := make([]domain.CompanyHealthConcernStory, 0, limit)
+	seen := make(map[string]bool)
+	for _, story := range stories {
+		key := normalizedStoryURL(story.URL)
+		if key == "" || seen[key] || story.Date == nil {
+			continue
+		}
+		if time.Since(*story.Date) > 365*24*time.Hour || story.Date.After(time.Now().Add(24*time.Hour)) {
+			continue
+		}
+		seen[key] = true
+		selected = append(selected, story)
+		if len(selected) >= limit {
+			break
+		}
+	}
+	return selected
+}
+
+func fetchBrowserConcernStoryTextThrottled(ctx context.Context, company string, rawURL string) (string, error) {
+	var text string
+	err := runThrottledHealthStep(ctx, companyHealthBrowserSem, "browser concern article", company, func() error {
+		var fetchErr error
+		if session := browserSessionFromContext(ctx); session != nil {
+			text, fetchErr = session.FetchArticleText(ctx, rawURL)
+		} else {
+			text, fetchErr = fetcher.FetchBrowserArticleText(ctx, rawURL)
+		}
+		return fetchErr
+	})
+	return text, err
+}
+
+func applyLLMCompanyHealthScoreModifier(result *domain.CompanyHealthResult, assessment *domain.LLMCompanyHealthAssessment) {
+	if result == nil || assessment == nil {
+		return
+	}
+	allowed := relatedArticleURLSet(result.ConcernStoryArticles, assessment.ArticleReviews)
+	if len(allowed) == 0 {
+		assessment.StoryInsight = ""
+		assessment.ScoreModifier = nil
+		return
+	}
+	if strings.TrimSpace(assessment.StoryInsight) == "" && assessment.ScoreModifier == nil {
+		return
+	}
+	if assessment.ScoreModifier == nil || *assessment.ScoreModifier == 0 {
+		return
+	}
+	if !modifierUsesAllowedSource(assessment.ScoreModifierSources, allowed) {
+		assessment.ScoreModifier = nil
+		return
+	}
+	if !novelModifierFactValid(assessment.ScoreModifierNovelFact, result) {
+		assessment.ScoreModifier = nil
+		return
+	}
+
+	delta := *assessment.ScoreModifier
+	if delta > 10 {
+		delta = 10
+	}
+	if delta < -10 {
+		delta = -10
+	}
+	oldScore := result.Score
+	newScore := clampHealthScoreForRisk(oldScore+delta, result.EmploymentRisk)
+	actualDelta := newScore - oldScore
+	if actualDelta == 0 {
+		assessment.ScoreModifier = nil
+		return
+	}
+	result.Score = newScore
+	assessment.ScoreModifier = &actualDelta
+	reason := strings.TrimSpace(assessment.ScoreModifierReason)
+	if reason == "" {
+		reason = strings.TrimSpace(assessment.ScoreModifierNovelFact)
+	}
+	result.Notes = append(result.Notes, fmt.Sprintf("LLM article review adjusted score %+d: %s", actualDelta, reason))
+}
+
+func relatedArticleURLSet(articles []domain.CompanyHealthConcernArticle, reviews []domain.LLMCompanyHealthArticleReview) map[string]bool {
+	articleURLs := make(map[string]bool, len(articles))
+	for _, article := range articles {
+		if key := normalizedStoryURL(article.URL); key != "" {
+			articleURLs[key] = true
+		}
+	}
+	related := make(map[string]bool)
+	for _, review := range reviews {
+		key := normalizedStoryURL(review.URL)
+		if key == "" || !review.Related || !articleURLs[key] {
+			continue
+		}
+		related[key] = true
+	}
+	return related
+}
+
+func modifierUsesAllowedSource(sources []string, allowed map[string]bool) bool {
+	for _, source := range sources {
+		if allowed[normalizedStoryURL(source)] {
+			return true
+		}
+	}
+	return false
+}
+
+func novelModifierFactValid(fact string, result *domain.CompanyHealthResult) bool {
+	fact = strings.TrimSpace(fact)
+	if len(fact) < 20 {
+		return false
+	}
+	foldedFact := strings.ToLower(fact)
+	for _, story := range result.ConcernStories {
+		title := strings.ToLower(strings.TrimSpace(story.Title))
+		if title != "" && (foldedFact == title || strings.Contains(title, foldedFact)) {
+			return false
+		}
+	}
+	return true
+}
+
+func clampHealthScoreForRisk(score int, risk *domain.EmploymentRisk) int {
+	if risk != nil {
+		switch {
+		case risk.Score >= 75 && score > 40:
+			score = 40
+		case risk.Score >= 50 && score > 55:
+			score = 55
+		}
+	}
+	if score < 0 {
+		return 0
+	}
+	if score > 100 {
+		return 100
+	}
+	return score
+}
+
+func normalizedStoryURL(rawURL string) string {
+	return strings.TrimRight(strings.ToLower(strings.TrimSpace(rawURL)), "/")
 }
 
 func shouldSkipEmployerReviewLookup(result *domain.CompanyHealthResult) bool {

--- a/internal/llm/aliases.go
+++ b/internal/llm/aliases.go
@@ -10,6 +10,8 @@ type LLMAuthConfig = config.LLMAuthConfig
 type LLMProviderConfig = config.LLMProviderConfig
 type CriteriaConfig = domain.CriteriaConfig
 type CompanyHealthEvidence = domain.CompanyHealthEvidence
+type CompanyHealthConcernArticle = domain.CompanyHealthConcernArticle
+type CompanyHealthConcernStory = domain.CompanyHealthConcernStory
 type CompanyHealthContext = domain.CompanyHealthContext
 type CompanyHealthResult = domain.CompanyHealthResult
 type EmployerReviewSignal = domain.EmployerReviewSignal
@@ -20,6 +22,7 @@ type JobIdentityEnrichment = domain.JobIdentityEnrichment
 type JobIdentityPage = domain.JobIdentityPage
 type LayoffSignal = domain.LayoffSignal
 type LLMCompanyHealthAssessment = domain.LLMCompanyHealthAssessment
+type LLMCompanyHealthArticleReview = domain.LLMCompanyHealthArticleReview
 type LLMTokenUsage = domain.LLMTokenUsage
 type RoleFamilyID = domain.RoleFamilyID
 

--- a/internal/llm/llm_enrichment.go
+++ b/internal/llm/llm_enrichment.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
@@ -17,6 +18,7 @@ import (
 )
 
 const maxCompanyHealthRejectedEvidenceInPrompt = 12
+const maxCompanyHealthArticleTextChars = 6000
 
 // LLMEvaluationResult holds the parsed JSON output from the LLM
 type LLMEvaluationResult struct {
@@ -79,8 +81,18 @@ type companyHealthLLMInput struct {
 	LayoffHeadlines      []string                          `json:"layoff_headlines,omitempty"`
 	HackerNewsHighlights []string                          `json:"hacker_news_highlights,omitempty"`
 	EmployerReviews      []string                          `json:"employer_reviews,omitempty"`
+	ArticleContext       []companyHealthArticleContext     `json:"article_context,omitempty"`
 	RejectedEvidence     []string                          `json:"rejected_evidence,omitempty"`
 	RejectedOmitted      []rejectedEvidenceOmissionSummary `json:"rejected_evidence_omitted_summary,omitempty"`
+}
+
+type companyHealthArticleContext struct {
+	Source  string `json:"source"`
+	Title   string `json:"title"`
+	URL     string `json:"url,omitempty"`
+	Date    string `json:"date,omitempty"`
+	Concern string `json:"concern,omitempty"`
+	Text    string `json:"text"`
 }
 
 type rejectedEvidenceOmissionSummary struct {
@@ -549,6 +561,9 @@ func buildCompanyHealthLLMPromptWithStats(result *CompanyHealthResult) (string, 
 		for _, signal := range result.EmployerReviews {
 			input.EmployerReviews = append(input.EmployerReviews, formatEmployerReviewSignal(signal))
 		}
+		for _, article := range result.ConcernStoryArticles {
+			input.ArticleContext = append(input.ArticleContext, formatCompanyHealthArticleContext(article))
+		}
 		input.RejectedEvidence, input.RejectedOmitted, stats = rejectedHealthEvidenceForPrompt(result.RejectedEvidence)
 	}
 
@@ -561,6 +576,9 @@ func buildCompanyHealthLLMPromptWithStats(result *CompanyHealthResult) (string, 
 	prompt.WriteString("Review this deterministic company health assessment for a job seeker. ")
 	prompt.WriteString("Do not invent facts. Use only the supplied signals. ")
 	prompt.WriteString("Do not rely on rejected evidence; it is included only to explain disambiguation decisions. ")
+	prompt.WriteString("If article_context is present, decide whether each article is actually related to the target company before using it. ")
+	prompt.WriteString("Use company identity, website/domain, aliases, industry, and article body text for that decision. ")
+	prompt.WriteString("Only provide a score modifier when related article text contains concrete novel information not already represented by the score, flags, notes, headlines, or employer reviews. ")
 	prompt.WriteString("Explain whether this company looks worth further investigation as a potential employer.\n\n")
 	prompt.WriteString("Assessment JSON:\n")
 	prompt.Write(data)
@@ -571,9 +589,38 @@ func buildCompanyHealthLLMPromptWithStats(result *CompanyHealthResult) (string, 
 	prompt.WriteString(`  "risk_level": string,` + "\n")
 	prompt.WriteString(`  "positive_signals": [string],` + "\n")
 	prompt.WriteString(`  "concerns": [string],` + "\n")
-	prompt.WriteString(`  "follow_up_questions": [string]` + "\n")
+	prompt.WriteString(`  "follow_up_questions": [string],` + "\n")
+	prompt.WriteString(`  "article_reviews": [{"url": string, "source": string, "related": boolean, "relevance_reason": string, "novel_fact": string}],` + "\n")
+	prompt.WriteString(`  "story_insight": string,` + "\n")
+	prompt.WriteString(`  "score_modifier": number,` + "\n")
+	prompt.WriteString(`  "score_modifier_reason": string,` + "\n")
+	prompt.WriteString(`  "score_modifier_novel_fact": string,` + "\n")
+	prompt.WriteString(`  "score_modifier_sources": [string]` + "\n")
 	prompt.WriteString("}\n")
 	return prompt.String(), stats
+}
+
+func formatCompanyHealthArticleContext(article CompanyHealthConcernArticle) companyHealthArticleContext {
+	date := ""
+	if article.Date != nil {
+		date = article.Date.Format(time.RFC3339)
+	}
+	return companyHealthArticleContext{
+		Source:  strings.TrimSpace(article.Source),
+		Title:   strings.TrimSpace(article.Title),
+		URL:     strings.TrimSpace(article.URL),
+		Date:    date,
+		Concern: strings.TrimSpace(article.Concern),
+		Text:    truncateCompanyHealthArticleText(article.Text),
+	}
+}
+
+func truncateCompanyHealthArticleText(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= maxCompanyHealthArticleTextChars {
+		return text
+	}
+	return strings.TrimSpace(text[:maxCompanyHealthArticleTextChars])
 }
 
 func rejectedHealthEvidenceForPrompt(evidence []CompanyHealthEvidence) ([]string, []rejectedEvidenceOmissionSummary, companyHealthPromptStats) {

--- a/internal/llm/llm_enrichment_test.go
+++ b/internal/llm/llm_enrichment_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/wallentx/jobscout/internal/domain"
@@ -370,6 +371,75 @@ func TestBuildCompanyHealthLLMPromptIncludesSignals(t *testing.T) {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("buildCompanyHealthLLMPrompt() missing %q in:\n%s", expected, prompt)
 		}
+	}
+}
+
+func TestBuildCompanyHealthLLMPromptIncludesConcernArticleContext(t *testing.T) {
+	published := time.Date(2026, 2, 3, 0, 0, 0, 0, time.UTC)
+	result := &CompanyHealthResult{
+		Company: "Acme",
+		ConcernStoryArticles: []domain.CompanyHealthConcernArticle{
+			{
+				Source:  "google_news_rss",
+				Title:   "Acme faces regulatory investigation",
+				URL:     "https://news.example/acme-investigation",
+				Date:    &published,
+				Concern: "negative news keyword: investigation",
+				Text:    "Acme disclosed that a regulator opened an investigation into its hiring and safety practices.",
+			},
+		},
+	}
+
+	input := parseCompanyHealthPromptInput(t, buildCompanyHealthLLMPrompt(result))
+	if len(input.ArticleContext) != 1 {
+		t.Fatalf("len(input.ArticleContext) = %d, want 1", len(input.ArticleContext))
+	}
+	article := input.ArticleContext[0]
+	if article.URL != "https://news.example/acme-investigation" || article.Concern != "negative news keyword: investigation" {
+		t.Fatalf("ArticleContext[0] = %#v; want story metadata", article)
+	}
+	if !strings.Contains(article.Text, "regulator opened an investigation") {
+		t.Fatalf("ArticleContext[0].Text = %q; want fetched article text", article.Text)
+	}
+}
+
+func TestEvaluateCompanyHealthWithLLMParsesStoryInsightAndModifier(t *testing.T) {
+	llm := fakeContentLLM{content: `{
+		"summary": "Recent coverage adds one concrete risk.",
+		"recommendation": "Ask about the investigation before applying.",
+		"risk_level": "medium",
+		"positive_signals": [],
+		"concerns": ["Regulatory follow-up is warranted."],
+		"follow_up_questions": ["Has the matter been resolved?"],
+		"article_reviews": [{
+			"url": "https://news.example/acme-investigation",
+			"source": "google_news_rss",
+			"related": true,
+			"relevance_reason": "The page names Acme and its security software business.",
+			"novel_fact": "The article says a regulator opened an investigation into Acme's hiring and safety practices."
+		}],
+		"story_insight": "Recent coverage points to an unresolved regulatory issue that is broader than the headline alone.",
+		"score_modifier": -6,
+		"score_modifier_reason": "The page describes an active regulator investigation.",
+		"score_modifier_novel_fact": "The article says a regulator opened an investigation into Acme's hiring and safety practices.",
+		"score_modifier_sources": ["https://news.example/acme-investigation"]
+	}`}
+
+	assessment, err := evaluateCompanyHealthWithLLM(context.Background(), llm, &CompanyHealthResult{Company: "Acme"})
+	if err != nil {
+		t.Fatalf("evaluateCompanyHealthWithLLM() error = %v", err)
+	}
+	if assessment.StoryInsight == "" {
+		t.Fatalf("StoryInsight = empty; want article insight")
+	}
+	if assessment.ScoreModifier == nil || *assessment.ScoreModifier != -6 {
+		t.Fatalf("ScoreModifier = %#v; want -6", assessment.ScoreModifier)
+	}
+	if len(assessment.ArticleReviews) != 1 || !assessment.ArticleReviews[0].Related {
+		t.Fatalf("ArticleReviews = %#v; want one related review", assessment.ArticleReviews)
+	}
+	if assessment.ScoreModifierNovelFact == "" || len(assessment.ScoreModifierSources) != 1 {
+		t.Fatalf("assessment = %#v; want novel fact and source", assessment)
 	}
 }
 

--- a/internal/storage/aliases.go
+++ b/internal/storage/aliases.go
@@ -3,6 +3,9 @@ package storage
 import "github.com/wallentx/jobscout/internal/domain"
 
 type Job = domain.Job
+type JobMetadata = domain.JobMetadata
+type JobSourceMetadata = domain.JobSourceMetadata
+type CompanyMetadata = domain.CompanyMetadata
 type JobIdentityMetadata = domain.JobIdentityMetadata
 type JobIdentityEvidence = domain.JobIdentityEvidence
 type CompanyHealthResult = domain.CompanyHealthResult

--- a/internal/storage/sqlite_store.go
+++ b/internal/storage/sqlite_store.go
@@ -151,6 +151,12 @@ func (s *SQLiteStore) ensureMigrations() error {
 				CREATE INDEX IF NOT EXISTS idx_company_identity_keys_type_value ON company_identity_keys(key_type, key_value);
 			`,
 		},
+		{
+			version: 6,
+			sql: `
+				ALTER TABLE jobs ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '';
+			`,
+		},
 	}
 
 	for _, migration := range migrations {
@@ -199,6 +205,7 @@ func (s *SQLiteStore) LoadJobs() ([]Job, error) {
 			company_summary,
 			company_industry,
 			company_identity_json,
+			metadata_json,
 			title,
 			remote,
 			compensation,
@@ -223,12 +230,14 @@ func (s *SQLiteStore) LoadJobs() ([]Job, error) {
 		var job Job
 		var whyMatchesJSON string
 		var companyIdentityJSON string
+		var metadataJSON string
 		if err := rows.Scan(
 			&job.Company,
 			&job.CompanyWebsite,
 			&job.CompanySummary,
 			&job.CompanyIndustry,
 			&companyIdentityJSON,
+			&metadataJSON,
 			&job.Title,
 			&job.Remote,
 			&job.Compensation,
@@ -248,6 +257,12 @@ func (s *SQLiteStore) LoadJobs() ([]Job, error) {
 			if err := json.Unmarshal([]byte(companyIdentityJSON), &job.CompanyIdentity); err != nil {
 				job.CompanyIdentity = nil
 			}
+		}
+		if strings.TrimSpace(metadataJSON) != "" {
+			if err := json.Unmarshal([]byte(metadataJSON), &job.Metadata); err != nil {
+				job.Metadata = nil
+			}
+			job.Metadata = domain.NormalizeJobMetadata(job.Metadata)
 		}
 		job.DateDiscovered = formatUnixDate(job.DateAdded)
 		jobs = append(jobs, job)
@@ -278,6 +293,7 @@ func (s *SQLiteStore) SaveJobs(jobs []Job) error {
 			company_summary,
 			company_industry,
 			company_identity_json,
+			metadata_json,
 			title,
 			remote,
 			compensation,
@@ -287,7 +303,7 @@ func (s *SQLiteStore) SaveJobs(jobs []Job) error {
 			status,
 			date_added,
 			description
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		_ = tx.Rollback()
@@ -312,6 +328,15 @@ func (s *SQLiteStore) SaveJobs(jobs []Job) error {
 			}
 			companyIdentityJSON = string(identityBytes)
 		}
+		metadataJSON := ""
+		if metadata := domain.NormalizeJobMetadata(domain.CloneJobMetadata(job.Metadata)); metadata != nil {
+			metadataBytes, err := json.Marshal(metadata)
+			if err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("marshal metadata for %s - %s: %w", job.Company, job.Title, err)
+			}
+			metadataJSON = string(metadataBytes)
+		}
 
 		dateAdded := job.DateAdded
 		if dateAdded <= 0 {
@@ -324,6 +349,7 @@ func (s *SQLiteStore) SaveJobs(jobs []Job) error {
 			job.CompanySummary,
 			job.CompanyIndustry,
 			companyIdentityJSON,
+			metadataJSON,
 			job.Title,
 			job.Remote,
 			job.Compensation,

--- a/internal/storage/sqlite_store_test.go
+++ b/internal/storage/sqlite_store_test.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+func intPtr(value int) *int {
+	return &value
+}
+
 func TestSQLiteStoreRoundTrip(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "jobscout.db")
 
@@ -42,10 +46,27 @@ func TestSQLiteStoreRoundTrip(t *testing.T) {
 			Compensation: "$200,000",
 			Source:       "test",
 			ApplyURL:     "https://example.com/jobs/1",
-			WhyMatches:   []string{"keyword"},
-			Status:       "Unopened",
-			DateAdded:    time.Now().Unix(),
-			Description:  "desc",
+			Metadata: &JobMetadata{
+				Source: &JobSourceMetadata{
+					PostingURL:        "https://example.com/jobs/1",
+					ExternalApplyURL:  "https://acme.example/careers/1",
+					CompanyProfileURL: "https://example.com/companies/acme",
+					Industries:        []string{"Developer Tools", "Cloud"},
+					Skills:            []string{"Go", "Kubernetes"},
+				},
+				Company: &CompanyMetadata{
+					Industries:         []string{"Developer Tools", "Cloud"},
+					EmployeeRange:      "501-1,000 employees",
+					EstimatedEmployees: intPtr(750),
+					FoundedYear:        intPtr(2018),
+					Headquarters:       "Austin, TX",
+					Ticker:             "ACME",
+				},
+			},
+			WhyMatches:  []string{"keyword"},
+			Status:      "Unopened",
+			DateAdded:   time.Now().Unix(),
+			Description: "desc",
 		},
 	}
 
@@ -73,6 +94,15 @@ func TestSQLiteStoreRoundTrip(t *testing.T) {
 	}
 	if loadedJobs[0].CompanyIdentity == nil || loadedJobs[0].CompanyIdentity.Industry == nil || !loadedJobs[0].CompanyIdentity.Industry.Provisional {
 		t.Fatalf("LoadJobs()[0].CompanyIdentity = %#v; want provisional industry evidence", loadedJobs[0].CompanyIdentity)
+	}
+	if loadedJobs[0].Metadata == nil || loadedJobs[0].Metadata.Source == nil || loadedJobs[0].Metadata.Company == nil {
+		t.Fatalf("LoadJobs()[0].Metadata = %#v; want source and company metadata", loadedJobs[0].Metadata)
+	}
+	if got := loadedJobs[0].Metadata.Source.ExternalApplyURL; got != "https://acme.example/careers/1" {
+		t.Fatalf("LoadJobs()[0].Metadata.Source.ExternalApplyURL = %q; want external apply URL", got)
+	}
+	if loadedJobs[0].Metadata.Company.EstimatedEmployees == nil || *loadedJobs[0].Metadata.Company.EstimatedEmployees != 750 {
+		t.Fatalf("LoadJobs()[0].Metadata.Company.EstimatedEmployees = %#v; want 750", loadedJobs[0].Metadata.Company.EstimatedEmployees)
 	}
 
 	cache := HealthCache{

--- a/internal/tuiapp/health_flow.go
+++ b/internal/tuiapp/health_flow.go
@@ -226,6 +226,19 @@ func renderHealthReport(r *CompanyHealthResult, contentWidth int) string {
 			main.WriteString(llmStyle.Render(fmt.Sprintf("  ! %s", concern)))
 			main.WriteString("\n")
 		}
+		if strings.TrimSpace(assessment.StoryInsight) != "" {
+			main.WriteString(llmStyle.Render(fmt.Sprintf("  ! Story insight: %s", assessment.StoryInsight)))
+			main.WriteString("\n")
+		}
+		if assessment.ScoreModifier != nil && *assessment.ScoreModifier != 0 {
+			modifier := fmt.Sprintf("%+d", *assessment.ScoreModifier)
+			reason := strings.TrimSpace(assessment.ScoreModifierReason)
+			if reason == "" {
+				reason = strings.TrimSpace(assessment.ScoreModifierNovelFact)
+			}
+			main.WriteString(llmStyle.Render(fmt.Sprintf("  ! LLM modifier: %s - %s", modifier, reason)))
+			main.WriteString("\n")
+		}
 		for _, question := range assessment.FollowUpQuestions {
 			main.WriteString(llmStyle.Render(fmt.Sprintf("  ? %s", question)))
 			main.WriteString("\n")
@@ -308,7 +321,7 @@ func renderHealthReport(r *CompanyHealthResult, contentWidth int) string {
 
 	if len(r.EmployerReviews) > 0 {
 		main.WriteString("\n")
-		main.WriteString(sectionStyle.Render("EMPLOYER REVIEWS"))
+		main.WriteString(sectionStyle.Render("EMPLOYEE REVIEWS"))
 		main.WriteString("\n")
 
 		reviewStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("183"))
@@ -393,6 +406,8 @@ func formatEmployerReviewSummary(review domain.EmployerReviewSignal) string {
 	}
 	if review.Rating != "" {
 		parts = append(parts, review.Rating)
+	} else if indicator := employerReviewIndicator(review); indicator != "" {
+		parts = append(parts, indicator)
 	}
 	if review.ReviewCount != nil {
 		parts = append(parts, fmt.Sprintf("%d reviews", *review.ReviewCount))
@@ -410,6 +425,29 @@ func formatEmployerReviewSummary(review domain.EmployerReviewSignal) string {
 		parts = append(parts, review.Title)
 	}
 	return strings.Join(parts, " | ")
+}
+
+func employerReviewIndicator(review domain.EmployerReviewSignal) string {
+	positive := false
+	negative := false
+	for _, flag := range review.Flags {
+		switch strings.ToLower(strings.TrimSpace(flag)) {
+		case "positive culture":
+			positive = true
+		case "burnout", "toxic culture", "poor culture", "long hours", "low pay", "layoff mentions":
+			negative = true
+		}
+	}
+	switch {
+	case positive && negative:
+		return "~"
+	case positive:
+		return "+"
+	case negative:
+		return "-"
+	default:
+		return ""
+	}
 }
 
 func formatHealthLLMTokenUsage(usage LLMTokenUsage) string {
@@ -606,13 +644,9 @@ func loadCompanyHealthForJob(job Job, forceRefresh bool) tea.Cmd {
 }
 
 func loadCompanyHealthForJobWithContext(ctx context.Context, job Job, forceRefresh bool, taskKey string, background bool) tea.Cmd {
-	return loadCompanyHealthWithIdentityAndContext(ctx, CompanyHealthContext{
-		Company:                 job.Company,
-		Website:                 job.CompanyWebsite,
-		Summary:                 job.CompanySummary,
-		Industry:                job.CompanyIndustry,
-		RequireResolvedIdentity: true,
-	}, forceRefresh, taskKey, background)
+	identity := domain.CompanyHealthContextForJob(job)
+	identity.RequireResolvedIdentity = true
+	return loadCompanyHealthWithIdentityAndContext(ctx, identity, forceRefresh, taskKey, background)
 }
 
 func loadCompanyHealthWithIdentity(identity CompanyHealthContext, forceRefresh bool) tea.Cmd {
@@ -651,13 +685,8 @@ func fetchBulkHealthStepWithContext(ctx context.Context, job Job, browserSession
 		if cfgErr != nil {
 			appCfg = nil
 		}
-		identity := CompanyHealthContext{
-			Company:                 job.Company,
-			Website:                 job.CompanyWebsite,
-			Summary:                 job.CompanySummary,
-			Industry:                job.CompanyIndustry,
-			RequireResolvedIdentity: true,
-		}
+		identity := domain.CompanyHealthContextForJob(job)
+		identity.RequireResolvedIdentity = true
 		company := strings.TrimSpace(job.Company)
 		logBulkHealthDebug("step start company=%q website=%q cache_key=%q mem=%s", company, job.CompanyWebsite, healthpkg.CacheKeyForJob(job), startMem)
 		if domain.CompanyHealthContextDomain(identity) == "" {

--- a/internal/tuiapp/health_overlay_test.go
+++ b/internal/tuiapp/health_overlay_test.go
@@ -6,11 +6,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wallentx/jobscout/internal/domain"
 	healthpkg "github.com/wallentx/jobscout/internal/health"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
+
+func TestFormatEmployerReviewSummaryShowsIndeedIndicator(t *testing.T) {
+	got := formatEmployerReviewSummary(domain.EmployerReviewSignal{
+		Source: "indeed",
+		Flags:  []string{"long hours", "low pay"},
+	})
+	if got != "Indeed | - | long hours, low pay" {
+		t.Fatalf("formatEmployerReviewSummary() = %q; want Indeed negative indicator with findings", got)
+	}
+
+	withRating := formatEmployerReviewSummary(domain.EmployerReviewSignal{
+		Source: "indeed",
+		Rating: "3.5/5",
+		Flags:  []string{"long hours"},
+	})
+	if withRating != "Indeed | 3.5/5 | long hours" {
+		t.Fatalf("formatEmployerReviewSummary() = %q; want numeric rating before flags", withRating)
+	}
+}
 
 func TestLoadCompanyHealthDoesNotMutateCacheInCmd(t *testing.T) {
 	prevHealthStore := runtimeHealthStore


### PR DESCRIPTION
Summary:
- Add richer company health context, concern-story review, and metadata fields used by health scoring.
- Capture company facts such as employee counts, tickers, sources, and evidence state more consistently.
- Add `docs/DATA_INVENTORY.md` to document the data fields Jobscout gathers and uses.

Notes:
- This is the first PR in the split from `wallentx/health`. Later PRs should build on this foundation to avoid conflicts.
