### PR TITLE
Add fetch limits and browser page debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ testdata/tmp/
 
 # Logs
 /*.log
+/debug-pages/
 /logs/
 
 # Secrets and local environment

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Options:
   --sources <list>        Use selected active fetch sources: rss, site, llm, llm_web, all
   --sources=<list>        Same as --sources <list>
                             llm_web is an opt-in experimental source
+  --candidate-limit <n>
+                          Evaluate at most n site candidates per source; 0 disables the cap
+  --candidate-limit=<n>
+                          Same as --candidate-limit <n>
+  --accepted-limit <n>    Return at most n accepted jobs from a fetch; 0 disables the cap
+  --accepted-limit=<n>    Same as --accepted-limit <n>
   --config <path>         Use an alternate config file
   --config=<path>         Same as --config <path>
   -h, --help              Show this help

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,15 +72,27 @@ Rel(update, githubReleases, "Checks latest release")
    SQLite database path.
 2. The fetch pipeline resolves effective sources from config, selected role
    families, and work settings.
-3. Enabled source groups run with bounded concurrency.
-4. Fetched jobs are normalized into the same `Job` shape.
-5. Deterministic filters remove jobs that clearly do not match.
-6. Company identity enrichment fills company website, summary, and industry
+3. Source order is randomized so one large site does not always consume the
+   early fetch budget.
+4. Enabled source groups run with bounded concurrency and site candidate caps.
+5. Fetched jobs are normalized into the same `Job` shape.
+6. Deterministic filters remove jobs that clearly do not match.
+7. Company identity enrichment fills company website, summary, and industry
    when possible.
-7. Optional LLM filtering reviews only jobs that still need fit judgment.
-8. Validation rejects non-job URLs, weak results, duplicates, and already-saved
+8. Optional LLM filtering reviews only jobs that still need fit judgment.
+9. Validation rejects non-job URLs, weak results, duplicates, and already-saved
    jobs.
-9. Accepted jobs are shown in the fetch review flow before they are saved.
+10. Accepted jobs are shown in the fetch review flow before they are saved.
+
+Fetch limits can be adjusted in `config.yaml`:
+
+```yaml
+fetch:
+  candidate_limit_per_source: 15
+  accepted_limit: 0
+```
+
+Use `0` to disable either cap.
 
 ## Job Sources
 
@@ -102,15 +114,19 @@ settings.
 The built-in catalog is not a flat list that always runs.
 
 - Role families choose role-specific RSS feeds and specialty sources.
+- Built-in remote-only sources run only when remote work is selected. This
+  includes Remotive, We Work Remotely, Real Work From Anywhere, and the Built
+  In remote target.
 - `kube.careers` is used only when DevOps / SRE / Systems is selected.
 - If the user selects only remote work, only the Built In remote catalog target
   is used from the Built In catalog.
 - If the user selects hybrid or on-site work, `jobscout` picks the closest Built
-  In regional site from the candidate location. If no region matches, it falls
-  back to the general Built In tech jobs target.
+  In regional site from the candidate location. The general Built In tech jobs
+  target is used only when no regional target matches.
 - If remote is selected along with hybrid or on-site work, the Built In remote
   target can run alongside the closest regional target.
-- User-configured site targets still run when site search is enabled.
+- User-configured site targets still run when site search is enabled, except
+  known remote-only targets are skipped when remote work is not selected.
 
 ### Built-In RSS Catalog
 
@@ -126,7 +142,6 @@ The built-in catalog is not a flat list that always runs.
 - Indeed Jobs
 - LinkedIn Jobs
 - Y Combinator Jobs
-- Himalayas Remote Jobs
 - Kube Careers
 - Built In Remote Tech Jobs
 - Built In Tech Jobs
@@ -148,7 +163,6 @@ The built-in catalog is not a flat list that always runs.
 - Indeed
 - LinkedIn
 - Y Combinator
-- Himalayas
 - Built In Remote
 
 ### Default Experimental `llm_web` Targets

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,11 @@ type LLMWebSearchConfig struct {
 	Targets []string `yaml:"targets"`
 }
 
+type FetchConfig struct {
+	CandidateLimitPerSource int `yaml:"candidate_limit_per_source,omitempty"`
+	AcceptedLimit           int `yaml:"accepted_limit,omitempty"`
+}
+
 type SourcesConfig struct {
 	Enabled         bool               `yaml:"enabled"`
 	BuiltinsEnabled bool               `yaml:"builtins_enabled,omitempty"`
@@ -84,6 +89,7 @@ type LLMConfig struct {
 }
 
 type AppConfig struct {
+	Fetch    FetchConfig    `yaml:"fetch,omitempty"`
 	Sources  SourcesConfig  `yaml:"sources"`
 	Criteria CriteriaConfig `yaml:"criteria,omitempty"`
 	LLM      LLMConfig      `yaml:"llm"`
@@ -123,6 +129,8 @@ const (
 func defaultAppConfig() AppConfig {
 	var cfg AppConfig
 
+	cfg.Fetch.CandidateLimitPerSource = 15
+	cfg.Fetch.AcceptedLimit = 0
 	cfg.Sources.Enabled = true
 	cfg.Sources.BuiltinsEnabled = true
 	cfg.Sources.RSS.Enabled = true
@@ -133,7 +141,6 @@ func defaultAppConfig() AppConfig {
 		"https://www.indeed.com/jobs",
 		"https://www.linkedin.com/jobs/search",
 		"https://www.ycombinator.com/jobs",
-		"https://himalayas.app/jobs",
 		"https://builtin.com/jobs/remote",
 	}
 	cfg.Sources.LLMWeb.Enabled = false
@@ -358,6 +365,7 @@ func loadAppConfig(path string) (*AppConfig, error) {
 		})
 	}
 	disableExperimentalFetchSources(&cfg)
+	normalizeFetchConfig(&cfg)
 	if criteria, ok, err := loadCriteriaSectionFromConfigData(data); err != nil {
 		return nil, err
 	} else if ok {
@@ -369,6 +377,31 @@ func loadAppConfig(path string) (*AppConfig, error) {
 
 func LoadAppConfig(path string) (*AppConfig, error) {
 	return loadAppConfig(path)
+}
+
+func normalizeFetchConfig(cfg *AppConfig) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Fetch.CandidateLimitPerSource < 0 {
+		cfg.Fetch.CandidateLimitPerSource = 0
+	}
+	if cfg.Fetch.AcceptedLimit < 0 {
+		cfg.Fetch.AcceptedLimit = 0
+	}
+}
+
+func ApplyFetchLimitOverrides(cfg *AppConfig, candidateLimitPerSource *int, acceptedLimit *int) {
+	if cfg == nil {
+		return
+	}
+	if candidateLimitPerSource != nil {
+		cfg.Fetch.CandidateLimitPerSource = *candidateLimitPerSource
+	}
+	if acceptedLimit != nil {
+		cfg.Fetch.AcceptedLimit = *acceptedLimit
+	}
+	normalizeFetchConfig(cfg)
 }
 
 // Experimental fetch sources are opt-in through --sources; keep their definitions

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,6 +72,17 @@ func TestSaveAppConfigUsesPrivatePermissions(t *testing.T) {
 	}
 }
 
+func TestDefaultFetchPolicyLimitsSiteCandidateEvaluation(t *testing.T) {
+	cfg := defaultAppConfig()
+
+	if cfg.Fetch.CandidateLimitPerSource != 15 {
+		t.Fatalf("default fetch candidate_limit_per_source = %d; want 15", cfg.Fetch.CandidateLimitPerSource)
+	}
+	if cfg.Fetch.AcceptedLimit != 0 {
+		t.Fatalf("default fetch accepted_limit = %d; want 0 for unlimited", cfg.Fetch.AcceptedLimit)
+	}
+}
+
 func TestModelOptionsForProviderIncludesCurrentOpenAITextModels(t *testing.T) {
 	options := ModelOptionsForProvider("openai")
 	for _, model := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-5.3-chat", "gpt-5.2-chat", "gpt-4o", "gpt-4o-mini", "o3"} {
@@ -179,10 +190,9 @@ func TestDefaultSiteSearchSitesAreSearchableTargets(t *testing.T) {
 		"https://www.indeed.com/jobs",
 		"https://www.linkedin.com/jobs/search",
 		"https://www.ycombinator.com/jobs",
-		"https://himalayas.app/jobs",
 		"https://builtin.com/jobs/remote",
 	} {
-		if !containsString(cfg.Sources.SiteSearch.Sites, want) {
+		if !slices.Contains(cfg.Sources.SiteSearch.Sites, want) {
 			t.Fatalf("defaultAppConfig().Sources.SiteSearch.Sites = %#v; want %q", cfg.Sources.SiteSearch.Sites, want)
 		}
 	}
@@ -200,7 +210,7 @@ func TestDefaultSiteSearchSitesAreSearchableTargets(t *testing.T) {
 		"site:careers-*.icims.com",
 		"site:*.bamboohr.com/jobs",
 	} {
-		if !containsString(cfg.Sources.LLMWeb.Targets, want) {
+		if !slices.Contains(cfg.Sources.LLMWeb.Targets, want) {
 			t.Fatalf("defaultAppConfig().Sources.LLMWeb.Targets = %#v; want %q", cfg.Sources.LLMWeb.Targets, want)
 		}
 	}
@@ -423,7 +433,7 @@ func TestEvaluateCapabilitiesFlagsDisabledLLMWithFeatureToggles(t *testing.T) {
 		t.Fatal("evaluateCapabilitiesForConfig(...).LLMFeaturesSelected = false; want true")
 	}
 	want := "LLM feature toggles are enabled but llm.enabled is false"
-	if !containsString(caps.SetupIssues, want) {
+	if !slices.Contains(caps.SetupIssues, want) {
 		t.Fatalf("evaluateCapabilitiesForConfig(...).SetupIssues = %#v; want %q", caps.SetupIssues, want)
 	}
 }
@@ -482,13 +492,4 @@ func TestEvaluateRuntimeCapabilitiesUsesConfiguredRuntimePath(t *testing.T) {
 	if !caps.SearchProfileReady {
 		t.Fatal("EvaluateRuntimeCapabilities().SearchProfileReady = false; want true")
 	}
-}
-
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/domain/location_test.go
+++ b/internal/domain/location_test.go
@@ -23,7 +23,4 @@ func TestParseWorkSettingsAcceptsNewlineSeparatedValues(t *testing.T) {
 	if !got.Onsite {
 		t.Fatal("ParseWorkSettings(...).Onsite = false; want true")
 	}
-	if got.Hybrid {
-		t.Fatal("ParseWorkSettings(...).Hybrid = true; want false")
-	}
 }

--- a/internal/fetcher/browser_debug.go
+++ b/internal/fetcher/browser_debug.go
@@ -1,7 +1,7 @@
 package fetcher
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -214,7 +214,7 @@ func debugBrowserPageArtifactPrefix(debugPath string, requestedURL string, statu
 	if parsed, err := url.Parse(requestedURL); err == nil && parsed.Hostname() != "" {
 		host = parsed.Hostname()
 	}
-	sum := sha1.Sum([]byte(requestedURL))
+	sum := sha256.Sum256([]byte(requestedURL))
 	hash := hex.EncodeToString(sum[:])[:10]
 	name := fmt.Sprintf(
 		"%s-%s-%s-%s",

--- a/internal/fetcher/browser_debug.go
+++ b/internal/fetcher/browser_debug.go
@@ -1,0 +1,262 @@
+package fetcher
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+const browserDebugSnapshotTimeout = 3 * time.Second
+
+var debugFilenameUnsafePattern = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+type browserPageDebugMetadata struct {
+	Scope          string   `json:"scope"`
+	Status         string   `json:"status"`
+	RequestedURL   string   `json:"requested_url"`
+	FinalURL       string   `json:"final_url,omitempty"`
+	Title          string   `json:"title,omitempty"`
+	DurationMillis int64    `json:"duration_ms"`
+	Error          string   `json:"error,omitempty"`
+	CapturedAt     string   `json:"captured_at"`
+	HTMLFile       string   `json:"html_file,omitempty"`
+	TextFile       string   `json:"text_file,omitempty"`
+	LinksFile      string   `json:"links_file,omitempty"`
+	HTMLBytes      int      `json:"html_bytes,omitempty"`
+	TextBytes      int      `json:"text_bytes,omitempty"`
+	Links          int      `json:"links,omitempty"`
+	CaptureErrors  []string `json:"capture_errors,omitempty"`
+}
+
+func captureBrowserPageDebugSnapshot(page *rod.Page, requestedURL string, scope string, duration time.Duration, runErr error) {
+	enabled, debugPath := debugSettings()
+	if !enabled || page == nil {
+		return
+	}
+
+	status := "ok"
+	errText := ""
+	if runErr != nil {
+		status = "error"
+		errText = SimplifySiteSearchError(runErr).Error()
+	}
+
+	metadata := browserPageDebugMetadata{
+		Scope:          strings.TrimSpace(scope),
+		Status:         status,
+		RequestedURL:   requestedURL,
+		DurationMillis: duration.Milliseconds(),
+		Error:          errText,
+		CapturedAt:     time.Now().Format(time.RFC3339Nano),
+	}
+
+	snapshotPage := page.Timeout(browserDebugSnapshotTimeout)
+	defer snapshotPage.CancelTimeout()
+
+	var (
+		html  string
+		text  string
+		links []pageLink
+	)
+
+	if err := rod.Try(func() {
+		info, err := snapshotPage.Info()
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("page info: %v", err))
+		} else if info != nil {
+			metadata.FinalURL = info.URL
+			metadata.Title = info.Title
+		}
+	}); err != nil {
+		metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("page info: %v", err))
+	}
+
+	if err := rod.Try(func() {
+		var err error
+		html, err = snapshotPage.HTML()
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("html: %v", err))
+		}
+	}); err != nil {
+		metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("html: %v", err))
+	}
+
+	if err := rod.Try(func() {
+		body, err := snapshotPage.Element("body")
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("body: %v", err))
+			return
+		}
+		bodyText, err := body.Text()
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("body text: %v", err))
+			return
+		}
+		text = NormalizeWhitespace(bodyText)
+	}); err != nil {
+		metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("body text: %v", err))
+	}
+
+	if err := rod.Try(func() {
+		elements, err := snapshotPage.Elements("a[href]")
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("links: %v", err))
+			return
+		}
+		baseURL := requestedURL
+		if metadata.FinalURL != "" {
+			baseURL = metadata.FinalURL
+		}
+		links = extractDebugPageLinks(elements, baseURL)
+	}); err != nil {
+		metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("links: %v", err))
+	}
+
+	prefix := debugBrowserPageArtifactPrefix(debugPath, requestedURL, status)
+	if html != "" {
+		path, err := writeDebugArtifact(prefix+".html", []byte(html))
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("write html: %v", err))
+		} else {
+			metadata.HTMLFile = path
+			metadata.HTMLBytes = len(html)
+		}
+	}
+	if text != "" {
+		path, err := writeDebugArtifact(prefix+".txt", []byte(text))
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("write text: %v", err))
+		} else {
+			metadata.TextFile = path
+			metadata.TextBytes = len(text)
+		}
+	}
+	if len(links) > 0 {
+		linkBytes, err := json.MarshalIndent(links, "", "  ")
+		if err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("marshal links: %v", err))
+		} else if path, err := writeDebugArtifact(prefix+".links.json", linkBytes); err != nil {
+			metadata.CaptureErrors = append(metadata.CaptureErrors, fmt.Sprintf("write links: %v", err))
+		} else {
+			metadata.LinksFile = path
+			metadata.Links = len(links)
+		}
+	}
+
+	metaBytes, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		logDebug("browser page snapshot metadata failed scope=%q status=%s url=%q error=%v", scope, status, requestedURL, err)
+		return
+	}
+	metaPath, err := writeDebugArtifact(prefix+".json", metaBytes)
+	if err != nil {
+		logDebug("browser page snapshot write failed scope=%q status=%s url=%q error=%v", scope, status, requestedURL, err)
+		return
+	}
+	logDebug(
+		"browser page snapshot saved scope=%q status=%s url=%q metadata=%q html_chars=%d text_chars=%d links=%d capture_errors=%d",
+		scope,
+		status,
+		requestedURL,
+		metaPath,
+		len(html),
+		len(text),
+		len(links),
+		len(metadata.CaptureErrors),
+	)
+}
+
+func extractDebugPageLinks(elements rod.Elements, baseRawURL string) []pageLink {
+	baseURL, err := url.Parse(baseRawURL)
+	if err != nil {
+		baseURL = nil
+	}
+	rawLinks := make([]pageLink, 0, len(elements))
+	for _, element := range elements {
+		text, err := element.Text()
+		if err != nil {
+			text = ""
+		}
+		href, err := element.Attribute("href")
+		if err != nil || href == nil || strings.TrimSpace(*href) == "" {
+			continue
+		}
+		resolved := strings.TrimSpace(*href)
+		if baseURL != nil {
+			if parsed, err := baseURL.Parse(resolved); err == nil {
+				resolved = parsed.String()
+			}
+		}
+		resolved = decodeSearchResultURL(resolved)
+		if resolved == "" {
+			continue
+		}
+		rawLinks = append(rawLinks, pageLink{
+			Text: NormalizeWhitespace(text),
+			URL:  resolved,
+		})
+	}
+	return dedupePageLinks(rawLinks)
+}
+
+func debugBrowserPageArtifactPrefix(debugPath string, requestedURL string, status string) string {
+	dir := debugBrowserPageArtifactDir(debugPath)
+	host := "page"
+	if parsed, err := url.Parse(requestedURL); err == nil && parsed.Hostname() != "" {
+		host = parsed.Hostname()
+	}
+	sum := sha1.Sum([]byte(requestedURL))
+	hash := hex.EncodeToString(sum[:])[:10]
+	name := fmt.Sprintf(
+		"%s-%s-%s-%s",
+		time.Now().UTC().Format("20060102T150405.000000000Z"),
+		status,
+		debugFilenamePart(host),
+		hash,
+	)
+	return filepath.Join(dir, name)
+}
+
+func debugBrowserPageArtifactDir(debugPath string) string {
+	debugPath = strings.TrimSpace(debugPath)
+	if debugPath == "" {
+		debugPath = "debug.log"
+	}
+	base := filepath.Base(debugPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	if name == "" || name == "." {
+		name = "debug"
+	}
+	return filepath.Join(filepath.Dir(debugPath), name+"-pages")
+}
+
+func debugFilenamePart(value string) string {
+	value = strings.Trim(debugFilenameUnsafePattern.ReplaceAllString(value, "-"), "-")
+	if value == "" {
+		return "page"
+	}
+	if len(value) > 80 {
+		return value[:80]
+	}
+	return value
+}
+
+func writeDebugArtifact(path string, content []byte) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/fetcher/builtin_listing_test.go
+++ b/internal/fetcher/builtin_listing_test.go
@@ -123,7 +123,7 @@ func TestParseBuiltInSiteSearchHTMLRecordsExistingListingCard(t *testing.T) {
 		ApplyURL: "https://builtin.com/job/staff-devops-engineer/7934986",
 	}})
 
-	jobs, filtered, handled, err := parseBuiltInSiteSearchHTML(context.Background(), rawHTML, "https://builtin.com/jobs/remote?search=staff", "Site Search: Built In", criteria, nil, nil, existing)
+	jobs, filtered, handled, err := parseBuiltInSiteSearchHTML(context.Background(), rawHTML, "https://builtin.com/jobs/remote?search=staff", "Site Search: Built In", "https://builtin.com/jobs/remote", criteria, nil, nil, existing, nil)
 
 	if err != nil {
 		t.Fatalf("parseBuiltInSiteSearchHTML() error = %v, want nil", err)
@@ -159,25 +159,6 @@ func TestBuiltInCompanyProfileURLFromJobUsesCardEvidence(t *testing.T) {
 	got := builtInCompanyProfileURLFromJob(job)
 	if got != "https://builtin.com/company/cadence-care" {
 		t.Fatalf("builtInCompanyProfileURLFromJob() = %q; want canonical Built In company profile URL", got)
-	}
-}
-
-func TestBuiltInCompanyProfileURLFromJobRejectsNonBuiltInJob(t *testing.T) {
-	job := Job{
-		Company:  "Cadence",
-		Title:    "Staff DevOps Engineer",
-		ApplyURL: "https://example.com/jobs/7934986",
-		CompanyIdentity: &domain.JobIdentityMetadata{
-			Industry: &JobIdentityEvidence{
-				Value:  "Healthtech",
-				Source: "builtin_card_industry",
-				URL:    "https://builtin.com/company/cadence-care",
-			},
-		},
-	}
-
-	if got := builtInCompanyProfileURLFromJob(job); got != "" {
-		t.Fatalf("builtInCompanyProfileURLFromJob() = %q; want empty for non-Built In job", got)
 	}
 }
 

--- a/internal/fetcher/company_health_browser.go
+++ b/internal/fetcher/company_health_browser.go
@@ -364,9 +364,6 @@ func discoverBrowserPublicProfileFacts(ctx context.Context, browser *rod.Browser
 		candidates := publicProfileIndustryCandidates(job, links, pageText)
 		profileFetches := 0
 		for _, candidate := range candidates {
-			if addCompanyPublicProfileEvidence(&profiles, seen, companyPublicProfileEvidenceFromText(candidate.Source, candidate.URL, candidate.Title, candidate.Snippet)) && len(profiles) >= 3 {
-				return profiles
-			}
 			if profileFetches >= 2 {
 				continue
 			}
@@ -548,8 +545,7 @@ func extractBrowserPageContent(ctx context.Context, browser *rod.Browser, pageUR
 		}
 
 		withReusableBrowserPage(ctx, browser, timeout, pageURL, func(page *rod.Page) {
-			page.MustWaitLoad()
-			time.Sleep(companyHealthBrowserSettleDelay)
+			waitBrowserPageReady(page, companyHealthBrowserSettleDelay)
 
 			info := page.MustInfo()
 			baseURL, err := url.Parse(info.URL)
@@ -611,13 +607,134 @@ func withReusableBrowserPage(ctx context.Context, browser *rod.Browser, timeout 
 	if slot.page == nil {
 		slot.page = browser.MustPage()
 	}
-	page := slot.page.Timeout(timeout)
-	defer page.CancelTimeout()
+	started := time.Now()
+	err = rod.Try(func() {
+		page := slot.page.Timeout(timeout)
+		defer page.CancelTimeout()
 
-	wait := page.MustWaitNavigation()
-	page.MustNavigate(pageURL)
-	wait()
-	fn(page)
+		page.MustNavigate("about:blank")
+		wait := page.MustWaitNavigation()
+		page.MustNavigate(pageURL)
+		if err := rod.Try(func() { wait() }); err != nil {
+			page = slot.page.Timeout(timeout)
+			defer page.CancelTimeout()
+			if !browserPageBodyAvailable(page) {
+				panic(err)
+			}
+			logDebug("browser navigation wait incomplete url=%q error=%v; using current DOM", pageURL, SimplifySiteSearchError(err))
+		}
+		if dismissed := dismissBrowserPageInterruptions(page); dismissed > 0 {
+			logDebug("browser page interruptions dismissed url=%q count=%d", pageURL, dismissed)
+		}
+		fn(page)
+	})
+	captureBrowserPageDebugSnapshot(slot.page, pageURL, "browser_page", time.Since(started), err)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func waitBrowserPageReady(page *rod.Page, settleDelay time.Duration) {
+	if page == nil {
+		return
+	}
+	waitPage := page.Timeout(3 * time.Second)
+	defer waitPage.CancelTimeout()
+	if err := rod.Try(func() { waitPage.MustWaitLoad() }); err != nil {
+		logDebug("browser page load wait incomplete: %v; using current DOM", SimplifySiteSearchError(err))
+	}
+	if settleDelay > 0 {
+		time.Sleep(settleDelay)
+	}
+	if dismissed := dismissBrowserPageInterruptions(page); dismissed > 0 {
+		logDebug("browser page interruptions dismissed after settle count=%d", dismissed)
+	}
+}
+
+func browserPageBodyAvailable(page *rod.Page) bool {
+	if page == nil {
+		return false
+	}
+	return rod.Try(func() {
+		shortPage := page.Timeout(2 * time.Second)
+		defer shortPage.CancelTimeout()
+		info := shortPage.MustInfo()
+		if info == nil || strings.TrimSpace(info.URL) == "" || strings.EqualFold(strings.TrimSpace(info.URL), "about:blank") {
+			panic("no navigated page")
+		}
+		shortPage.MustElement("body")
+	}) == nil
+}
+
+func dismissBrowserPageInterruptions(page *rod.Page) int {
+	if page == nil {
+		return 0
+	}
+	dismissed := 0
+	if err := rod.Try(func() {
+		res, err := page.Eval(`() => {
+			const normalize = (value) => (value || "").replace(/\s+/g, " ").trim().toLowerCase();
+			const visible = (el) => {
+				if (!el || !el.isConnected) return false;
+				const style = window.getComputedStyle(el);
+				if (style.display === "none" || style.visibility === "hidden" || style.pointerEvents === "none") return false;
+				const rect = el.getBoundingClientRect();
+				return rect.width > 0 && rect.height > 0;
+			};
+			const exactLabels = new Set([
+				"close",
+				"dismiss",
+				"not now",
+				"skip",
+				"maybe later",
+				"continue without signing in",
+				"continue without an account"
+			]);
+			const partialLabels = [
+				"close dialog",
+				"close modal",
+				"dismiss dialog",
+				"dismiss modal"
+			];
+			const selectors = [
+				"button",
+				"[role='button']",
+				"a[aria-label]",
+				"[aria-label]",
+				"[title]",
+				"[data-testid*='close' i]",
+				"[data-test*='close' i]"
+			];
+			const seen = new Set();
+			let dismissed = 0;
+			for (const el of Array.from(document.querySelectorAll(selectors.join(",")))) {
+				if (seen.has(el) || !visible(el)) continue;
+				seen.add(el);
+				const label = normalize(
+					el.innerText ||
+					el.textContent ||
+					el.getAttribute("aria-label") ||
+					el.getAttribute("title") ||
+					el.getAttribute("data-testid") ||
+					el.getAttribute("data-test")
+				);
+				if (!label) continue;
+				if (!exactLabels.has(label) && !partialLabels.some((partial) => label.includes(partial))) continue;
+				el.click();
+				dismissed++;
+			}
+			return dismissed;
+		}`)
+		if err != nil {
+			panic(err)
+		}
+		if res != nil {
+			dismissed = res.Value.Int()
+		}
+	}); err != nil {
+		logDebug("browser page interruption dismissal skipped: %v", SimplifySiteSearchError(err))
+	}
+	return dismissed
 }
 
 func reusableBrowserPagePoolFor(browser *rod.Browser) *reusableBrowserPagePool {

--- a/internal/fetcher/company_health_browser_test.go
+++ b/internal/fetcher/company_health_browser_test.go
@@ -2,7 +2,6 @@ package fetcher
 
 import (
 	"context"
-	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -50,21 +49,6 @@ func TestCanonicalCompanySiteURLReturnsHostRoot(t *testing.T) {
 	raw := "https://www.example.com/about?x=1"
 	if got, want := canonicalCompanySiteURL(raw), "https://www.example.com/"; got != want {
 		t.Fatalf("canonicalCompanySiteURL(%q) = %q; want %q", raw, got, want)
-	}
-}
-
-func TestScoreCompanyAboutLinkRejectsExternalHosts(t *testing.T) {
-	baseURL, err := url.Parse("https://example.com/")
-	if err != nil {
-		t.Fatalf("url.Parse(%q): %v", "https://example.com/", err)
-	}
-
-	link := pageLink{
-		Text: "About Example",
-		URL:  "https://other.example.org/about",
-	}
-	if got := scoreCompanyAboutLink(baseURL, link); got != 0 {
-		t.Fatalf("scoreCompanyAboutLink(%q, %v) = %d; want 0 for external host", baseURL.String(), link, got)
 	}
 }
 

--- a/internal/fetcher/company_identity_extract.go
+++ b/internal/fetcher/company_identity_extract.go
@@ -170,9 +170,9 @@ func enrichJobFromHTML(job *Job, rawHTML string, pageURL string) {
 	} else {
 		setJobCompanyIfMissing(job, companyNameFromSummary(job.CompanySummary))
 	}
-	if explicitIndustry := extractExplicitCompanyIndustryFromHTML(rawHTML); explicitIndustry != "" && jobCompanyIndustryNeedsEnrichment(*job) {
+	if explicitIndustry, reason := extractApplyPageCompanyIndustryFromHTML(rawHTML, pageURL, job.Company); explicitIndustry != "" && jobCompanyIndustryNeedsEnrichment(*job) {
 		job.CompanyIndustry = explicitIndustry
-		setJobIdentityEvidence(job, "industry", explicitIndustry, "apply_page", pageURL, "medium", false, "Industry came from an explicit page label.")
+		setJobIdentityEvidence(job, "industry", explicitIndustry, "apply_page", pageURL, "medium", false, reason)
 	} else if summaryIndustry := inferCompanyIndustry(job.CompanySummary); summaryIndustry != "" && jobCompanyIndustryNeedsEnrichment(*job) {
 		job.CompanyIndustry = summaryIndustry
 		setJobIdentityEvidence(job, "industry", summaryIndustry, "company_summary_inference", pageURL, "low", true, "Industry inferred from company summary text.")
@@ -220,6 +220,77 @@ func jobHasSourceCompanyProfile(applyURL string) bool {
 	}
 	host := strings.ToLower(parsed.Host)
 	return strings.Contains(host, "weworkremotely.com") || strings.Contains(host, "realworkfromanywhere.com")
+}
+
+func extractApplyPageCompanyIndustryFromHTML(rawHTML string, pageURL string, company string) (string, string) {
+	if industry := extractExplicitCompanyIndustryFromHTML(rawHTML); industry != "" {
+		return industry, "Industry came from an explicit page label."
+	}
+	if isLinkedInJobURL(pageURL) {
+		if industry := extractLinkedInJobAboutCompanyIndustry(rawHTML, company); industry != "" {
+			return industry, "Industry extracted from LinkedIn About the company section."
+		}
+	}
+	return "", ""
+}
+
+func extractLinkedInJobAboutCompanyIndustry(rawHTML string, company string) string {
+	aboutText := extractLinkedInJobAboutCompanyText(rawHTML)
+	if aboutText == "" {
+		return ""
+	}
+	if industry := extractPublicProfileIndustryFromText(aboutText); industry != "" {
+		return industry
+	}
+
+	employeeMarker := `(?:[0-9][0-9,.k+\s]*(?:(?:-|–|—|to)\s*[0-9][0-9,.k+\s]*)?\s*employees?|Company size|Headquarters)`
+	patterns := make([]*regexp.Regexp, 0, 3)
+	if normalizedCompany := NormalizeWhitespace(company); normalizedCompany != "" {
+		patterns = append(patterns, regexp.MustCompile(`(?i)\b`+regexp.QuoteMeta(normalizedCompany)+`\b\s+(?:[0-9][0-9,]*\s+followers\s+)?([A-Za-z][A-Za-z0-9 &,/+\-]{2,80}?)\s+`+employeeMarker))
+	}
+	patterns = append(patterns,
+		regexp.MustCompile(`(?i)\bfollowers\s+([A-Za-z][A-Za-z0-9 &,/+\-]{2,80}?)\s+`+employeeMarker),
+	)
+
+	for _, pattern := range patterns {
+		match := pattern.FindStringSubmatch(aboutText)
+		if len(match) < 2 {
+			continue
+		}
+		industry := cleanPublicProfileIndustry(match[1])
+		if looksLikeCompanyIndustry(industry) {
+			return industry
+		}
+	}
+	return ""
+}
+
+func extractLinkedInJobAboutCompanyText(rawHTML string) string {
+	text := normalizeHTMLText(rawHTML)
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	index := strings.Index(lower, "about the company")
+	if index < 0 {
+		return ""
+	}
+	text = strings.TrimSpace(text[index:])
+	lower = strings.ToLower(text)
+	for _, stop := range []string{
+		" similar jobs",
+		" see all jobs",
+		" show more jobs",
+		" job function",
+		" seniority level",
+		" employment type",
+	} {
+		if stopIndex := strings.Index(lower, stop); stopIndex > 0 {
+			text = strings.TrimSpace(text[:stopIndex])
+			break
+		}
+	}
+	return text
 }
 
 func inferCompanyWebsiteFromApplyURL(job Job) string {
@@ -423,7 +494,10 @@ func looksLikeCompanyIndustry(industry string) bool {
 	}
 	lower := strings.ToLower(industry)
 	switch strings.Trim(lower, " .,;:") {
-	case "alt", "before", "building a path to compliance 3", "carousel", "icon-30x30", "link", "member trust", "wide":
+	case "alt", "before", "building a path to compliance 3", "carousel", "icon-30x30", "job", "jobs", "job search", "link", "member trust", "search", "wide":
+		return false
+	}
+	if regexp.MustCompile(`\bsearch\b`).MatchString(lower) {
 		return false
 	}
 	for _, token := range []string{
@@ -443,7 +517,6 @@ func looksLikeCompanyIndustry(industry string) bool {
 		"standard security",
 		"remote united states",
 		"salary",
-		"search",
 		"west coast",
 	} {
 		if strings.Contains(lower, token) {

--- a/internal/fetcher/company_profile_extract.go
+++ b/internal/fetcher/company_profile_extract.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func extractSourceCompanyProfileURL(rawHTML string, pageURL string) string {
@@ -28,6 +30,10 @@ func extractSourceCompanyProfileURL(rawHTML string, pageURL string) string {
 			return resolved
 		case isBuiltInHost(host) && strings.EqualFold(parsed.Host, page.Host) && strings.HasPrefix(path, "/company/"):
 			return resolved
+		case isLinkedInHost(host) && strings.EqualFold(parsed.Host, page.Host) && strings.HasPrefix(path, "/company/"):
+			parsed.RawQuery = ""
+			parsed.Fragment = ""
+			return parsed.String()
 		}
 	}
 	return ""
@@ -61,6 +67,13 @@ func applyCompanyProfileMetadata(job *Job, rawHTML string, profileURL string) {
 	}
 	text := normalizeHTMLText(rawHTML)
 	evidence := companyPublicProfileEvidenceFromText("builtin", profileURL, "", text)
+	applyCompanyPublicProfileEvidence(job, evidence, "company_profile")
+}
+
+func applyCompanyPublicProfileEvidence(job *Job, evidence domain.CompanyPublicProfile, source string) {
+	if job == nil {
+		return
+	}
 	if !companyPublicProfileEvidenceUseful(evidence) && strings.TrimSpace(job.CompanyIndustry) == "" {
 		return
 	}
@@ -88,6 +101,10 @@ func applyCompanyProfileMetadata(job *Job, rawHTML string, profileURL string) {
 	}
 	if strings.TrimSpace(evidence.Industry) != "" {
 		job.EnsureSourceMetadata().Industries = appendUniqueString(job.EnsureSourceMetadata().Industries, evidence.Industry)
+		if jobCompanyIndustryNeedsEnrichment(*job) {
+			job.CompanyIndustry = evidence.Industry
+			setJobIdentityEvidence(job, "industry", evidence.Industry, source, evidence.URL, "medium", false, "Industry extracted from public company profile evidence.")
+		}
 	}
 }
 
@@ -116,6 +133,53 @@ func extractCompanyWebsiteFromHTML(rawHTML string, applyURL string, company stri
 		}
 	}
 	return ""
+}
+
+func companyWebsiteFromProfileLinks(links []pageLink, profileURL string, company string) string {
+	best := ""
+	bestScore := 0
+	for _, link := range links {
+		website := companyWebsiteFromExternalApplyURL(link.URL, profileURL, company)
+		if website == "" {
+			continue
+		}
+		score := scoreCompanyProfileWebsiteLink(link, website)
+		if score > bestScore {
+			bestScore = score
+			best = website
+		}
+	}
+	if bestScore <= 0 {
+		return ""
+	}
+	return best
+}
+
+func scoreCompanyProfileWebsiteLink(link pageLink, website string) int {
+	parsed, err := url.Parse(website)
+	if err != nil || parsed.Host == "" {
+		return 0
+	}
+	if source := publicProfileSource(link.URL); source != "" {
+		return 0
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if isIndeedHost(host) || isLinkedInHost(host) || isGoogleHost(host) || isBuiltInHost(host) {
+		return 0
+	}
+
+	score := 1
+	textLower := strings.ToLower(link.Text)
+	urlLower := strings.ToLower(link.URL)
+	for _, marker := range []string{"website", "company site", "home page", "visit", "official"} {
+		if strings.Contains(textLower, marker) {
+			score += 3
+		}
+	}
+	if strings.Contains(urlLower, "utm_source=indeed") || strings.Contains(urlLower, "linkedin") {
+		score++
+	}
+	return score
 }
 
 func extractStructuredCompanyWebsite(rawHTML string) string {
@@ -253,11 +317,16 @@ func cleanCompanyProfileSummary(summary string, company string) string {
 
 func extractLabeledHref(rawHTML string, applyURL string, labels []string) string {
 	for _, href := range extractHTMLHrefs(rawHTML) {
-		if !looksLikeCompanyWebsite(href, applyURL) {
+		candidate := decodeProfileExternalLink(resolveURL(applyURL, href))
+		if !looksLikeCompanyWebsite(candidate, applyURL) {
 			continue
 		}
 		needle := strings.ToLower(href)
 		idx := strings.Index(strings.ToLower(rawHTML), needle)
+		if idx < 0 {
+			needle = strings.ToLower(candidate)
+			idx = strings.Index(strings.ToLower(rawHTML), needle)
+		}
 		if idx < 0 {
 			continue
 		}
@@ -272,9 +341,40 @@ func extractLabeledHref(rawHTML string, applyURL string, labels []string) string
 		contextText := strings.ToLower(normalizeHTMLText(rawHTML[start:end]))
 		for _, label := range labels {
 			if strings.Contains(contextText, strings.ToLower(label)) {
-				return href
+				return candidate
 			}
 		}
 	}
 	return ""
+}
+
+func decodeProfileExternalLink(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return rawURL
+	}
+	if isLinkedInHost(parsed.Hostname()) {
+		for _, key := range []string{"url", "target", "redirectUrl"} {
+			target := strings.TrimSpace(parsed.Query().Get(key))
+			if target == "" {
+				continue
+			}
+			decoded, err := url.QueryUnescape(target)
+			if err == nil {
+				target = decoded
+			}
+			targetParsed, err := url.Parse(target)
+			if err == nil && targetParsed.Scheme != "" && targetParsed.Host != "" {
+				return targetParsed.String()
+			}
+		}
+	}
+	if decoded := decodeSearchResultURL(rawURL); decoded != "" {
+		return decoded
+	}
+	return rawURL
 }

--- a/internal/fetcher/debug.go
+++ b/internal/fetcher/debug.go
@@ -65,3 +65,14 @@ func logDebug(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	_, _ = fmt.Fprintf(file, "%s fetcher: %s\n", time.Now().Format(time.RFC3339), message)
 }
+
+func debugSettings() (bool, string) {
+	fetcherDebug.Lock()
+	defer fetcherDebug.Unlock()
+
+	path := strings.TrimSpace(fetcherDebug.path)
+	if path == "" {
+		path = "debug.log"
+	}
+	return fetcherDebug.enabled, path
+}

--- a/internal/fetcher/fetch_policy.go
+++ b/internal/fetcher/fetch_policy.go
@@ -1,0 +1,126 @@
+package fetcher
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+type fetchPolicy struct {
+	CandidateLimitPerSource int
+	AcceptedLimit           int
+}
+
+func fetchPolicyFromConfig(cfg *AppConfig) fetchPolicy {
+	if cfg == nil {
+		return fetchPolicy{}
+	}
+	return fetchPolicy{
+		CandidateLimitPerSource: nonNegativeInt(cfg.Fetch.CandidateLimitPerSource),
+		AcceptedLimit:           nonNegativeInt(cfg.Fetch.AcceptedLimit),
+	}
+}
+
+func nonNegativeInt(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func randomizeResolvedSources(sources *ResolvedSourceSet) {
+	if sources == nil {
+		return
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Shuffle(len(sources.RSSFeeds), func(i, j int) {
+		sources.RSSFeeds[i], sources.RSSFeeds[j] = sources.RSSFeeds[j], sources.RSSFeeds[i]
+	})
+	r.Shuffle(len(sources.APISources), func(i, j int) {
+		sources.APISources[i], sources.APISources[j] = sources.APISources[j], sources.APISources[i]
+	})
+	r.Shuffle(len(sources.SiteTargets), func(i, j int) {
+		sources.SiteTargets[i], sources.SiteTargets[j] = sources.SiteTargets[j], sources.SiteTargets[i]
+	})
+	r.Shuffle(len(sources.LLMWebTargets), func(i, j int) {
+		sources.LLMWebTargets[i], sources.LLMWebTargets[j] = sources.LLMWebTargets[j], sources.LLMWebTargets[i]
+	})
+}
+
+type siteCandidateLimiter struct {
+	limit int
+	mu    sync.Mutex
+	used  map[string]int
+}
+
+func newSiteCandidateLimiter(limit int) *siteCandidateLimiter {
+	if limit <= 0 {
+		return nil
+	}
+	return &siteCandidateLimiter{
+		limit: limit,
+		used:  make(map[string]int),
+	}
+}
+
+func (l *siteCandidateLimiter) exhausted(source string) bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.used[siteCandidateLimitKey(source)] >= l.limit
+}
+
+func (l *siteCandidateLimiter) take(source string, candidates []siteSearchCandidate) ([]siteSearchCandidate, int) {
+	if l == nil || len(candidates) == 0 {
+		return candidates, 0
+	}
+	kept := l.takeCount(source, len(candidates))
+	if kept >= len(candidates) {
+		return candidates, 0
+	}
+	return candidates[:kept], len(candidates) - kept
+}
+
+func (l *siteCandidateLimiter) takeCount(source string, count int) int {
+	if l == nil || count <= 0 {
+		return count
+	}
+	key := siteCandidateLimitKey(source)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	remaining := l.limit - l.used[key]
+	if remaining <= 0 {
+		return 0
+	}
+	if count <= remaining {
+		l.used[key] += count
+		return count
+	}
+	l.used[key] += remaining
+	return remaining
+}
+
+func siteCandidateLimitKey(source string) string {
+	return strings.ToLower(strings.TrimSpace(source))
+}
+
+func capAcceptedFetchedJobs(jobs []Job, limit int, summary *FetchSummary) []Job {
+	if limit <= 0 || len(jobs) <= limit {
+		return jobs
+	}
+	kept := jobs[:limit]
+	omitted := append([]Job(nil), jobs[limit:]...)
+	if summary != nil {
+		if summary.Filtered == nil {
+			summary.Filtered = make(map[string][]Job)
+		}
+		summary.Filtered["accepted limit reached"] = append(summary.Filtered["accepted limit reached"], omitted...)
+		appendFetchNotice(summary, "Accepted result limit reached; additional matching jobs were omitted from this fetch.")
+	}
+	logDebug("fetch policy: accepted result limit kept=%d omitted=%d", len(kept), len(omitted))
+	return kept
+}

--- a/internal/fetcher/fetch_policy_test.go
+++ b/internal/fetcher/fetch_policy_test.go
@@ -1,0 +1,40 @@
+package fetcher
+
+import "testing"
+
+func TestSiteCandidateLimiterCapsCandidatesPerSource(t *testing.T) {
+	limiter := newSiteCandidateLimiter(3)
+	first, skipped := limiter.take("https://www.indeed.com/jobs", []siteSearchCandidate{
+		{Title: "One"},
+		{Title: "Two"},
+	})
+	if len(first) != 2 || skipped != 0 {
+		t.Fatalf("first take len=%d skipped=%d; want len=2 skipped=0", len(first), skipped)
+	}
+
+	second, skipped := limiter.take("https://www.indeed.com/jobs", []siteSearchCandidate{
+		{Title: "Three"},
+		{Title: "Four"},
+		{Title: "Five"},
+	})
+	if len(second) != 1 || skipped != 2 {
+		t.Fatalf("second take len=%d skipped=%d; want len=1 skipped=2", len(second), skipped)
+	}
+}
+
+func TestCapAcceptedFetchedJobsKeepsConfiguredLimit(t *testing.T) {
+	summary := newFetchSummary()
+	jobs := []Job{
+		{Company: "One", Title: "Engineer"},
+		{Company: "Two", Title: "Engineer"},
+		{Company: "Three", Title: "Engineer"},
+	}
+
+	got := capAcceptedFetchedJobs(jobs, 2, &summary)
+	if len(got) != 2 {
+		t.Fatalf("capAcceptedFetchedJobs len = %d; want 2", len(got))
+	}
+	if got := len(summary.Filtered["accepted limit reached"]); got != 1 {
+		t.Fatalf("accepted limit filtered count = %d; want 1", got)
+	}
+}

--- a/internal/fetcher/job_fetcher.go
+++ b/internal/fetcher/job_fetcher.go
@@ -47,6 +47,7 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 	if err := refreshLinkedInCriteriaHints(ctx, criteriaCfg); err != nil {
 		logDebug("linkedin criteria hint refresh failed: %v", err)
 	}
+	policy := fetchPolicyFromConfig(appCfg)
 	urlVisits := beginURLVisitRun()
 	sourceProfiles := beginSourceProfileRun()
 	defer func() {
@@ -54,6 +55,7 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 		logDebug("url visit registry summary: fetches=%d hits=%d html_entries=%d probe_entries=%d", fetches, hits, htmlEntries, probeEntries)
 	}()
 	effectiveSources := resolveEffectiveSources(appCfg, criteriaCfg)
+	randomizeResolvedSources(&effectiveSources)
 	logDebug(
 		"fetch start: llm_enabled=%t llm_job_search=%t llm_job_filtering=%t llm_company_health=%t sources_enabled=%t rss_enabled=%t rss_feeds=%d api_sources=%d site_enabled=%t site_targets=%d llm_web_enabled=%t llm_web_targets=%d",
 		appCfg.LLM.Enabled,
@@ -74,6 +76,11 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 	logDebug("source resolution: api=%s", debugAPISources(effectiveSources.APISources))
 	logDebug("source resolution: site_targets=%s", debugStringList(effectiveSources.SiteTargets))
 	logDebug("source resolution: llm_web_targets=%s", debugStringList(effectiveSources.LLMWebTargets))
+	logDebug(
+		"fetch policy: candidate_limit_per_source=%d accepted_limit=%d randomize_sources=true",
+		policy.CandidateLimitPerSource,
+		policy.AcceptedLimit,
+	)
 
 	var mu sync.Mutex
 
@@ -104,6 +111,8 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 						mu.Unlock()
 					} else {
 						var dropped map[string][]string
+						markLLMJobsForValidation(jobs)
+						jobs = enrichLLMJobsBeforeValidation(ctx, appCfg, jobs, progress)
 						jobs, dropped = validateFetchedJobs(ctx, jobs)
 						mu.Lock()
 						summary.Rejected = mergeRejectedBySearch(summary.Rejected, fetchSearchLLM, dropped)
@@ -405,17 +414,19 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 			builtInDetails := newBuiltInDetailCache()
 			builtInProfiles := sourceProfiles
 			blockedSiteSearches := newSiteSearchBlocklist()
+			blockedSiteDetails := newSiteSearchBlocklist()
+			candidateLimiter := newSiteCandidateLimiter(policy.CandidateLimitPerSource)
 			runBounded(ctx, len(tasks), maxConcurrentSiteSearchFetch, func(i int) {
 				task := tasks[i]
 				reportFetchProgress(progress, "Searching site target: %s", strings.TrimSpace(task.site))
-				results[i] = fetchSiteSearchTask(ctx, task, criteriaCfg, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches)
+				results[i] = fetchSiteSearchTask(ctx, task, criteriaCfg, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches, blockedSiteDetails, candidateLimiter)
 			})
 
 			for i, result := range results {
 				if result.err != nil {
 					if result.notice != "" {
 						mu.Lock()
-						summary.Notices = append(summary.Notices, result.notice)
+						appendFetchNotice(&summary, result.notice)
 						mu.Unlock()
 					}
 					siteErrors++
@@ -427,6 +438,7 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 				mu.Lock()
 				summary.Filtered = mergeFiltered(summary.Filtered, result.filtered)
 				summary.Rejected = mergeRejectedBySearch(summary.Rejected, fetchSearchSite, result.dropped)
+				appendFetchNotice(&summary, result.notice)
 				siteCount += len(result.jobs)
 				siteFiltered += countFilteredJobs(result.filtered)
 				siteRejected += countRejectedJobs(result.dropped)
@@ -473,6 +485,8 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 		logDebug("fetch finalization: deduped %d duplicate fetched jobs before review/LLM filtering", len(duplicates))
 	}
 
+	allFetched = capAcceptedFetchedJobs(allFetched, policy.AcceptedLimit, &summary)
+
 	return allFetched, summary, nil
 }
 
@@ -497,6 +511,19 @@ func markLLMWebJobsForValidation(jobs []Job) {
 	}
 }
 
+func markLLMJobsForValidation(jobs []Job) {
+	for i := range jobs {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(jobs[i].Source)), strings.ToLower(fetchSearchLLM)+":") {
+			continue
+		}
+		source := strings.TrimSpace(jobs[i].Source)
+		if source == "" {
+			source = "llm_job_search"
+		}
+		jobs[i].Source = formatSearchSource(fetchSearchLLM, source)
+	}
+}
+
 func filterLLMWebJobsBeforeEnrichment(jobs []Job, criteria *CriteriaConfig) ([]Job, map[string][]Job) {
 	if len(jobs) == 0 {
 		return jobs, nil
@@ -518,7 +545,15 @@ func filterLLMWebJobsBeforeEnrichment(jobs []Job, criteria *CriteriaConfig) ([]J
 	return kept, filtered
 }
 
+func enrichLLMJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jobs []Job, progress func(string)) []Job {
+	return enrichLLMGeneratedJobsBeforeValidation(ctx, appCfg, jobs, progress, "llm job search")
+}
+
 func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jobs []Job, progress func(string)) []Job {
+	return enrichLLMGeneratedJobsBeforeValidation(ctx, appCfg, jobs, progress, "llm web search")
+}
+
+func enrichLLMGeneratedJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jobs []Job, progress func(string), label string) []Job {
 	if len(jobs) == 0 {
 		return jobs
 	}
@@ -526,7 +561,7 @@ func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jo
 	indexes := make([]int, 0, len(jobs))
 	candidates := make([]Job, 0, len(jobs))
 	for i, job := range jobs {
-		if !llmWebJobNeedsPreValidationIdentity(job) {
+		if !llmGeneratedJobNeedsPreValidationIdentity(job) {
 			continue
 		}
 		indexes = append(indexes, i)
@@ -537,7 +572,7 @@ func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jo
 	}
 
 	start := time.Now()
-	logDebug("llm web search: repairing identity for %d/%d jobs before validation", len(candidates), len(jobs))
+	logDebug("%s: repairing identity for %d/%d jobs before validation", label, len(candidates), len(jobs))
 	enriched := enrichJobsFromApplyPagesForValidation(ctx, candidates, progress)
 	repaired := 0
 	fallbackIndexes := make([]int, 0, len(enriched))
@@ -551,7 +586,8 @@ func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jo
 		fallbackCandidates = append(fallbackCandidates, job)
 	}
 	logDebug(
-		"llm web search: fast identity repair checked %d jobs; repaired=%d fallback=%d duration=%s",
+		"%s: fast identity repair checked %d jobs; repaired=%d fallback=%d duration=%s",
+		label,
 		len(enriched),
 		repaired,
 		len(fallbackCandidates),
@@ -560,12 +596,12 @@ func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jo
 
 	if len(fallbackCandidates) > 0 {
 		fallbackStart := time.Now()
-		logDebug("llm web search: running full identity enrichment fallback for %d jobs", len(fallbackCandidates))
+		logDebug("%s: running full identity enrichment fallback for %d jobs", label, len(fallbackCandidates))
 		fallbackEnriched := EnrichJobsFromApplyPagesWithConfigAndProgress(ctx, fallbackCandidates, appCfg, progress, nil)
 		for i, idx := range fallbackIndexes {
 			enriched[idx] = fallbackEnriched[i]
 		}
-		logDebug("llm web search: full identity enrichment fallback finished in %s", time.Since(fallbackStart).Round(time.Millisecond))
+		logDebug("%s: full identity enrichment fallback finished in %s", label, time.Since(fallbackStart).Round(time.Millisecond))
 	}
 
 	for i, idx := range indexes {
@@ -574,7 +610,7 @@ func enrichLLMWebJobsBeforeValidation(ctx context.Context, appCfg *AppConfig, jo
 	return jobs
 }
 
-func llmWebJobNeedsPreValidationIdentity(job Job) bool {
+func llmGeneratedJobNeedsPreValidationIdentity(job Job) bool {
 	if !isLLMGeneratedJob(job) {
 		return false
 	}
@@ -671,18 +707,23 @@ func normalizedSiteSearchHost(rawURL string) string {
 	return strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www.")
 }
 
-func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *CriteriaConfig, ensureBrowser func() (*rod.Browser, error), browserSem chan struct{}, builtInDetails *builtInDetailCache, builtInProfiles *sourceProfileEnricher, existing *existingJobIndex, blocked *siteSearchBlocklist) sourceFetchResult {
+func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *CriteriaConfig, ensureBrowser func() (*rod.Browser, error), browserSem chan struct{}, builtInDetails *builtInDetailCache, builtInProfiles *sourceProfileEnricher, existing *existingJobIndex, blocked *siteSearchBlocklist, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter) sourceFetchResult {
 	var jobs []Job
 	var filtered map[string][]Job
 	var err error
+	var detailNotice string
 	handled := false
 	logDebug("site search %s query %d/%d: target URL %s", task.site, task.queryIndex+1, task.queryCount, task.targetURL)
 	if reason := blocked.reasonFor(task.targetURL); reason != "" {
 		logDebug("site search %s query %d/%d: skipped because host was blocked earlier in this fetch: %s", task.site, task.queryIndex+1, task.queryCount, reason)
 		return sourceFetchResult{}
 	}
+	if candidateLimiter.exhausted(task.site) {
+		logDebug("site search %s query %d/%d: skipped because candidate limit is exhausted", task.site, task.queryIndex+1, task.queryCount)
+		return sourceFetchResult{}
+	}
 	logDebug("site search %s query %d/%d: trying static handler", task.site, task.queryIndex+1, task.queryCount)
-	jobs, filtered, handled, err = fetchBuiltInSiteSearch(ctx, task.targetURL, task.sourceName, criteria, builtInDetails, builtInProfiles, existing)
+	jobs, filtered, handled, err = fetchBuiltInSiteSearch(ctx, task.targetURL, task.sourceName, task.site, criteria, builtInDetails, builtInProfiles, existing, candidateLimiter)
 	if handled {
 		logDebug("site search %s query %d/%d: static handler completed with %d accepted and %d filtered", task.site, task.queryIndex+1, task.queryCount, len(jobs), countFilteredJobs(filtered))
 	} else if err != nil {
@@ -691,6 +732,10 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 		logDebug("site search %s query %d/%d: static handler did not handle target", task.site, task.queryIndex+1, task.queryCount)
 	}
 	if !handled && err == nil {
+		if candidateLimiter.exhausted(task.site) {
+			logDebug("site search %s query %d/%d: skipped browser probe because candidate limit is exhausted", task.site, task.queryIndex+1, task.queryCount)
+			return sourceFetchResult{}
+		}
 		select {
 		case browserSem <- struct{}{}:
 			defer func() {
@@ -700,6 +745,10 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 			err = ctx.Err()
 		}
 		if err == nil {
+			if candidateLimiter.exhausted(task.site) {
+				logDebug("site search %s query %d/%d: skipped browser probe because candidate limit was exhausted while waiting", task.site, task.queryIndex+1, task.queryCount)
+				return sourceFetchResult{}
+			}
 			if reason := blocked.reasonFor(task.targetURL); reason != "" {
 				logDebug("site search %s query %d/%d: skipped browser probe because host was blocked while waiting: %s", task.site, task.queryIndex+1, task.queryCount, reason)
 				return sourceFetchResult{}
@@ -707,12 +756,15 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 			var browser *rod.Browser
 			browser, err = ensureBrowser()
 			if err == nil {
-				jobs, filtered, err = fetchGenericSiteSearch(ctx, browser, task.site, task.targetURL, task.sourceName, criteria)
+				jobs, filtered, detailNotice, err = fetchGenericSiteSearch(ctx, browser, task.site, task.targetURL, task.sourceName, criteria, detailBlocked, candidateLimiter)
+				if detailNotice != "" {
+					logDebug("site search %s query %d/%d: %s", task.site, task.queryIndex+1, task.queryCount, detailNotice)
+				}
 				if errors.Is(err, errSiteSearchVerificationRequired) {
 					if blocked.block(task.targetURL, err.Error()) {
 						logDebug("site search %s query %d/%d: blocked remaining searches for host after verification page: %v", task.site, task.queryIndex+1, task.queryCount, err)
 					}
-					return sourceFetchResult{}
+					return sourceFetchResult{err: err, notice: fmt.Sprintf("Search page blocked for %s: %v", task.site, err)}
 				}
 			}
 		}
@@ -732,7 +784,25 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 		filtered["already saved"] = append(filtered["already saved"], skippedExisting...)
 		logDebug("site search %s query %d/%d: skipped %d already saved jobs after validation", task.site, task.queryIndex+1, task.queryCount, len(skippedExisting))
 	}
-	return newSourceFetchResult(validated, filtered, dropped)
+	result := newSourceFetchResult(validated, filtered, dropped)
+	result.notice = detailNotice
+	return result
+}
+
+func appendFetchNotice(summary *FetchSummary, notice string) {
+	if summary == nil {
+		return
+	}
+	notice = strings.TrimSpace(notice)
+	if notice == "" {
+		return
+	}
+	for _, existing := range summary.Notices {
+		if existing == notice {
+			return
+		}
+	}
+	summary.Notices = append(summary.Notices, notice)
 }
 
 func runBounded(ctx context.Context, total int, limit int, work func(int)) {

--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -182,7 +182,7 @@ func TestValidateFetchedJobsRejectsLLMJobsWithoutCompanyIdentity(t *testing.T) {
 			Title:          "Platform Engineer",
 			ApplyURL:       okServer.URL,
 			Source:         "LLM: llm_job_search",
-			CompanyWebsite: "https://acme.example",
+			CompanyWebsite: "https://acme.com",
 			CompanySummary: "Acme builds deployment tooling for software teams.",
 		},
 		{
@@ -202,6 +202,25 @@ func TestValidateFetchedJobsRejectsLLMJobsWithoutCompanyIdentity(t *testing.T) {
 	}
 	if got := len(warnings["missing company identity"]); got != 2 {
 		t.Fatalf("missing company identity warnings = %d, want 2: %#v", got, warnings)
+	}
+}
+
+func TestValidateFetchedJobsRejectsPlaceholderURLs(t *testing.T) {
+	jobs := []Job{{
+		Company:        "Acme",
+		Title:          "Platform Engineer",
+		ApplyURL:       "https://jobs.acme.example/jobs/platform-engineer",
+		CompanyWebsite: "https://acme.example",
+		CompanySummary: "Acme builds deployment tooling for software teams.",
+	}}
+
+	filtered, warnings := validateFetchedJobs(context.Background(), jobs)
+
+	if len(filtered) != 0 {
+		t.Fatalf("validateFetchedJobs() kept %#v, want none", filtered)
+	}
+	if got := len(warnings["placeholder URL"]); got != 1 {
+		t.Fatalf("placeholder URL warnings = %d, want 1: %#v", got, warnings)
 	}
 }
 
@@ -427,7 +446,7 @@ func TestFetchAllJobsLLMWebUsesDedicatedRunner(t *testing.T) {
 			Company:        "Acme",
 			Title:          "Software Engineer",
 			ApplyURL:       applyServer.URL,
-			CompanyWebsite: "https://acme.example.com",
+			CompanyWebsite: "https://acme.com",
 			CompanySummary: "Acme builds developer productivity software for engineering teams that ship cloud applications.",
 			Source:         "provider web search",
 		}}, nil
@@ -546,6 +565,86 @@ func TestFetchAllJobsLLMWebRepairsIdentityBeforeValidation(t *testing.T) {
 	}
 	if status := summary.Searches[FetchSearchLLMWeb]; !strings.HasPrefix(status, "executed; found 1 results") {
 		t.Fatalf("summary.Searches[%q] = %q; want executed status", FetchSearchLLMWeb, status)
+	}
+}
+
+func TestFetchAllJobsLLMSearchRepairsIdentityBeforeValidation(t *testing.T) {
+	applyGETRequests := 0
+	applyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodGet {
+			return
+		}
+		applyGETRequests++
+		_, _ = w.Write([]byte(`
+<html>
+  <body>
+    <h1>Software Engineer</h1>
+    <p>Acme builds developer productivity software for engineering teams shipping cloud applications.</p>
+    <p>Industry: Developer Tools</p>
+    <a href="https://www.acme.com">Company website</a>
+  </body>
+</html>`))
+	}))
+	defer applyServer.Close()
+
+	prevInit := fetchAllJobsInitConfiguredLLM
+	prevSearch := fetchAllJobsExecuteLLMSearch
+	prevReadFile := fetchAllJobsReadFile
+	initTasks := []string(nil)
+	fetchAllJobsInitConfiguredLLM = func(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error) {
+		initTasks = append(initTasks, task)
+		return fakeLLMModel{}, func() {}, nil
+	}
+	fetchAllJobsExecuteLLMSearch = func(ctx context.Context, llm llms.Model, prompt string) ([]Job, error) {
+		return []Job{{
+			Company:  "Acme",
+			Title:    "Software Engineer",
+			ApplyURL: applyServer.URL,
+		}}, nil
+	}
+	fetchAllJobsReadFile = func(path string) ([]byte, error) {
+		return []byte("prompt"), nil
+	}
+	t.Cleanup(func() {
+		fetchAllJobsInitConfiguredLLM = prevInit
+		fetchAllJobsExecuteLLMSearch = prevSearch
+		fetchAllJobsReadFile = prevReadFile
+	})
+
+	appCfg := defaultAppConfig()
+	appCfg.LLM.Enabled = true
+	appCfg.LLM.JobSearch = true
+	appCfg.LLM.JobFiltering = false
+	appCfg.Sources.Enabled = false
+	appCfg.Sources.RSS.Enabled = false
+	appCfg.Sources.APIs = nil
+	appCfg.Sources.SiteSearch.Enabled = false
+	appCfg.Sources.SiteSearch.Sites = nil
+	appCfg.Sources.LLMWeb.Enabled = false
+	criteria := defaultCriteriaConfig()
+
+	jobs, summary, err := fetchAllJobs(context.Background(), &appCfg, &criteria, nil)
+	if err != nil {
+		t.Fatalf("fetchAllJobs() error = %v", err)
+	}
+	if got, want := len(jobs), 1; got != want {
+		t.Fatalf("fetchAllJobs() jobs len = %d, want %d; rejected=%#v", got, want, summary.Rejected)
+	}
+	if applyGETRequests == 0 {
+		t.Fatal("fetchAllJobs() did not fetch the apply page for llm_job_search identity repair")
+	}
+	if len(initTasks) != 1 || initTasks[0] != llmTaskJobSearch {
+		t.Fatalf("fetchAllJobs() initialized LLM tasks %#v, want only %q", initTasks, llmTaskJobSearch)
+	}
+	if got, want := jobs[0].CompanyWebsite, "https://www.acme.com"; got != want {
+		t.Fatalf("jobs[0].CompanyWebsite = %q, want %q", got, want)
+	}
+	if !strings.Contains(jobs[0].CompanySummary, "developer productivity software") {
+		t.Fatalf("jobs[0].CompanySummary = %q, want apply-page company summary", jobs[0].CompanySummary)
+	}
+	if got, want := jobs[0].CompanyIndustry, "Developer Tools"; got != want {
+		t.Fatalf("jobs[0].CompanyIndustry = %q, want %q", got, want)
 	}
 }
 
@@ -1387,6 +1486,12 @@ func TestExtractSourceCompanyProfileURL(t *testing.T) {
 			want:    "https://builtin.com/company/gusto",
 		},
 		{
+			name:    "linkedin",
+			pageURL: "https://www.linkedin.com/jobs/view/software-engineer-at-acme-123",
+			html:    `<a href="https://www.linkedin.com/company/acme/?trk=public_jobs_topcard-org-name">Acme</a>`,
+			want:    "https://www.linkedin.com/company/acme/",
+		},
+		{
 			name:    "ignore unrelated host",
 			pageURL: "https://example.com/jobs/123",
 			html:    `<a href="/company/example">View company</a>`,
@@ -1401,6 +1506,44 @@ func TestExtractSourceCompanyProfileURL(t *testing.T) {
 				t.Fatalf("extractSourceCompanyProfileURL(%q) = %q; want %q", tt.pageURL, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCompanyWebsiteFromProfileLinksUsesCompanyWebsiteLink(t *testing.T) {
+	links := []pageLink{{
+		Text: "Company website",
+		URL:  "https://app.dataannotation.tech/worker_signup?worker_src=I&utm_source=indeed",
+	}}
+
+	got := companyWebsiteFromProfileLinks(links, "https://www.indeed.com/cmp/DataAnnotation", "DataAnnotation")
+	want := "https://dataannotation.tech/"
+	if got != want {
+		t.Fatalf("companyWebsiteFromProfileLinks(...) = %q; want %q", got, want)
+	}
+}
+
+func TestEnrichJobFromCompanyProfileHTMLExtractsLinkedInWebsite(t *testing.T) {
+	job := Job{Company: "Kabilah"}
+	rawHTML := `
+<html><body>
+  <a href="https://static.licdn.com/sc/h/app.css">LinkedIn asset</a>
+  <section>
+    <h2>About us</h2>
+    <p>Every nurse needs a workflow sidekick.</p>
+    <div>Website</div>
+    <a href="https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww.kabilah.com%2F&amp;urlhash=abc">https://www.kabilah.com/</a>
+    <div>Industry</div>
+    <div>Hospitals and Health Care</div>
+  </section>
+</body></html>`
+
+	enrichJobFromCompanyProfileHTML(&job, rawHTML, "https://www.linkedin.com/company/kabilah")
+
+	if job.CompanyWebsite != "https://www.kabilah.com" {
+		t.Fatalf("CompanyWebsite = %q; want https://www.kabilah.com", job.CompanyWebsite)
+	}
+	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil || job.CompanyIdentity.Website.Source != "company_profile" {
+		t.Fatalf("CompanyIdentity.Website = %#v; want company profile website evidence", job.CompanyIdentity)
 	}
 }
 
@@ -1921,6 +2064,32 @@ func TestEnrichJobFromCompanyWebsitePagesUsesAboutPage(t *testing.T) {
 	}
 }
 
+func TestEnrichJobFromHTMLExtractsLinkedInAboutCompanyIndustry(t *testing.T) {
+	job := Job{
+		Company: "Allen Institute",
+		Title:   "Software Engineer II",
+	}
+	rawHTML := `
+<html><body>
+  <section>
+    <h2>About the company</h2>
+    <a href="https://www.linkedin.com/company/allen-institute/">Allen Institute</a>
+    <div>51,000 followers</div>
+    <div>Research Services</div>
+    <div>501-1,000 employees</div>
+  </section>
+</body></html>`
+
+	enrichJobFromHTML(&job, rawHTML, "https://www.linkedin.com/jobs/view/4397181050/")
+
+	if job.CompanyIndustry != "Research Services" {
+		t.Fatalf("CompanyIndustry = %q; want Research Services", job.CompanyIndustry)
+	}
+	if job.CompanyIdentity == nil || job.CompanyIdentity.Industry == nil || job.CompanyIdentity.Industry.Source != "apply_page" {
+		t.Fatalf("CompanyIdentity = %#v; want apply-page industry evidence", job.CompanyIdentity)
+	}
+}
+
 func TestEnrichJobFromCompanyWebsitePagesSuppliesAboutPageToLLM(t *testing.T) {
 	companyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -2017,24 +2186,6 @@ func TestPopulateCompanySiteProfileIdentity(t *testing.T) {
 	}
 }
 
-func TestEnrichJobsFromApplyPagesDoesNotUseBrowserCompanySearchFallback(t *testing.T) {
-	job := Job{
-		Company:  "Acme",
-		Title:    "Staff Platform Engineer",
-		ApplyURL: "https://www.indeed.com/viewjob?jk=abc123",
-		Source:   "Site Search: https://www.indeed.com/jobs",
-	}
-
-	enriched := enrichJobsFromApplyPagesWithLLMAndProgress(context.Background(), []Job{job}, nil, nil, nil)
-
-	if len(enriched) != 1 {
-		t.Fatalf("enrichJobsFromApplyPagesWithLLMAndProgress(...) len = %d; want 1", len(enriched))
-	}
-	if enriched[0].CompanyWebsite != "" || enriched[0].CompanySummary != "" || enriched[0].CompanyIndustry != "" {
-		t.Fatalf("enriched job identity = website %q summary %q industry %q; want browser fallback not to fill fields", enriched[0].CompanyWebsite, enriched[0].CompanySummary, enriched[0].CompanyIndustry)
-	}
-}
-
 func TestBrowserCompanySearchTargetsDedupesCompanies(t *testing.T) {
 	jobs := []Job{
 		{Company: "Acme Inc.", Title: "Platform Engineer"},
@@ -2074,7 +2225,13 @@ func TestFetchAllJobsCombinesLLMAndRSSSources(t *testing.T) {
 	}
 	fetchAllJobsExecuteLLMSearch = func(ctx context.Context, llm llms.Model, prompt string) ([]Job, error) {
 		return []Job{
-			{Company: "LLMCo", Title: "LLM Role", ApplyURL: applyServer.URL},
+			{
+				Company:        "LLMCo",
+				Title:          "LLM Role",
+				ApplyURL:       applyServer.URL,
+				CompanyWebsite: "https://llmco.com",
+				CompanySummary: "LLMCo builds infrastructure tooling for software engineering teams.",
+			},
 		}, nil
 	}
 	fetchAllJobsEnrichJobIdentity = func(ctx context.Context, llm llms.Model, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error) {

--- a/internal/fetcher/job_filter.go
+++ b/internal/fetcher/job_filter.go
@@ -138,49 +138,10 @@ func filterJobReason(job *Job, criteria *CriteriaConfig) string {
 		return ""
 	}
 
-	titleLower := strings.ToLower(job.Title)
+	if reason := titleScopeFilterReason(job.Title, criteria); reason != "" {
+		return reason
+	}
 	descLower := strings.ToLower(job.Description)
-
-	// 1. Title Excludes (Fail fast)
-	if len(criteria.Filters.TitleExcludes) > 0 {
-		for _, exclude := range criteria.Filters.TitleExcludes {
-			if strings.Contains(titleLower, strings.ToLower(exclude)) {
-				return "title excludes"
-			}
-		}
-	}
-
-	// 2. Title Requires (Strict scope enforcement - MUST match as whole word)
-	if len(criteria.Filters.TitleRequires) > 0 {
-		match := false
-		for _, req := range criteria.Filters.TitleRequires {
-			pattern := `(?i)(^|[^a-zA-Z])` + regexp.QuoteMeta(req) + `([^a-zA-Z]|$)`
-			re, err := regexp.Compile(pattern)
-			if err == nil && re.MatchString(job.Title) {
-				match = true
-				break
-			}
-		}
-		if !match {
-			return "title requirements"
-		}
-	}
-
-	// 3. Title Includes (General role targeting - MUST match as whole word/boundary)
-	if len(criteria.Filters.TitleIncludes) > 0 {
-		match := false
-		for _, include := range criteria.Filters.TitleIncludes {
-			pattern := `(?i)(^|[^a-zA-Z])` + regexp.QuoteMeta(include) + `([^a-zA-Z]|$)`
-			re, err := regexp.Compile(pattern)
-			if err == nil && re.MatchString(job.Title) {
-				match = true
-				break
-			}
-		}
-		if !match {
-			return "title includes"
-		}
-	}
 
 	// 4. Industry Excludes (Scan description)
 	if len(criteria.Filters.IndustryExcludes) > 0 {
@@ -201,6 +162,57 @@ func filterJobReason(job *Job, criteria *CriteriaConfig) string {
 	// 6. Work Settings / Remote check (Basic heuristic)
 	if !jobMatchesWorkSettings(job, criteria.Filters.WorkSettings) {
 		return "work setting"
+	}
+
+	return ""
+}
+
+func titleScopeFilterReason(title string, criteria *CriteriaConfig) string {
+	if criteria == nil {
+		return ""
+	}
+
+	titleLower := strings.ToLower(title)
+
+	// 1. Title Excludes (Fail fast)
+	if len(criteria.Filters.TitleExcludes) > 0 {
+		for _, exclude := range criteria.Filters.TitleExcludes {
+			if strings.Contains(titleLower, strings.ToLower(exclude)) {
+				return "title excludes"
+			}
+		}
+	}
+
+	// 2. Title Requires (Strict scope enforcement - MUST match as whole word)
+	if len(criteria.Filters.TitleRequires) > 0 {
+		match := false
+		for _, req := range criteria.Filters.TitleRequires {
+			pattern := `(?i)(^|[^a-zA-Z])` + regexp.QuoteMeta(req) + `([^a-zA-Z]|$)`
+			re, err := regexp.Compile(pattern)
+			if err == nil && re.MatchString(title) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return "title requirements"
+		}
+	}
+
+	// 3. Title Includes (General role targeting - MUST match as whole word/boundary)
+	if len(criteria.Filters.TitleIncludes) > 0 {
+		match := false
+		for _, include := range criteria.Filters.TitleIncludes {
+			pattern := `(?i)(^|[^a-zA-Z])` + regexp.QuoteMeta(include) + `([^a-zA-Z]|$)`
+			re, err := regexp.Compile(pattern)
+			if err == nil && re.MatchString(title) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return "title includes"
+		}
 	}
 
 	return ""

--- a/internal/fetcher/job_validation.go
+++ b/internal/fetcher/job_validation.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func validateFetchedJobs(ctx context.Context, jobs []Job) ([]Job, map[string][]string) {
@@ -51,8 +53,13 @@ func unusableJobReason(job Job) string {
 	if reason := unusableJobURLReason(job); reason != "" {
 		return reason
 	}
-	if isLLMGeneratedJob(job) && !jobHasRequiredCompanyIdentity(job) {
-		return "missing company identity"
+	if usesReservedPlaceholderDomain(job.CompanyWebsite) {
+		return "placeholder URL"
+	}
+	if isLLMGeneratedJob(job) {
+		if !jobHasRequiredCompanyIdentity(job) {
+			return "missing company identity"
+		}
 	}
 	return ""
 }
@@ -61,6 +68,12 @@ func unusableJobURLReason(job Job) string {
 	applyURL := strings.TrimSpace(job.ApplyURL)
 	if applyURL == "" {
 		return "empty URL"
+	}
+	if usesReservedPlaceholderDomain(applyURL) {
+		return "placeholder URL"
+	}
+	if isIndeedPageadClickURL(applyURL) {
+		return "Indeed click tracking URL"
 	}
 	if isKnownNonJobApplyURL(applyURL) {
 		return "not a direct job URL"
@@ -83,10 +96,36 @@ func isLLMGeneratedJob(job Job) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(job.Source)), "llm")
 }
 
+func usesReservedPlaceholderDomain(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := strings.ToLower(strings.TrimPrefix(parsed.Hostname(), "www."))
+	switch {
+	case host == "example.com" || strings.HasSuffix(host, ".example.com"):
+		return true
+	case host == "example.org" || strings.HasSuffix(host, ".example.org"):
+		return true
+	case host == "example.net" || strings.HasSuffix(host, ".example.net"):
+		return true
+	case host == "localhost" || strings.HasSuffix(host, ".localhost"):
+		return true
+	case host == "test" || strings.HasSuffix(host, ".test"):
+		return true
+	case host == "invalid" || strings.HasSuffix(host, ".invalid"):
+		return true
+	case host == "example" || strings.HasSuffix(host, ".example"):
+		return true
+	default:
+		return false
+	}
+}
+
 func jobHasRequiredCompanyIdentity(job Job) bool {
 	return !jobCompanyMissingOrUnknown(job.Company) &&
-		!jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
-		!jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
+		!domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
+		!domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
 }
 
 func isKnownNonJobApplyURL(rawURL string) bool {

--- a/internal/fetcher/job_validation_test.go
+++ b/internal/fetcher/job_validation_test.go
@@ -48,3 +48,15 @@ func TestIsKnownNonJobApplyURLAllowsBuiltInDirectJobDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestUnusableJobReasonRejectsIndeedPageadClickURL(t *testing.T) {
+	job := Job{
+		Company:  "Example",
+		Title:    "Software Engineer",
+		ApplyURL: "https://www.indeed.com/pagead/clk?mo=r&ad=abc&p=0",
+	}
+
+	if got := unusableJobReason(job); got != "Indeed click tracking URL" {
+		t.Fatalf("unusableJobReason() = %q; want Indeed click tracking URL", got)
+	}
+}

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
+	"golang.org/x/net/publicsuffix"
 )
 
 const (
@@ -33,10 +34,11 @@ const (
 )
 
 type siteSearchCandidate struct {
-	Title   string
-	Company string
-	URL     string
-	Score   int
+	Title       string
+	Company     string
+	URL         string
+	Description string
+	Score       int
 }
 
 var siteSearchNetworkErrorPattern = regexp.MustCompile(`net::[A-Z_]+`)
@@ -143,17 +145,22 @@ func FindSiteSearchBrowserBinary() string {
 	return findSiteSearchBrowserBinary()
 }
 
-func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target string, targetURL string, sourceName string, criteria *CriteriaConfig) ([]Job, map[string][]Job, error) {
+func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target string, targetURL string, sourceName string, criteria *CriteriaConfig, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, string, error) {
 	candidates, err := probeSiteSearchCandidates(ctx, browser, targetURL, criteria)
 	if err != nil {
 		logDebug("site search %s: browser candidate probe failed: %v", target, err)
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	logDebug("site search %s: browser candidate probe returned %d candidates", target, len(candidates))
 
 	jobs := make([]Job, 0, len(candidates))
 	filtered := make(map[string][]Job)
 	seen := make(map[string]bool)
+	notice := ""
+	if kept, skipped := candidateLimiter.take(target, candidates); skipped > 0 {
+		logDebug("site search %s: candidate limit kept=%d skipped=%d", target, len(kept), skipped)
+		candidates = kept
+	}
 
 	for _, candidate := range candidates {
 		title := candidate.Title
@@ -185,13 +192,20 @@ func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target st
 			ApplyURL:     candidate.URL,
 			Source:       sourceName,
 			Status:       "Unopened",
-			Remote:       inferWorkSetting(candidate.Title+" "+candidate.URL, criteria),
+			Remote:       inferWorkSetting(candidate.Title+" "+candidate.Description+" "+candidate.URL, criteria),
 			Compensation: "Not listed",
-			Description:  candidate.URL,
+			Description:  firstNonEmptyString(candidate.Description, candidate.URL),
 		}
 		job.SetDateAdded(time.Now().Unix())
 		enrichJobFromDescription(&job)
-		enrichSiteSearchJobIdentityBeforeFilter(ctx, &job)
+		if reason := titleScopeFilterReason(job.Title, criteria); reason != "" {
+			logDebug("site search %s: filtered candidate %s - %s before detail enrichment: %s", target, job.Company, job.Title, reason)
+			filtered[reason] = append(filtered[reason], job)
+			continue
+		}
+		if enrichmentNotice := enrichSiteSearchJobIdentityBeforeFilter(ctx, browser, &job, detailBlocked); enrichmentNotice != "" && notice == "" {
+			notice = enrichmentNotice
+		}
 		logDebug("site search %s: candidate score=%d company=%q title=%q url=%s", target, candidate.Score, job.Company, job.Title, job.ApplyURL)
 
 		if siteSearchCompanyMissingOrInvalid(job.Company) {
@@ -209,12 +223,15 @@ func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target st
 	}
 
 	logDebug("site search %s: accepted %d; filtered %d after generic candidate filtering", target, len(jobs), countFilteredJobs(filtered))
-	return jobs, filtered, nil
+	return jobs, filtered, notice, nil
 }
 
-func enrichSiteSearchJobIdentityBeforeFilter(ctx context.Context, job *Job) {
+func enrichSiteSearchJobIdentityBeforeFilter(ctx context.Context, browser *rod.Browser, job *Job, detailBlocked *siteSearchBlocklist) string {
 	if job == nil || !siteSearchJobNeedsPreFilterDetail(*job) {
-		return
+		return ""
+	}
+	if isIndeedURL(job.ApplyURL) {
+		return enrichIndeedJobIdentityBeforeFilter(ctx, browser, job, detailBlocked)
 	}
 	rawHTML, finalURL, err := fetchApplyPage(ctx, job.ApplyURL)
 	if err != nil || strings.TrimSpace(rawHTML) == "" {
@@ -223,7 +240,7 @@ func enrichSiteSearchJobIdentityBeforeFilter(ctx context.Context, job *Job) {
 		} else {
 			logDebug("site search pre-filter identity %s: empty detail page", job.ApplyURL)
 		}
-		return
+		return ""
 	}
 	if strings.TrimSpace(finalURL) != "" {
 		job.ApplyURL = finalURL
@@ -240,6 +257,7 @@ func enrichSiteSearchJobIdentityBeforeFilter(ctx context.Context, job *Job) {
 		beforeWebsite,
 		job.CompanyWebsite,
 	)
+	return ""
 }
 
 func siteSearchJobNeedsPreFilterIdentity(job Job) bool {
@@ -253,15 +271,167 @@ func siteSearchJobNeedsPreFilterDetail(job Job) bool {
 	if isKnownNonJobApplyURL(job.ApplyURL) {
 		return false
 	}
-	if isIndeedURL(job.ApplyURL) {
-		return false
-	}
 	return siteSearchJobNeedsPreFilterIdentity(job) ||
 		jobDescriptionMissingOrURL(job.Description) ||
-		jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
-		jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
+		domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
+		domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
 		jobCompanyIndustryNeedsEnrichment(job) ||
-		jobCompensationMissing(job.Compensation)
+		domain.JobCompensationMissing(job.Compensation)
+}
+
+func enrichIndeedJobIdentityBeforeFilter(ctx context.Context, browser *rod.Browser, job *Job, detailBlocked *siteSearchBlocklist) string {
+	if browser == nil {
+		logDebug("site search pre-filter identity %s: skipped Indeed detail enrichment: browser unavailable", job.ApplyURL)
+		return ""
+	}
+	if reason := detailBlocked.reasonFor(job.ApplyURL); reason != "" {
+		logDebug("site search pre-filter identity %s: skipped Indeed detail enrichment because detail probes are blocked: %s", job.ApplyURL, reason)
+		return ""
+	}
+	pageText, links, err := extractBrowserPageContent(ctx, browser, job.ApplyURL)
+	if err != nil || strings.TrimSpace(pageText) == "" {
+		if err != nil {
+			logDebug("site search pre-filter identity %s: Indeed browser fetch failed: %v", job.ApplyURL, err)
+		} else {
+			logDebug("site search pre-filter identity %s: Indeed browser fetch empty", job.ApplyURL)
+		}
+		return ""
+	}
+	if isSiteSearchVerificationPage("", pageText) {
+		reason := "Indeed blocked detail-page access; using listing snippets only"
+		if line := verificationDebugLine(pageText); line != "" {
+			reason += ": " + line
+		}
+		if detailBlocked.block(job.ApplyURL, reason) {
+			logDebug("site search pre-filter identity %s: blocked remaining Indeed detail probes after verification page: %s", job.ApplyURL, reason)
+			return "Indeed blocked detail-page access; using listing snippets only"
+		}
+		logDebug("site search pre-filter identity %s: Indeed detail blocked by verification page: %s", job.ApplyURL, reason)
+		return ""
+	}
+
+	beforeCompany := job.Company
+	beforeWebsite := job.CompanyWebsite
+	if source := job.EnsureSourceMetadata(); strings.TrimSpace(source.PostingURL) == "" {
+		source.PostingURL = strings.TrimSpace(job.ApplyURL)
+	}
+	enrichJobFromIndeedDetailText(job, pageText, job.ApplyURL)
+	enrichJobFromIndeedDetailLinks(job, links)
+	sanitizeExistingJobIdentity(job)
+	logDebug(
+		"site search pre-filter identity %s: Indeed detail company %q -> %q website %q -> %q links=%d",
+		job.ApplyURL,
+		beforeCompany,
+		job.Company,
+		beforeWebsite,
+		job.CompanyWebsite,
+		len(links),
+	)
+	return ""
+}
+
+func enrichJobFromIndeedDetailText(job *Job, pageText string, pageURL string) {
+	if job == nil {
+		return
+	}
+	if isSiteSearchVerificationPage("", pageText) {
+		return
+	}
+	if jobDescriptionMissingOrURL(job.Description) && strings.TrimSpace(pageText) != "" {
+		job.Description = truncateAtSentence(pageText, 1200)
+	}
+	if evidence := companyPublicProfileEvidenceFromText("indeed", pageURL, job.Company, pageText); companyPublicProfileEvidenceUseful(evidence) {
+		applyCompanyPublicProfileEvidence(job, evidence, "indeed_detail")
+	}
+}
+
+func enrichJobFromIndeedDetailLinks(job *Job, links []pageLink) {
+	if job == nil {
+		return
+	}
+	if profileURL := indeedCompanyProfileURLFromLinks(links); profileURL != "" {
+		job.EnsureSourceMetadata().CompanyProfileURL = profileURL
+	}
+	if externalURL := indeedExternalApplyURLFromLinks(links, job.Company); externalURL != "" {
+		source := job.EnsureSourceMetadata()
+		source.ExternalApplyURL = externalURL
+		if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+			if website := companyWebsiteFromExternalApplyURL(externalURL, job.ApplyURL, job.Company); website != "" {
+				job.CompanyWebsite = website
+				setJobIdentityEvidence(job, "website", website, "indeed_apply_link", externalURL, "high", false, "Website inferred from Indeed company-site apply link.")
+			}
+		}
+	}
+}
+
+func indeedCompanyProfileURLFromLinks(links []pageLink) string {
+	for _, link := range links {
+		if publicProfileSource(link.URL) == "indeed" {
+			return link.URL
+		}
+	}
+	return ""
+}
+
+func indeedExternalApplyURLFromLinks(links []pageLink, company string) string {
+	best := ""
+	bestScore := 0
+	for _, link := range links {
+		score := scoreIndeedExternalApplyLink(link, company)
+		if score > bestScore {
+			bestScore = score
+			best = link.URL
+		}
+	}
+	return best
+}
+
+func companyWebsiteFromExternalApplyURL(externalURL string, applyURL string, company string) string {
+	parsed, err := url.Parse(strings.TrimSpace(externalURL))
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	scheme := parsed.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	host := parsed.Hostname()
+	if rootHost, err := publicsuffix.EffectiveTLDPlusOne(host); err == nil && rootHost != "" {
+		host = rootHost
+	}
+	website := (&url.URL{Scheme: scheme, Host: host, Path: "/"}).String()
+	if !looksLikeCompanyWebsite(website, applyURL) || !candidateWebsiteMatchesCompany(website, company) {
+		return ""
+	}
+	return website
+}
+
+func scoreIndeedExternalApplyLink(link pageLink, company string) int {
+	parsed, err := url.Parse(strings.TrimSpace(link.URL))
+	if err != nil || parsed.Host == "" {
+		return 0
+	}
+	host := strings.ToLower(strings.TrimPrefix(parsed.Hostname(), "www."))
+	if isIndeedDomain(host) || isGoogleHost(host) {
+		return 0
+	}
+	candidate := canonicalCompanySiteURL(link.URL)
+	if candidate == "" || !looksLikeCompanyWebsite(candidate, "") {
+		return 0
+	}
+	score := 1
+	textLower := strings.ToLower(link.Text)
+	urlLower := strings.ToLower(link.URL)
+	if strings.Contains(textLower, "apply") || strings.Contains(textLower, "company site") || strings.Contains(urlLower, "worker_signup") || strings.Contains(urlLower, "signup") {
+		score += 6
+	}
+	if candidateWebsiteMatchesCompany(candidate, company) {
+		score += 4
+	}
+	if strings.Contains(urlLower, "utm_source=indeed") || strings.Contains(urlLower, "indeed") {
+		score += 2
+	}
+	return score
 }
 
 func jobDescriptionMissingOrURL(description string) bool {
@@ -353,7 +523,7 @@ func builtInDetailResultForSource(result builtInDetailResult, sourceName string)
 	return result
 }
 
-func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex) ([]Job, map[string][]Job, bool, error) {
+func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, bool, error) {
 	parsed, err := url.Parse(strings.TrimSpace(targetURL))
 	if err != nil || parsed.Host == "" || !isBuiltInHost(parsed.Hostname()) {
 		return nil, nil, false, nil
@@ -367,14 +537,26 @@ func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName st
 		}
 		return nil, nil, true, err
 	}
-	return parseBuiltInSiteSearchHTML(ctx, rawHTML, finalURL, sourceName, criteria, detailCache, profileEnricher, existing)
+	return parseBuiltInSiteSearchHTML(ctx, rawHTML, finalURL, sourceName, sourceKey, criteria, detailCache, profileEnricher, existing, candidateLimiter)
 }
 
-func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL string, sourceName string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex) ([]Job, map[string][]Job, bool, error) {
+func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, bool, error) {
 	hrefs := extractHTMLHrefs(rawHTML)
 	listingJobs, cardCount := extractBuiltInListingJobs(rawHTML, finalURL, sourceName, criteria)
 	if cardCount > 0 {
+		var skippedByLimit []builtInListingJob
+		if keptCount := candidateLimiter.takeCount(sourceKey, len(listingJobs)); keptCount < len(listingJobs) {
+			skippedByLimit = append(skippedByLimit, listingJobs[keptCount:]...)
+			listingJobs = listingJobs[:keptCount]
+			logDebug("site search built-in %s: candidate limit kept=%d skipped=%d", finalURL, keptCount, len(skippedByLimit))
+		}
 		acceptedListingJobs, cardFiltered := filterBuiltInListingJobsWithProfiles(listingJobs, criteria)
+		if len(skippedByLimit) > 0 {
+			if cardFiltered == nil {
+				cardFiltered = make(map[string][]Job)
+			}
+			cardFiltered["candidate limit reached"] = append(cardFiltered["candidate limit reached"], builtInListingJobsToJobs(skippedByLimit)...)
+		}
 		var skippedExisting []Job
 		acceptedListingJobs, skippedExisting = skipExistingBuiltInListingJobs(acceptedListingJobs, existing)
 		if len(skippedExisting) > 0 {
@@ -397,6 +579,10 @@ func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL st
 	}
 	if len(links) > 50 {
 		links = links[:50]
+	}
+	if keptCount := candidateLimiter.takeCount(sourceKey, len(links)); keptCount < len(links) {
+		logDebug("site search built-in %s: candidate limit kept=%d skipped=%d", finalURL, keptCount, len(links)-keptCount)
+		links = links[:keptCount]
 	}
 	logDebug("site search built-in %s: found %d job detail links", finalURL, len(links))
 
@@ -503,6 +689,9 @@ func fetchBuiltInJobDetail(ctx context.Context, detailURL string, sourceName str
 		Compensation: "Not listed",
 	}
 	enrichJobFromHTML(&job, detailHTML, finalURL)
+	if profileURL := extractSourceCompanyProfileURL(detailHTML, finalURL); profileURL != "" {
+		job.EnsureSourceMetadata().CompanyProfileURL = profileURL
+	}
 	if jobCompanyMissingOrUnknown(job.Company) || strings.TrimSpace(job.Title) == "" {
 		logDebug("site search built-in detail %s: missing company/title after parsing", finalURL)
 		return builtInDetailResult{}
@@ -896,12 +1085,44 @@ func isIndeedHost(host string) bool {
 	return host == "indeed.com"
 }
 
+func isIndeedDomain(host string) bool {
+	host = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(host), "www."))
+	return host == "indeed.com" || strings.HasSuffix(host, ".indeed.com")
+}
+
 func isIndeedURL(rawURL string) bool {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || parsed.Host == "" {
 		return false
 	}
 	return isIndeedHost(parsed.Hostname())
+}
+
+func isIndeedPageadClickURL(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" || !isIndeedHost(parsed.Hostname()) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimRight(parsed.EscapedPath(), "/"), "/pagead/clk")
+}
+
+func canonicalIndeedJobURL(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" || !isIndeedHost(parsed.Hostname()) {
+		return ""
+	}
+	path := strings.ToLower(strings.TrimRight(parsed.EscapedPath(), "/"))
+	switch path {
+	case "/viewjob":
+		if jobKey := strings.TrimSpace(parsed.Query().Get("jk")); jobKey != "" {
+			return "https://www.indeed.com/viewjob?jk=" + url.QueryEscape(jobKey)
+		}
+	case "/rc/clk", "/pagead/clk":
+		if jobKey := strings.TrimSpace(parsed.Query().Get("jk")); jobKey != "" {
+			return "https://www.indeed.com/viewjob?jk=" + url.QueryEscape(jobKey)
+		}
+	}
+	return ""
 }
 
 func isLinkedInHost(host string) bool {
@@ -944,8 +1165,6 @@ func isSiteSearchDirectJobCandidate(baseHost string, title string, resolved *url
 		return false
 	case host == "ycombinator.com":
 		return isYCombinatorJobURL(rawURL)
-	case host == "himalayas.app":
-		return isHimalayasJobURL(rawURL)
 	case isBuiltInHost(host):
 		return isBuiltInJobCandidate(title, resolved)
 	case isSharedATSDirectoryHost(host):
@@ -953,6 +1172,46 @@ func isSiteSearchDirectJobCandidate(baseHost string, title string, resolved *url
 	default:
 		return true
 	}
+}
+
+func siteSearchCandidateApplyURL(baseHost string, resolved *url.URL, canonicalRaw string) (string, bool) {
+	if resolved == nil {
+		return "", false
+	}
+	rawURL := resolved.String()
+	if canonical := safeCanonicalSiteSearchCandidateURL(rawURL, canonicalRaw); canonical != "" {
+		return canonical, true
+	}
+	if canonical := canonicalIndeedJobURL(rawURL); canonical != "" {
+		return canonical, true
+	}
+	if isIndeedHost(baseHost) && isIndeedPageadClickURL(rawURL) {
+		return "", false
+	}
+	return rawURL, true
+}
+
+func safeCanonicalSiteSearchCandidateURL(rawURL string, canonicalRaw string) string {
+	canonicalRaw = strings.TrimSpace(canonicalRaw)
+	if canonicalRaw == "" {
+		return ""
+	}
+	base, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	canonical, err := base.Parse(canonicalRaw)
+	if err != nil || canonical.Host == "" || canonical.Scheme == "" {
+		return ""
+	}
+	if canonical.Scheme != "http" && canonical.Scheme != "https" {
+		return ""
+	}
+	canonicalURL := canonical.String()
+	if usesReservedPlaceholderDomain(canonicalURL) || isKnownNonJobApplyURL(canonicalURL) || isIndeedPageadClickURL(canonicalURL) {
+		return ""
+	}
+	return canonicalURL
 }
 
 func unwrapGoogleSearchResultURL(resolved *url.URL) *url.URL {
@@ -976,16 +1235,6 @@ func unwrapGoogleSearchResultURL(resolved *url.URL) *url.URL {
 	return unwrapped
 }
 
-func isHimalayasJobURL(rawURL string) bool {
-	parsed, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil {
-		return false
-	}
-	host := strings.ToLower(strings.TrimPrefix(parsed.Hostname(), "www."))
-	path := strings.ToLower(parsed.EscapedPath())
-	return host == "himalayas.app" && strings.HasPrefix(path, "/companies/") && strings.Contains(path, "/jobs/")
-}
-
 func isSharedATSDirectoryHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	switch host {
@@ -1001,8 +1250,6 @@ func inferCompanyFromSiteSearchURL(rawURL string) string {
 	switch {
 	case isYCombinatorJobURL(rawURL):
 		return ycCompanyNameFromURL(rawURL)
-	case isHimalayasJobURL(rawURL):
-		return companyNameFromPathSegment(rawURL, "companies")
 	case isLinkedInJobURL(rawURL):
 		return linkedInCompanyNameFromJobURL(rawURL)
 	case isGreenhouseJobURL(rawURL):
@@ -1210,20 +1457,6 @@ func linkedInCompanyNameFromJobURL(rawURL string) string {
 	return titleCaseSlug(companySlug)
 }
 
-func companyNameFromPathSegment(rawURL string, marker string) string {
-	parsed, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil {
-		return ""
-	}
-	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
-	for i, part := range parts {
-		if part == marker && i+1 < len(parts) {
-			return titleCaseSlug(parts[i+1])
-		}
-	}
-	return ""
-}
-
 func companyNameFromGreenhouseURL(rawURL string) string {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
@@ -1248,24 +1481,21 @@ func probeSiteSearchCandidates(ctx context.Context, browser *rod.Browser, target
 			}
 		}
 
-		page := browser.Timeout(timeout).MustPage(targetURL)
-		defer page.MustClose()
+		withReusableBrowserPage(ctx, browser, timeout, targetURL, func(page *rod.Page) {
+			waitBrowserPageReady(page, siteSearchSettleDelay)
 
-		page.MustWaitLoad()
-		time.Sleep(siteSearchSettleDelay)
-
-		info := page.MustInfo()
-		baseURL, err := url.Parse(info.URL)
-		if err != nil {
-			baseURL, err = url.Parse(targetURL)
+			info := page.MustInfo()
+			baseURL, err := url.Parse(info.URL)
 			if err != nil {
-				panic(err)
+				baseURL, err = url.Parse(targetURL)
+				if err != nil {
+					panic(err)
+				}
 			}
-		}
 
-		// Execute a single JS evaluation to extract all anchors and their contextual
-		// parent text to avoid accumulating hundreds of CDP element references.
-		res, err := page.Eval(`() => {
+			// Execute a single JS evaluation to extract all anchors and their contextual
+			// parent text to avoid accumulating hundreds of CDP element references.
+			res, err := page.Eval(`() => {
 			const maxAnchors = 500;
 			const maxTitleLength = 300;
 			const maxContextLength = 700;
@@ -1295,12 +1525,64 @@ func probeSiteSearchCandidates(ctx context.Context, browser *rod.Browser, target
 				}
 				return text;
 			};
-			let results = [];
-			let elements = document.querySelectorAll("a[href]");
-			for (let i = 0; i < elements.length && results.length < maxAnchors; i++) {
-				let el = elements[i];
-				let title = truncateInline(el.innerText || el.textContent || "", maxTitleLength);
-				let href = el.getAttribute("href") || "";
+				let results = [];
+				const isLinkedIn = /(^|\.)linkedin\.com$/i.test(window.location.hostname || "");
+				const isIndeed = /(^|\.)indeed\.com$/i.test(window.location.hostname || "");
+				const normalizeURL = (value) => {
+					try {
+						if (!value) return "";
+						return new URL(value, window.location.href).href;
+					} catch (_) {
+						return "";
+					}
+				};
+				const indeedURLKey = (value) => {
+					try {
+						let parsed = new URL(value, window.location.href);
+						if (!/(^|\.)indeed\.com$/i.test(parsed.hostname || "")) return "";
+						parsed.searchParams.delete("jsa");
+						return parsed.pathname + "?" + parsed.searchParams.toString();
+					} catch (_) {
+						return "";
+					}
+				};
+				const indeedCanonicalByClick = new Map();
+				const indeedCanonicalByKey = new Map();
+				const addIndeedCanonical = (clickURL, canonicalURL) => {
+					let canonical = normalizeURL(canonicalURL);
+					if (!canonical) return;
+					let clickKey = indeedURLKey(clickURL);
+					if (clickKey) indeedCanonicalByClick.set(clickKey, canonical);
+				};
+				const addIndeedJob = (job) => {
+					if (!job) return;
+					let key = (job.key || "").trim();
+					let canonical = normalizeURL(job.url || (key ? "/viewjob?jk=" + encodeURIComponent(key) : ""));
+					if (!canonical) return;
+					if (key) indeedCanonicalByKey.set(key, canonical);
+					let clickURL = job.tracking && job.tracking.jobClick && job.tracking.jobClick.url;
+					addIndeedCanonical(clickURL, canonical);
+				};
+				if (isIndeed) {
+					try {
+						let initial = window._initialData || {};
+						let results = (((initial.hostQueryExecutionResult || {}).data || {}).jobData || {}).results || [];
+						for (let result of results) addIndeedJob(result && result.job);
+						let autoKey = ((initial.autoOpenJobAttributes || {}).jobKey || "").trim();
+						let autoLink = (initial.autoOpenJobAttributes || {}).link || "";
+						if (autoKey && indeedCanonicalByKey.has(autoKey)) {
+							addIndeedCanonical(autoLink, indeedCanonicalByKey.get(autoKey));
+						} else if (autoKey) {
+							addIndeedCanonical(autoLink, "/viewjob?jk=" + encodeURIComponent(autoKey));
+						}
+					} catch (_) {
+					}
+				}
+				let elements = document.querySelectorAll("a[href]");
+				for (let i = 0; i < elements.length && results.length < maxAnchors; i++) {
+					let el = elements[i];
+					let title = truncateInline(el.innerText || el.textContent || "", maxTitleLength);
+					let href = el.getAttribute("href") || "";
 				let contexts = [];
 				let seenContexts = new Set();
 				let addContext = (node) => {
@@ -1310,22 +1592,30 @@ func probeSiteSearchCandidates(ctx context.Context, browser *rod.Browser, target
 						contexts.push(text);
 					}
 				};
-				let card = el.closest('[data-jk], [data-testid*="job"], .job_seen_beacon, .cardOutline, .result, article, li');
+				let cardSelector = isLinkedIn
+					? ".job-search-card, .base-search-card, .base-card"
+					: '[data-jk], [data-testid*="job"], .job_seen_beacon, .cardOutline, .result, article, li';
+				let card = el.closest(cardSelector);
+				let hasCardContext = false;
 				if (card && card !== document.body && card !== document.documentElement) {
 					addContext(card);
+					hasCardContext = true;
 				}
-				let curr = el.parentElement;
-				for (let j = 0; j < 6; j++) {
-					if (!curr) break;
-					addContext(curr);
-					curr = curr.parentElement;
+				if (!isLinkedIn || !hasCardContext) {
+					let curr = el.parentElement;
+					for (let j = 0; j < 6; j++) {
+						if (!curr) break;
+						addContext(curr);
+						curr = curr.parentElement;
+					}
+					}
+					results.push({
+						title: title,
+						href: href,
+						canonicalHref: isIndeed ? (indeedCanonicalByClick.get(indeedURLKey(href)) || "") : "",
+						contexts: contexts
+					});
 				}
-				results.push({
-					title: title,
-					href: href,
-					contexts: contexts
-				});
-			}
 			const bodyText = (document.body && document.body.innerText || "")
 				.replace(/[ \t\r\f\v]+/g, " ")
 				.replace(/\n{3,}/g, "\n\n")
@@ -1335,111 +1625,119 @@ func probeSiteSearchCandidates(ctx context.Context, browser *rod.Browser, target
 				bodyText: bodyText.slice(0, 2000),
 				anchors: results
 			};
-		}`)
-		if err != nil {
-			panic(err)
-		}
-
-		pageTitle := res.Value.Get("title").Str()
-		bodyText := res.Value.Get("bodyText").Str()
-		anchors := res.Value.Get("anchors").Arr()
-		if isSiteSearchVerificationPage(pageTitle, bodyText) {
-			probeErr = fmt.Errorf("%w: %s", errSiteSearchVerificationRequired, siteSearchVerificationSummary(pageTitle, bodyText))
-			logDebug("site search probe %s: final_url=%s verification required title=%q body=%q", targetURL, baseURL.String(), pageTitle, verificationDebugLine(bodyText))
-			return
-		}
-
-		raw := make([]siteSearchCandidate, 0, len(anchors))
-		emptyLinks := 0
-		builtInNonJobLinks := 0
-		nonJobLinks := 0
-		lowScoreLinks := 0
-		badIdentityLinks := 0
-
-		for _, item := range anchors {
-			title := normalizeWhitespace(item.Get("title").Str())
-			href := strings.TrimSpace(item.Get("href").Str())
-
-			if title == "" || href == "" {
-				emptyLinks++
-				continue
-			}
-
-			resolved, err := baseURL.Parse(href)
+			}`)
 			if err != nil {
-				continue
-			}
-			if isGoogleHost(baseURL.Hostname()) {
-				resolved = unwrapGoogleSearchResultURL(resolved)
-			}
-			if isBuiltInHost(baseURL.Hostname()) && !isBuiltInJobCandidate(title, resolved) {
-				builtInNonJobLinks++
-				continue
-			}
-			if !isSiteSearchDirectJobCandidate(baseURL.Hostname(), title, resolved) {
-				nonJobLinks++
-				continue
+				panic(err)
 			}
 
-			score := scoreSiteSearchCandidate(title, resolved.String(), criteria)
-			if score <= 0 {
-				lowScoreLinks++
-				continue
+			pageTitle := res.Value.Get("title").Str()
+			bodyText := res.Value.Get("bodyText").Str()
+			anchors := res.Value.Get("anchors").Arr()
+			if isSiteSearchVerificationPage(pageTitle, bodyText) {
+				probeErr = fmt.Errorf("%w: %s", errSiteSearchVerificationRequired, siteSearchVerificationSummary(pageTitle, bodyText))
+				logDebug("site search probe %s: final_url=%s verification required title=%q body=%q", targetURL, baseURL.String(), pageTitle, verificationDebugLine(bodyText))
+				return
 			}
 
-			var contexts []string
-			for _, c := range item.Get("contexts").Arr() {
-				contexts = append(contexts, c.Str())
-			}
+			raw := make([]siteSearchCandidate, 0, len(anchors))
+			emptyLinks := 0
+			builtInNonJobLinks := 0
+			nonJobLinks := 0
+			lowScoreLinks := 0
+			badIdentityLinks := 0
 
-			company := ""
-			if c := inferCompanyFromSiteSearchURL(resolved.String()); c != "" {
-				company = c
-			} else {
-				for _, text := range contexts {
-					if c := inferCompanyFromCandidateContext(baseURL.Hostname(), title, text); c != "" {
-						company = c
-						break
+			for _, item := range anchors {
+				title := normalizeWhitespace(item.Get("title").Str())
+				href := strings.TrimSpace(item.Get("href").Str())
+				canonicalHref := strings.TrimSpace(item.Get("canonicalHref").Str())
+
+				if title == "" || href == "" {
+					emptyLinks++
+					continue
+				}
+
+				resolved, err := baseURL.Parse(href)
+				if err != nil {
+					continue
+				}
+				if isGoogleHost(baseURL.Hostname()) {
+					resolved = unwrapGoogleSearchResultURL(resolved)
+				}
+				if isBuiltInHost(baseURL.Hostname()) && !isBuiltInJobCandidate(title, resolved) {
+					builtInNonJobLinks++
+					continue
+				}
+				if !isSiteSearchDirectJobCandidate(baseURL.Hostname(), title, resolved) {
+					nonJobLinks++
+					continue
+				}
+				applyURL, ok := siteSearchCandidateApplyURL(baseURL.Hostname(), resolved, canonicalHref)
+				if !ok {
+					nonJobLinks++
+					continue
+				}
+
+				score := scoreSiteSearchCandidate(title, applyURL, criteria)
+				if score <= 0 {
+					lowScoreLinks++
+					continue
+				}
+
+				var contexts []string
+				for _, c := range item.Get("contexts").Arr() {
+					contexts = append(contexts, c.Str())
+				}
+
+				company := ""
+				if c := inferCompanyFromSiteSearchURL(resolved.String()); c != "" {
+					company = c
+				} else {
+					for _, text := range contexts {
+						if c := inferCompanyFromCandidateContext(baseURL.Hostname(), title, text); c != "" {
+							company = c
+							break
+						}
 					}
 				}
-			}
 
-			if siteSearchCandidateMissingRequiredIdentity(baseURL.Hostname(), company, resolved.String()) {
-				badIdentityLinks++
-				continue
-			}
+				if siteSearchCandidateMissingRequiredIdentity(baseURL.Hostname(), company, applyURL) {
+					badIdentityLinks++
+					continue
+				}
 
-			raw = append(raw, siteSearchCandidate{
-				Title:   title,
-				Company: company,
-				URL:     resolved.String(),
-				Score:   score,
+				raw = append(raw, siteSearchCandidate{
+					Title:       title,
+					Company:     company,
+					URL:         applyURL,
+					Description: siteSearchCandidateDescription(title, company, contexts),
+					Score:       score,
+				})
+			}
+			logDebug(
+				"site search probe %s: final_url=%s anchors=%d raw_candidates=%d skipped_empty=%d skipped_builtin_non_job=%d skipped_non_job=%d skipped_low_score=%d skipped_bad_identity=%d",
+				targetURL,
+				baseURL.String(),
+				len(anchors),
+				len(raw),
+				emptyLinks,
+				builtInNonJobLinks,
+				nonJobLinks,
+				lowScoreLinks,
+				badIdentityLinks,
+			)
+
+			candidates = dedupeSiteSearchCandidates(raw)
+			sort.SliceStable(candidates, func(i, j int) bool {
+				if candidates[i].Score == candidates[j].Score {
+					return candidates[i].Title < candidates[j].Title
+				}
+				return candidates[i].Score > candidates[j].Score
 			})
-		}
-		logDebug(
-			"site search probe %s: final_url=%s anchors=%d raw_candidates=%d skipped_empty=%d skipped_builtin_non_job=%d skipped_non_job=%d skipped_low_score=%d skipped_bad_identity=%d",
-			targetURL,
-			baseURL.String(),
-			len(anchors),
-			len(raw),
-			emptyLinks,
-			builtInNonJobLinks,
-			nonJobLinks,
-			lowScoreLinks,
-			badIdentityLinks,
-		)
 
-		candidates = dedupeSiteSearchCandidates(raw)
-		sort.SliceStable(candidates, func(i, j int) bool {
-			if candidates[i].Score == candidates[j].Score {
-				return candidates[i].Title < candidates[j].Title
+			if len(candidates) > 50 {
+				candidates = candidates[:50]
 			}
-			return candidates[i].Score > candidates[j].Score
 		})
-
-		if len(candidates) > 50 {
-			candidates = candidates[:50]
-		}
 	})
 	if err != nil {
 		return nil, simplifySiteSearchError(err)
@@ -1535,12 +1833,60 @@ func siteSearchCandidateRequiresCompanyAtProbe(baseHost string, rawURL string) b
 	return isIndeedHost(host) || isLinkedInHost(host)
 }
 
+func siteSearchCandidateDescription(title string, company string, contexts []string) string {
+	best := ""
+	bestScore := 0
+	seen := make(map[string]bool, len(contexts))
+	for _, context := range contexts {
+		context = normalizeWhitespace(context)
+		if context == "" || seen[context] {
+			continue
+		}
+		seen[context] = true
+		if strings.EqualFold(context, title) {
+			continue
+		}
+		if siteSearchCandidateContextTooBroad(context) {
+			continue
+		}
+
+		lower := strings.ToLower(context)
+		score := 1
+		if title != "" && strings.Contains(lower, strings.ToLower(title)) {
+			score += 2
+		}
+		if company != "" && !siteSearchCompanyMissingOrInvalid(company) && strings.Contains(lower, strings.ToLower(company)) {
+			score += 2
+		}
+		signals := detectWorkSettingSignals(context)
+		if signals.remote || signals.hybrid || signals.onsite {
+			score++
+		}
+		if score > bestScore || (score == bestScore && (best == "" || len(context) < len(best))) {
+			best = context
+			bestScore = score
+		}
+	}
+	return truncateAtSentence(best, 1200)
+}
+
+func siteSearchCandidateContextTooBroad(context string) bool {
+	lower := strings.ToLower(context)
+	return strings.Contains(lower, "get notified about new") ||
+		strings.Contains(lower, "sign in to create job alert") ||
+		strings.Contains(lower, "linkedin ©") ||
+		strings.Contains(lower, "privacy policy") && strings.Contains(lower, "user agreement")
+}
+
 func simplifySiteSearchError(err error) error {
 	if err == nil {
 		return nil
 	}
 
 	message := strings.TrimSpace(err.Error())
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(message, "context.deadlineExceededError") || strings.Contains(message, "context deadline exceeded") {
+		return fmt.Errorf("browser page timed out")
+	}
 	if match := siteSearchNetworkErrorPattern.FindString(message); match != "" {
 		return fmt.Errorf("navigation failed: %s", match)
 	}

--- a/internal/fetcher/site_search_browser_test.go
+++ b/internal/fetcher/site_search_browser_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
 type fakeBrowserCloser struct {
@@ -508,11 +510,6 @@ func TestInferCompanyFromSiteSearchURL(t *testing.T) {
 			want: "Just Appraised",
 		},
 		{
-			name: "himalayas company slug",
-			raw:  "https://himalayas.app/companies/acme-inc/jobs/software-engineer",
-			want: "Acme Inc",
-		},
-		{
 			name: "greenhouse board slug",
 			raw:  "https://job-boards.greenhouse.io/muckrack/jobs/8523017002",
 			want: "Muckrack",
@@ -689,6 +686,35 @@ func TestSiteSearchCandidateMissingRequiredIdentity(t *testing.T) {
 	}
 }
 
+func TestSiteSearchCandidateApplyURLAvoidsIndeedPageadClickURL(t *testing.T) {
+	pageadURL, err := url.Parse("https://www.indeed.com/pagead/clk?mo=r&ad=abc&p=0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := siteSearchCandidateApplyURL("www.indeed.com", pageadURL, ""); ok || got != "" {
+		t.Fatalf("siteSearchCandidateApplyURL() = %q, %t; want no usable URL for bare pagead click", got, ok)
+	}
+
+	got, ok := siteSearchCandidateApplyURL(
+		"www.indeed.com",
+		pageadURL,
+		"https://app.example-careers.com/jobs/123",
+	)
+	if !ok || got != "https://app.example-careers.com/jobs/123" {
+		t.Fatalf("siteSearchCandidateApplyURL() = %q, %t; want canonical external URL", got, ok)
+	}
+
+	indeedClickURL, err := url.Parse("https://www.indeed.com/rc/clk?jk=122356c368d02242&bb=abc&vjs=3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok = siteSearchCandidateApplyURL("www.indeed.com", indeedClickURL, "")
+	if !ok || got != "https://www.indeed.com/viewjob?jk=122356c368d02242" {
+		t.Fatalf("siteSearchCandidateApplyURL() = %q, %t; want canonical Indeed viewjob URL", got, ok)
+	}
+}
+
 func TestEnrichSiteSearchJobIdentityBeforeFilterUsesDeterministicHTML(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`<html><head><script type="application/ld+json">{
@@ -713,7 +739,7 @@ func TestEnrichSiteSearchJobIdentityBeforeFilterUsesDeterministicHTML(t *testing
 		Compensation: "Not listed",
 	}
 
-	enrichSiteSearchJobIdentityBeforeFilter(t.Context(), &job)
+	enrichSiteSearchJobIdentityBeforeFilter(t.Context(), nil, &job, nil)
 
 	if job.Company != "Acme Tools" {
 		t.Fatalf("Company = %q; want Acme Tools", job.Company)
@@ -750,7 +776,7 @@ func TestEnrichSiteSearchJobIdentityBeforeFilterFetchesWeakDetailRows(t *testing
 		Description:  server.URL + "/jobs/staff-platform-engineer",
 	}
 
-	enrichSiteSearchJobIdentityBeforeFilter(t.Context(), &job)
+	enrichSiteSearchJobIdentityBeforeFilter(t.Context(), nil, &job, nil)
 
 	if job.CompanyWebsite != "https://www.acmetools.example" {
 		t.Fatalf("CompanyWebsite = %q; want https://www.acmetools.example", job.CompanyWebsite)
@@ -863,6 +889,123 @@ func TestSimplifySiteSearchErrorKeepsCDPMessageOnly(t *testing.T) {
 	if got := err.Error(); got != want {
 		t.Fatalf("simplifySiteSearchError() = %q; want %q", got, want)
 	}
+}
+
+func TestSimplifySiteSearchErrorNormalizesDeadlineExceeded(t *testing.T) {
+	err := simplifySiteSearchError(assertError("error value: context.deadlineExceededError{}"))
+	if err == nil {
+		t.Fatal("simplifySiteSearchError() = nil; want simplified error")
+	}
+	if got, want := err.Error(), "browser page timed out"; got != want {
+		t.Fatalf("simplifySiteSearchError() = %q; want %q", got, want)
+	}
+}
+
+func TestEnrichJobFromIndeedDetailLinksUsesCompanySiteApplyURL(t *testing.T) {
+	job := Job{
+		Company:  "DataAnnotation",
+		Title:    "Software Developer - AI Trainer",
+		ApplyURL: "https://www.indeed.com/viewjob?jk=93a47e75c343d396",
+	}
+
+	enrichJobFromIndeedDetailLinks(&job, []pageLink{{
+		Text: "Apply on company site",
+		URL:  "https://app.dataannotation.tech/worker_signup?projects=PROG_SA&worker_src=I&utm_source=indeed",
+	}})
+
+	if job.CompanyWebsite != "https://dataannotation.tech/" {
+		t.Fatalf("CompanyWebsite = %q; want https://dataannotation.tech/", job.CompanyWebsite)
+	}
+	if job.Metadata == nil || job.Metadata.Source == nil || job.Metadata.Source.ExternalApplyURL == "" {
+		t.Fatalf("Metadata.Source = %#v; want external apply URL", job.Metadata)
+	}
+	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil || job.CompanyIdentity.Website.Source != "indeed_apply_link" {
+		t.Fatalf("CompanyIdentity.Website = %#v; want Indeed apply-link evidence", job.CompanyIdentity)
+	}
+}
+
+func TestIndeedVerificationPageDoesNotBecomeJobDetail(t *testing.T) {
+	job := Job{
+		Company:     "DataAnnotation",
+		Title:       "Software Developer - AI Trainer",
+		ApplyURL:    "https://www.indeed.com/viewjob?jk=93a47e75c343d396",
+		Description: "https://www.indeed.com/viewjob?jk=93a47e75c343d396",
+	}
+	verificationText := "Find jobs Company Reviews Additional Verification Required Your Ray ID for this request is a000c7e54f956c81 Troubleshooting Cloudflare Errors"
+
+	enrichJobFromIndeedDetailText(&job, verificationText, job.ApplyURL)
+	enrichJobFromIndeedDetailLinks(&job, []pageLink{{
+		Text: "Sign in",
+		URL:  "https://secure.indeed.com/account/login?hl=en&continue=https%3A%2F%2Fwww.indeed.com",
+	}})
+
+	if job.Description != job.ApplyURL {
+		t.Fatalf("Description = %q; want original apply URL placeholder", job.Description)
+	}
+	if job.Metadata != nil && job.Metadata.Source != nil && job.Metadata.Source.ExternalApplyURL != "" {
+		t.Fatalf("ExternalApplyURL = %q; want empty", job.Metadata.Source.ExternalApplyURL)
+	}
+}
+
+func TestSiteSearchCandidateDescriptionPrefersSpecificCardContext(t *testing.T) {
+	got := siteSearchCandidateDescription("Software Engineer III", "Google", []string{
+		"Get notified about new Software Engineer jobs in Seattle. Sign in to create job alert 1,000+ Software Engineer Jobs in Seattle Software Engineer Software Engineer Harvey Nash Seattle, WA Actively Hiring 1 week ago Software Engineer III Software Engineer III Google Kirkland, WA Actively Hiring 3 weeks ago LinkedIn © 2026 Privacy Policy User Agreement",
+		"Software Engineer III\nGoogle\nKirkland, WA\nActively Hiring\n3 weeks ago",
+	})
+
+	if strings.Contains(got, "Harvey Nash") || strings.Contains(got, "Sign in to create job alert") {
+		t.Fatalf("description = %q; want specific Google card context", got)
+	}
+	if !strings.Contains(got, "Google") || !strings.Contains(got, "Software Engineer III") {
+		t.Fatalf("description = %q; want specific Google card context", got)
+	}
+}
+
+func TestProbeSiteSearchCandidatesReusesPooledPage(t *testing.T) {
+	browser, cleanup, err := newSiteSearchBrowser()
+	if err != nil {
+		t.Skipf("site-search browser unavailable: %v", err)
+	}
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><body>
+			<a href="/viewjob?jk=abc123">Software Engineer</a>
+		</body></html>`))
+	}))
+	defer server.Close()
+
+	criteria := &CriteriaConfig{}
+	criteria.Filters.TitleIncludes = []string{"software engineer"}
+
+	for i := 0; i < defaultReusableHealthBrowserPagePoolSize+2; i++ {
+		if _, err := probeSiteSearchCandidates(t.Context(), browser, server.URL, criteria); err != nil {
+			t.Fatalf("probeSiteSearchCandidates() call %d error = %v", i+1, err)
+		}
+	}
+	pages, available := reusableBrowserPoolStatsForTest(browser)
+	if pages != defaultReusableHealthBrowserPagePoolSize || available != defaultReusableHealthBrowserPagePoolSize {
+		t.Fatalf("reusable browser pool stats = pages %d available %d; want %d/%d", pages, available, defaultReusableHealthBrowserPagePoolSize, defaultReusableHealthBrowserPagePoolSize)
+	}
+}
+
+func reusableBrowserPoolStatsForTest(browser *rod.Browser) (int, int) {
+	reusableBrowserPools.Lock()
+	defer reusableBrowserPools.Unlock()
+	pool := reusableBrowserPools.pools[browser]
+	if pool == nil {
+		return 0, 0
+	}
+	pages := 0
+	available := len(pool.slots)
+	for range available {
+		slot := <-pool.slots
+		if slot.page != nil {
+			pages++
+		}
+		pool.slots <- slot
+	}
+	return pages, available
 }
 
 type assertError string

--- a/internal/fetcher/site_search_browser_test.go
+++ b/internal/fetcher/site_search_browser_test.go
@@ -998,7 +998,7 @@ func reusableBrowserPoolStatsForTest(browser *rod.Browser) (int, int) {
 	}
 	pages := 0
 	available := len(pool.slots)
-	for range available {
+	for i := 0; i < available; i++ {
 		slot := <-pool.slots
 		if slot.page != nil {
 			pages++

--- a/internal/fetcher/source_catalog.go
+++ b/internal/fetcher/source_catalog.go
@@ -286,14 +286,6 @@ func sourceCatalog() []SourceSpec {
 			RoleFamilies: allRoles,
 		},
 		{
-			ID:           "site-himalayas",
-			Label:        "Himalayas Remote Jobs",
-			Target:       "https://himalayas.app/jobs",
-			Kind:         SourceKindSite,
-			Group:        SourceGroupSiteAggregator,
-			RoleFamilies: allRoles,
-		},
-		{
 			ID:           "site-kube-careers",
 			Label:        "Kube Careers",
 			Target:       "kube.careers",
@@ -499,6 +491,10 @@ func resolveEffectiveSources(appCfg *AppConfig, criteria *CriteriaConfig) Resolv
 			if target == "" || seenSite[target] {
 				continue
 			}
+			if shouldSkipSiteTargetForWorkSettings(target, criteria) {
+				logDebug("source resolution: skipped site target %s because remote work is not selected", target)
+				continue
+			}
 			if shouldSkipSiteTargetForRoles(target, roleFamilies) {
 				logDebug("source resolution: skipped site target %s because DevOps / SRE / Systems is not selected", target)
 				continue
@@ -525,6 +521,10 @@ func resolveEffectiveSources(appCfg *AppConfig, criteria *CriteriaConfig) Resolv
 	resolved := resolveCatalogSources(roleFamilies)
 
 	for _, source := range resolved {
+		if shouldSkipCatalogSourceForWorkSettings(source, criteria) {
+			logDebug("source resolution: skipped catalog source %s because remote work is not selected", source.Label)
+			continue
+		}
 		switch source.Kind {
 		case SourceKindRSS:
 			if !appCfg.Sources.RSS.Enabled {
@@ -611,6 +611,62 @@ func effectiveRoleFamilies(appCfg *AppConfig, criteria *CriteriaConfig) []RoleFa
 
 func shouldSkipSiteTargetForRoles(target string, roleFamilies []RoleFamilyID) bool {
 	return isKubeCareersTarget(target) && !roleFamilySelected(roleFamilies, RoleDevOpsSRESystems)
+}
+
+func shouldSkipCatalogSourceForWorkSettings(source SourceSpec, criteria *CriteriaConfig) bool {
+	if criteria == nil || workSettingsAllowRemoteOnly(criteria.Filters.WorkSettings) {
+		return false
+	}
+	return isRemoteOnlyCatalogSource(source)
+}
+
+func shouldSkipSiteTargetForWorkSettings(target string, criteria *CriteriaConfig) bool {
+	if criteria == nil || workSettingsAllowRemoteOnly(criteria.Filters.WorkSettings) {
+		return false
+	}
+	return isKnownRemoteOnlySiteTarget(target)
+}
+
+func workSettingsAllowRemoteOnly(settings WorkSettingsConfig) bool {
+	return !workSettingsConfigured(settings) || settings.Remote
+}
+
+func isRemoteOnlyCatalogSource(source SourceSpec) bool {
+	switch source.Group {
+	case SourceGroupRSSRemotive, SourceGroupRSSWeWorkRemotely, SourceGroupRSSRealWorkFromAnywhere, SourceGroupSiteBuiltInRemote:
+		return true
+	default:
+		return false
+	}
+}
+
+func isKnownRemoteOnlySiteTarget(target string) bool {
+	host, path := siteTargetHostPath(target)
+	switch host {
+	case "builtin.com":
+		return path == "/jobs/remote" || strings.HasPrefix(path, "/jobs/remote/")
+	case "weworkremotely.com", "realworkfromanywhere.com":
+		return true
+	case "remotive.com":
+		return strings.Contains(path, "/remote-jobs")
+	default:
+		return false
+	}
+}
+
+func siteTargetHostPath(target string) (string, string) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", ""
+	}
+	if !strings.Contains(target, "://") {
+		target = "https://" + strings.TrimPrefix(target, "//")
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", ""
+	}
+	return strings.TrimPrefix(strings.ToLower(u.Hostname()), "www."), strings.ToLower(u.EscapedPath())
 }
 
 func roleFamilySelected(roleFamilies []RoleFamilyID, want RoleFamilyID) bool {

--- a/internal/fetcher/source_catalog_test.go
+++ b/internal/fetcher/source_catalog_test.go
@@ -172,6 +172,52 @@ func TestResolveEffectiveSourcesUsesRoleFamiliesWhenPresent(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveSourcesUsesOnsiteWorkSettingsForSources(t *testing.T) {
+	appCfg := defaultAppConfig()
+	criteria := defaultCriteriaConfig()
+	criteria.RoleFamilies = []RoleFamilyID{RoleBackendEngineering}
+	criteria.Candidate.City = "Austin"
+	criteria.Candidate.State = "TX"
+	criteria.Candidate.CountryCode = "US"
+	criteria.Filters.WorkSettings.Onsite = true
+
+	resolved := resolveEffectiveSources(&appCfg, &criteria)
+
+	if len(resolved.RSSFeeds) != 0 {
+		t.Fatalf("resolveEffectiveSources().RSSFeeds = %#v; want no remote-only catalog RSS feeds", resolved.RSSFeeds)
+	}
+	if !siteTargetsContain(resolved.SiteTargets, "https://www.builtinaustin.com") {
+		t.Fatalf("resolveEffectiveSources().SiteTargets = %#v; want regional Built In target", resolved.SiteTargets)
+	}
+	for _, blocked := range []string{"https://builtin.com/jobs/remote", "https://builtin.com/jobs"} {
+		if siteTargetsContain(resolved.SiteTargets, blocked) {
+			t.Fatalf("resolveEffectiveSources().SiteTargets = %#v; did not want %s for on-site-only criteria", resolved.SiteTargets, blocked)
+		}
+	}
+}
+
+func TestResolveEffectiveSourcesKeepsRemoteSourcesWhenRemoteSelected(t *testing.T) {
+	appCfg := defaultAppConfig()
+	criteria := defaultCriteriaConfig()
+	criteria.RoleFamilies = []RoleFamilyID{RoleBackendEngineering}
+	criteria.Candidate.City = "Austin"
+	criteria.Candidate.State = "TX"
+	criteria.Candidate.CountryCode = "US"
+	criteria.Filters.WorkSettings.Remote = true
+	criteria.Filters.WorkSettings.Onsite = true
+
+	resolved := resolveEffectiveSources(&appCfg, &criteria)
+
+	if len(resolved.RSSFeeds) != 3 {
+		t.Fatalf("resolveEffectiveSources().RSSFeeds len = %d; want 3 remote catalog RSS feeds", len(resolved.RSSFeeds))
+	}
+	for _, want := range []string{"https://builtin.com/jobs/remote", "https://www.builtinaustin.com"} {
+		if !siteTargetsContain(resolved.SiteTargets, want) {
+			t.Fatalf("resolveEffectiveSources().SiteTargets = %#v; want %s when remote is selected", resolved.SiteTargets, want)
+		}
+	}
+}
+
 func TestResolveEffectiveSourcesFallsBackToConfigWhenNoRoleFamilies(t *testing.T) {
 	appCfg := defaultAppConfig()
 	criteria := defaultCriteriaConfig()

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -110,6 +110,7 @@ func runFetchDryRun(options appruntime.Options, stores appruntime.Stores, jsonOu
 		return 1
 	}
 	config.ApplyFetchSourceSelection(appCfg, options.SourceSelection)
+	config.ApplyFetchLimitOverrides(appCfg, options.CandidateLimitPerSource, options.AcceptedLimit)
 
 	criteriaCfg, err := config.LoadCriteriaConfig(options.Paths.Config)
 	if err != nil {

--- a/internal/jobscout/cli_test.go
+++ b/internal/jobscout/cli_test.go
@@ -85,6 +85,8 @@ func TestPrintHelpDocumentsCommandLineOptions(t *testing.T) {
 	for _, want := range []string{
 		"--sources=<list>",
 		"rss, site, llm, llm_web, all",
+		"--candidate-limit <n>",
+		"--accepted-limit <n>",
 		"--config=<path>",
 		"--bench-llm [options]",
 		"--list",

--- a/internal/jobscout/run.go
+++ b/internal/jobscout/run.go
@@ -171,6 +171,12 @@ func renderHelp() string {
   --sources <list>        Use selected active fetch sources: rss, site, llm, llm_web, all
   --sources=<list>        Same as --sources <list>
                             llm_web is an opt-in experimental source
+  --candidate-limit <n>
+                          Evaluate at most n site candidates per source; 0 disables the cap
+  --candidate-limit=<n>
+                          Same as --candidate-limit <n>
+  --accepted-limit <n>    Return at most n accepted jobs from a fetch; 0 disables the cap
+  --accepted-limit=<n>    Same as --accepted-limit <n>
   --config <path>         Use an alternate config file
   --config=<path>         Same as --config <path>
   -h, --help              Show this help

--- a/internal/runtime/args.go
+++ b/internal/runtime/args.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -35,12 +36,14 @@ type Paths struct {
 }
 
 type Options struct {
-	Paths           Paths
-	Debug           bool
-	Demo            bool
-	SourceSelection []string
-	Command         string
-	CommandArgs     []string
+	Paths                   Paths
+	Debug                   bool
+	Demo                    bool
+	SourceSelection         []string
+	CandidateLimitPerSource *int
+	AcceptedLimit           *int
+	Command                 string
+	CommandArgs             []string
 }
 
 func DefaultDir() string {
@@ -95,6 +98,18 @@ func ParseArgs(args []string) (Options, error) {
 				return Options{}, err
 			}
 			options.SourceSelection = sources
+		case strings.HasPrefix(arg, "--candidate-limit="):
+			value, err := parseNonNegativeIntFlag("--candidate-limit", strings.TrimPrefix(arg, "--candidate-limit="))
+			if err != nil {
+				return Options{}, err
+			}
+			options.CandidateLimitPerSource = &value
+		case strings.HasPrefix(arg, "--accepted-limit="):
+			value, err := parseNonNegativeIntFlag("--accepted-limit", strings.TrimPrefix(arg, "--accepted-limit="))
+			if err != nil {
+				return Options{}, err
+			}
+			options.AcceptedLimit = &value
 		case arg == "--config":
 			if i+1 >= len(args) {
 				return Options{}, fmt.Errorf("--config requires a file path")
@@ -117,6 +132,26 @@ func ParseArgs(args []string) (Options, error) {
 			}
 			options.SourceSelection = sources
 			i++
+		case arg == "--candidate-limit":
+			if i+1 >= len(args) {
+				return Options{}, fmt.Errorf("--candidate-limit requires a non-negative integer")
+			}
+			value, err := parseNonNegativeIntFlag("--candidate-limit", args[i+1])
+			if err != nil {
+				return Options{}, err
+			}
+			options.CandidateLimitPerSource = &value
+			i++
+		case arg == "--accepted-limit":
+			if i+1 >= len(args) {
+				return Options{}, fmt.Errorf("--accepted-limit requires a non-negative integer")
+			}
+			value, err := parseNonNegativeIntFlag("--accepted-limit", args[i+1])
+			if err != nil {
+				return Options{}, err
+			}
+			options.AcceptedLimit = &value
+			i++
 		case arg == "--migrate":
 			return Options{}, fmt.Errorf("--migrate has been removed; use --import to load JSON exports into the configured SQLite database")
 		case isCommand(arg):
@@ -128,6 +163,18 @@ func ParseArgs(args []string) (Options, error) {
 		}
 	}
 	return options, nil
+}
+
+func parseNonNegativeIntFlag(name string, raw string) (int, error) {
+	valueText := strings.TrimSpace(raw)
+	if valueText == "" {
+		return 0, fmt.Errorf("%s requires a non-negative integer", name)
+	}
+	value, err := strconv.Atoi(valueText)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("%s requires a non-negative integer", name)
+	}
+	return value, nil
 }
 
 func isCommand(arg string) bool {

--- a/internal/runtime/args_test.go
+++ b/internal/runtime/args_test.go
@@ -183,9 +183,34 @@ func TestParseArgsSourcesFlagWithEqualsAndAliases(t *testing.T) {
 	}
 }
 
+func TestParseArgsFetchLimitOverrides(t *testing.T) {
+	options, err := ParseArgs([]string{
+		"jobscout",
+		"--candidate-limit=12",
+		"--accepted-limit",
+		"30",
+		"--fetch-dry-run",
+	})
+	if err != nil {
+		t.Fatalf("ParseArgs() error = %v", err)
+	}
+	if options.CandidateLimitPerSource == nil || *options.CandidateLimitPerSource != 12 {
+		t.Fatalf("ParseArgs(...).CandidateLimitPerSource = %v; want 12", options.CandidateLimitPerSource)
+	}
+	if options.AcceptedLimit == nil || *options.AcceptedLimit != 30 {
+		t.Fatalf("ParseArgs(...).AcceptedLimit = %v; want 30", options.AcceptedLimit)
+	}
+}
+
 func TestParseArgsSourcesFlagRejectsUnsupportedSource(t *testing.T) {
 	if _, err := ParseArgs([]string{"jobscout", "--sources", "rss,google"}); err == nil {
 		t.Fatal("ParseArgs(... --sources rss,google) error = nil; want error")
+	}
+}
+
+func TestParseArgsFetchLimitRejectsNegativeValue(t *testing.T) {
+	if _, err := ParseArgs([]string{"jobscout", "--accepted-limit=-1"}); err == nil {
+		t.Fatal("ParseArgs(... --accepted-limit=-1) error = nil; want error")
 	}
 }
 

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -26,6 +26,7 @@ func sessionFetchConfig(disableLLM bool, appCfg *AppConfig) *AppConfig {
 	}
 	cfgCopy := *appCfg
 	config.ApplyFetchSourceSelection(&cfgCopy, runtimeSourceSelection)
+	config.ApplyFetchLimitOverrides(&cfgCopy, runtimeCandidateLimitPerSource, runtimeAcceptedLimit)
 	if disableLLM {
 		cfgCopy.LLM.Enabled = false
 		cfgCopy.LLM.JobSearch = false
@@ -151,6 +152,7 @@ func previewFetchCmd(appCfg AppConfig, criteriaCfg *CriteriaConfig) tea.Cmd {
 		defer cancel()
 
 		config.ApplyFetchSourceSelection(&appCfg, runtimeSourceSelection)
+		config.ApplyFetchLimitOverrides(&appCfg, runtimeCandidateLimitPerSource, runtimeAcceptedLimit)
 		newJobs, summary, err := fetchAllJobs(ctx, &appCfg, criteriaCfg, nil, nil)
 		if err != nil {
 			return setupPreviewMsg{err: err}

--- a/internal/tuiapp/runtime.go
+++ b/internal/tuiapp/runtime.go
@@ -12,6 +12,8 @@ func ConfigureRuntime(options appruntime.Options, stores appruntime.Stores, buil
 	runtimeSQLitePath = options.Paths.SQLite
 	setRuntimeDebug(options.Debug, runtimeDebugPath)
 	runtimeSourceSelection = append([]string(nil), options.SourceSelection...)
+	runtimeCandidateLimitPerSource = cloneRuntimeIntPtr(options.CandidateLimitPerSource)
+	runtimeAcceptedLimit = cloneRuntimeIntPtr(options.AcceptedLimit)
 	runtimeBuildVersion = buildVersion
 	if stores.Jobs != nil {
 		runtimeJobStore = stores.Jobs
@@ -26,4 +28,12 @@ func ConfigureRuntime(options appruntime.Options, stores appruntime.Stores, buil
 
 func NewModel() tea.Model {
 	return initialModel()
+}
+
+func cloneRuntimeIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }

--- a/internal/tuiapp/runtime_state.go
+++ b/internal/tuiapp/runtime_state.go
@@ -23,6 +23,8 @@ var runtimeSQLitePath = sqliteFilePath
 var runtimeDebugEnabled bool
 var runtimeDebugPath = "debug.log"
 var runtimeSourceSelection []string
+var runtimeCandidateLimitPerSource *int
+var runtimeAcceptedLimit *int
 var runtimeBuildVersion = "dev"
 
 var defaultRuntimeStores = appruntime.InMemoryStores()


### PR DESCRIPTION
Summary:
- Add configurable fetch candidate and accepted-result limits so browser fetches stop after enough useful work.
- Capture debug page snapshots during browser fetches when debug mode is enabled.
- Document the new fetch limit behavior and debug-page output.

Notes:
- This is the next split PR after #30 and only includes the fetch limit/browser debugging commit.
