### PR TITLE
Add browser-based Indeed and company site enrichment

### DIFF
--- a/internal/fetcher/apply_page_enrichment.go
+++ b/internal/fetcher/apply_page_enrichment.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/wallentx/jobscout/internal/domain"
 )
 
@@ -18,6 +19,10 @@ func enrichJobFromApplyPageWithProfiles(ctx context.Context, job *Job, llmEnrich
 }
 
 func enrichJobFromApplyPageWithProfilesAndStats(ctx context.Context, job *Job, llmEnrich jobIdentityPageEnrichFunc, profileEnricher *sourceProfileEnricher, stats *acceptedEnrichmentStats) {
+	enrichJobFromApplyPageWithProfilesStatsAndBrowser(ctx, job, llmEnrich, profileEnricher, stats, nil)
+}
+
+func enrichJobFromApplyPageWithProfilesStatsAndBrowser(ctx context.Context, job *Job, llmEnrich jobIdentityPageEnrichFunc, profileEnricher *sourceProfileEnricher, stats *acceptedEnrichmentStats, browser *rod.Browser) {
 	if job == nil {
 		return
 	}
@@ -31,7 +36,7 @@ func enrichJobFromApplyPageWithProfilesAndStats(ctx context.Context, job *Job, l
 	sanitizeExistingJobIdentity(job)
 	setJobCompanyIfMissing(job, companyNameFromSummary(job.CompanySummary))
 	enrichJobIndustryFromExistingSummary(job)
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		if website := inferCompanyWebsiteFromApplyURL(*job); website != "" {
 			job.CompanyWebsite = website
 			setJobIdentityEvidence(job, "website", website, "apply_url_host", job.ApplyURL, "medium", false, "Website inferred from a first-party apply URL host.")
@@ -50,30 +55,177 @@ func enrichJobFromApplyPageWithProfilesAndStats(ctx context.Context, job *Job, l
 	if jobNeedsApplyPageEnrichment(*job) {
 		stats.inc(&stats.applyFetchAttempts)
 		logDebug("identity enrichment apply/source pages: fetching apply_url=%q company=%q title=%q", job.ApplyURL, job.Company, job.Title)
-		rawHTML, finalURL, err := fetchApplyPage(ctx, job.ApplyURL)
-		if err == nil && strings.TrimSpace(rawHTML) != "" {
-			stats.inc(&stats.applyFetchSuccess)
-			logDebug("identity enrichment apply/source pages: fetched apply_url=%q final_url=%q bytes=%d llm=%t", job.ApplyURL, finalURL, len(rawHTML), llmEnrich != nil)
-			enrichJobFromHTML(job, rawHTML, finalURL)
-			if profileURL := extractSourceCompanyProfileURL(rawHTML, finalURL); profileURL != "" {
-				enrichJobFromSourceCompanyProfile(ctx, job, profileURL, llmEnrich, "llm_source_profile", profileEnricher, stats)
-			}
-			if jobNeedsLLMIdentityEnrichment(*job) {
-				stats.addLLMUsage(applyLLMJobIdentityEnrichment(ctx, job, buildJobIdentityPage(rawHTML, finalURL), llmEnrich, "llm_apply_page"))
-			}
-		} else if err != nil {
-			stats.inc(&stats.applyFetchFailed)
-			if isBlockedFetchError(err) {
-				stats.inc(&stats.applyFetchBlocked)
-			}
-			logDebug("identity enrichment apply/source pages: fetch failed apply_url=%q error=%v", job.ApplyURL, err)
+		if isIndeedURL(job.ApplyURL) {
+			enrichAcceptedIndeedJobWithBrowser(ctx, browser, job, llmEnrich, stats)
 		} else {
-			stats.inc(&stats.applyFetchEmpty)
-			logDebug("identity enrichment apply/source pages: empty apply page apply_url=%q", job.ApplyURL)
+			enrichAcceptedJobWithStaticApplyPage(ctx, job, llmEnrich, profileEnricher, stats)
 		}
 	}
 
 	enrichJobFromCompanyWebsitePagesWithStats(ctx, job, llmEnrich, stats)
+}
+
+func enrichAcceptedJobWithStaticApplyPage(ctx context.Context, job *Job, llmEnrich jobIdentityPageEnrichFunc, profileEnricher *sourceProfileEnricher, stats *acceptedEnrichmentStats) {
+	if job == nil {
+		return
+	}
+	rawHTML, finalURL, err := fetchApplyPage(ctx, job.ApplyURL)
+	if err == nil && strings.TrimSpace(rawHTML) != "" {
+		stats.inc(&stats.applyFetchSuccess)
+		logDebug("identity enrichment apply/source pages: fetched apply_url=%q final_url=%q bytes=%d llm=%t", job.ApplyURL, finalURL, len(rawHTML), llmEnrich != nil)
+		enrichJobFromHTML(job, rawHTML, finalURL)
+		if profileURL := extractSourceCompanyProfileURL(rawHTML, finalURL); profileURL != "" {
+			enrichJobFromSourceCompanyProfile(ctx, job, profileURL, llmEnrich, "llm_source_profile", profileEnricher, stats)
+		}
+		if jobNeedsLLMIdentityEnrichment(*job) {
+			stats.addLLMUsage(applyLLMJobIdentityEnrichment(ctx, job, buildJobIdentityPage(rawHTML, finalURL), llmEnrich, "llm_apply_page"))
+		}
+	} else if err != nil {
+		stats.inc(&stats.applyFetchFailed)
+		if isBlockedFetchError(err) {
+			stats.inc(&stats.applyFetchBlocked)
+		}
+		logDebug("identity enrichment apply/source pages: fetch failed apply_url=%q error=%v", job.ApplyURL, err)
+	} else {
+		stats.inc(&stats.applyFetchEmpty)
+		logDebug("identity enrichment apply/source pages: empty apply page apply_url=%q", job.ApplyURL)
+	}
+}
+
+func enrichAcceptedIndeedJobWithBrowser(ctx context.Context, browser *rod.Browser, job *Job, llmEnrich jobIdentityPageEnrichFunc, stats *acceptedEnrichmentStats) {
+	if job == nil {
+		return
+	}
+	if browser == nil {
+		stats.inc(&stats.applyFetchFailed)
+		stats.inc(&stats.applyFetchBlocked)
+		logDebug("identity enrichment apply/source pages: skipped Indeed browser fetch apply_url=%q browser unavailable", job.ApplyURL)
+		return
+	}
+
+	pageText, links, err := extractBrowserPageContent(ctx, browser, job.ApplyURL)
+	if err != nil {
+		stats.inc(&stats.applyFetchFailed)
+		if isBlockedFetchError(err) {
+			stats.inc(&stats.applyFetchBlocked)
+		}
+		logDebug("identity enrichment apply/source pages: Indeed browser fetch failed apply_url=%q error=%v", job.ApplyURL, err)
+		return
+	}
+	if strings.TrimSpace(pageText) == "" {
+		stats.inc(&stats.applyFetchEmpty)
+		logDebug("identity enrichment apply/source pages: empty Indeed browser page apply_url=%q links=%d", job.ApplyURL, len(links))
+		return
+	}
+
+	stats.inc(&stats.applyFetchSuccess)
+	logDebug("identity enrichment apply/source pages: fetched Indeed apply_url=%q text_chars=%d links=%d llm=%t", job.ApplyURL, len(pageText), len(links), llmEnrich != nil)
+	enrichJobFromIndeedDetailText(job, pageText, job.ApplyURL)
+	enrichJobFromIndeedDetailLinks(job, links)
+	sanitizeExistingJobIdentity(job)
+	enrichAcceptedIndeedCompanyProfileWithBrowser(ctx, browser, job, llmEnrich, stats)
+	if jobNeedsLLMIdentityEnrichment(*job) {
+		stats.addLLMUsage(applyLLMJobIdentityEnrichment(ctx, job, buildJobIdentityPageFromBrowserText(pageText, links, job.ApplyURL), llmEnrich, "llm_indeed_detail"))
+	}
+}
+
+func enrichAcceptedIndeedCompanyProfileWithBrowser(ctx context.Context, browser *rod.Browser, job *Job, llmEnrich jobIdentityPageEnrichFunc, stats *acceptedEnrichmentStats) {
+	if job == nil || browser == nil || job.Metadata == nil || job.Metadata.Source == nil {
+		return
+	}
+	profileURL := strings.TrimSpace(job.Metadata.Source.CompanyProfileURL)
+	if profileURL == "" || publicProfileSource(profileURL) != "indeed" {
+		return
+	}
+
+	stats.inc(&stats.sourceProfileAttempts)
+	stats.inc(&stats.sourceProfileFetches)
+	logDebug("identity enrichment source profile: fetching Indeed profile_url=%q company=%q title=%q", profileURL, job.Company, job.Title)
+	pageText, links, err := extractBrowserPageContent(ctx, browser, profileURL)
+	if err != nil {
+		stats.inc(&stats.sourceProfileFailed)
+		if isBlockedFetchError(err) {
+			stats.inc(&stats.sourceProfileBlocked)
+		}
+		logDebug("identity enrichment source profile: Indeed browser fetch failed profile_url=%q error=%v", profileURL, err)
+		return
+	}
+	if strings.TrimSpace(pageText) == "" {
+		stats.inc(&stats.sourceProfileFailed)
+		logDebug("identity enrichment source profile: empty Indeed profile profile_url=%q links=%d", profileURL, len(links))
+		return
+	}
+
+	stats.inc(&stats.sourceProfileSuccess)
+	logDebug("identity enrichment source profile: fetched Indeed profile_url=%q text_chars=%d links=%d llm=%t", profileURL, len(pageText), len(links), llmEnrich != nil)
+	applyCompanyPublicProfileEvidence(job, companyPublicProfileEvidenceFromText("indeed", profileURL, job.Company, pageText), "indeed_profile")
+	if website := companyWebsiteFromProfileLinks(links, profileURL, job.Company); website != "" && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+		job.CompanyWebsite = website
+		setJobIdentityEvidence(job, "website", website, "indeed_company_profile", profileURL, "high", false, "Website extracted from Indeed company profile links.")
+	}
+	if jobNeedsLLMIdentityEnrichment(*job) {
+		stats.addLLMUsage(applyLLMJobIdentityEnrichment(ctx, job, buildJobIdentityPageFromBrowserText(pageText, links, profileURL), llmEnrich, "llm_indeed_profile"))
+	}
+}
+
+func buildJobIdentityPageFromBrowserText(pageText string, links []pageLink, pageURL string) JobIdentityPage {
+	text := strings.TrimSpace(pageText)
+	if len(links) > 0 {
+		linkText := make([]string, 0, min(len(links), 80))
+		for _, link := range links {
+			if strings.TrimSpace(link.URL) == "" {
+				continue
+			}
+			if strings.TrimSpace(link.Text) != "" {
+				linkText = append(linkText, strings.TrimSpace(link.Text)+" - "+strings.TrimSpace(link.URL))
+			} else {
+				linkText = append(linkText, strings.TrimSpace(link.URL))
+			}
+			if len(linkText) >= 80 {
+				break
+			}
+		}
+		if len(linkText) > 0 {
+			text += "\n\nLinks:\n- " + strings.Join(linkText, "\n- ")
+		}
+	}
+	return JobIdentityPage{
+		URL:  pageURL,
+		Text: text,
+	}
+}
+
+func acceptedJobEnrichmentBrowser(jobs []Job) (*rod.Browser, func()) {
+	if !acceptedJobsNeedBrowserEnrichment(jobs) {
+		return nil, nil
+	}
+	if FindSiteSearchBrowserBinary() == "" {
+		logDebug("identity enrichment apply/source pages: skipped accepted-job browser; browser unavailable")
+		return nil, nil
+	}
+
+	browser, cleanup, err := NewSiteSearchBrowser()
+	if err != nil {
+		logDebug("identity enrichment apply/source pages: accepted-job browser launch failed: %v", err)
+		return nil, nil
+	}
+	logDebug("identity enrichment apply/source pages: accepted-job browser started")
+	return browser, func() {
+		cleanup()
+		logDebug("identity enrichment apply/source pages: accepted-job browser cleanup complete")
+	}
+}
+
+func acceptedJobsNeedBrowserEnrichment(jobs []Job) bool {
+	for _, job := range jobs {
+		if isIndeedURL(job.ApplyURL) && jobNeedsApplyPageEnrichment(job) {
+			return true
+		}
+		if jobNeedsBrowserCompanySearch(job) {
+			return true
+		}
+	}
+	return false
 }
 
 func enrichJobFromBuiltInCompanyProfile(ctx context.Context, job *Job, llmEnrich jobIdentityPageEnrichFunc, profileEnricher *sourceProfileEnricher, stats *acceptedEnrichmentStats) {
@@ -124,6 +276,10 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 	cache := NewCompanyIdentityCache()
 	stats.addCopiedFields(seedCompanyIdentityFromTrustedJobs(jobs, cache))
 	profileEnricher := currentSourceProfileRun()
+	browser, cleanupBrowser := acceptedJobEnrichmentBrowser(jobs)
+	if cleanupBrowser != nil {
+		defer cleanupBrowser()
+	}
 	for i := range jobs {
 		wg.Add(1)
 		go func(idx int) {
@@ -143,7 +299,7 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 				stats.inc(&stats.localCacheHits)
 				ApplyCachedIdentity(&jobs[idx], record)
 			}
-			enrichJobFromApplyPageWithProfilesAndStats(ctx, &jobs[idx], llmEnrich, profileEnricher, stats)
+			enrichJobFromApplyPageWithProfilesStatsAndBrowser(ctx, &jobs[idx], llmEnrich, profileEnricher, stats, browser)
 			if cache.IsIdentityComplete(jobs[idx]) {
 				cache.Set(jobs[idx].Company, CompanyIdentityRecord{
 					Website:  jobs[idx].CompanyWebsite,
@@ -166,10 +322,19 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 		}(i)
 	}
 	wg.Wait()
-	logDebug("browser company search: disabled during accepted-job enrichment; leaving unresolved identity fields for source-specific repair")
-	stats.addCopiedFields(propagateSameCompanyIdentity(jobs))
+	browserSearchChanged := enrichJobsFromBrowserCompanySearch(ctx, jobs, browser, llmEnrich, stats, progress)
+	copiedFields := propagateSameCompanyIdentity(jobs)
+	stats.addCopiedFields(copiedFields)
 	for i := range jobs {
 		backfillJobIdentityEvidence(&jobs[i], jobs[i].Source, jobs[i].ApplyURL)
+	}
+	if browserSearchChanged > 0 || copiedFields > 0 {
+		for i := range jobs {
+			persistCompanyIdentityToStore(ctx, jobs[i], identityStore, stats)
+			if onJobEnriched != nil {
+				onJobEnriched(jobs[i])
+			}
+		}
 	}
 	elapsed := time.Since(start).Round(time.Millisecond).String()
 	stats.log(elapsed)
@@ -177,6 +342,45 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 	logDebug("url visit registry summary: fetches=%d hits=%d html_entries=%d probe_entries=%d", fetches, hits, htmlEntries, probeEntries)
 	logJobIdentityBatchSummary("apply/source pages", jobs, elapsed)
 	return jobs
+}
+
+func enrichJobsFromBrowserCompanySearch(ctx context.Context, jobs []Job, browser *rod.Browser, llmEnrich jobIdentityPageEnrichFunc, stats *acceptedEnrichmentStats, progress func(string)) int {
+	targets := browserCompanySearchTargets(jobs)
+	if len(targets) == 0 {
+		logDebug("browser company search: skipped during accepted-job enrichment; no unresolved company websites")
+		return 0
+	}
+	if browser == nil {
+		logDebug("browser company search: skipped during accepted-job enrichment; browser unavailable targets=%d", len(targets))
+		return 0
+	}
+
+	logDebug("browser company search: start accepted-job enrichment targets=%d", len(targets))
+	reportFetchProgress(progress, "Searching company sites for %d unresolved companies...", len(targets))
+	changed := 0
+	for _, target := range targets {
+		if ctx.Err() != nil {
+			break
+		}
+		stats.inc(&stats.browserCompanySearchTargets)
+		profile := discoverCompanySiteProfile(ctx, browser, target.Company)
+		if profile == nil || strings.TrimSpace(profile.WebsiteURL) == "" {
+			stats.inc(&stats.browserCompanySearchFailed)
+			logDebug("browser company search: no company site found company=%q indexes=%d", target.Company, len(target.Indexes))
+			continue
+		}
+		stats.inc(&stats.browserCompanySearchSuccess)
+		logDebug("browser company search: found company=%q website=%q indexes=%d", target.Company, profile.WebsiteURL, len(target.Indexes))
+		for _, idx := range target.Indexes {
+			before := debugJobIdentitySnapshot(jobs[idx])
+			applyBrowserCompanySiteProfile(ctx, &jobs[idx], profile, llmEnrich)
+			if debugJobIdentitySnapshot(jobs[idx]) != before {
+				changed++
+			}
+		}
+	}
+	logDebug("browser company search: complete accepted-job enrichment targets=%d changed_jobs=%d", len(targets), changed)
+	return changed
 }
 
 func hydrateCompanyIdentityFromStore(ctx context.Context, job *Job, identityStore PersistentCompanyIdentityStore, stats *acceptedEnrichmentStats) (CompanyIdentityRecord, bool) {
@@ -291,7 +495,7 @@ func enrichJobFromApplyPageForValidationWithProfiles(ctx context.Context, job *J
 	sanitizeExistingJobIdentity(job)
 	setJobCompanyIfMissing(job, companyNameFromSummary(job.CompanySummary))
 	enrichJobIndustryFromExistingSummary(job)
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		if website := inferCompanyWebsiteFromApplyURL(*job); website != "" {
 			job.CompanyWebsite = website
 			setJobIdentityEvidence(job, "website", website, "apply_url_host", job.ApplyURL, "medium", false, "Website inferred from a first-party apply URL host.")

--- a/internal/fetcher/apply_page_enrichment.go
+++ b/internal/fetcher/apply_page_enrichment.go
@@ -2,6 +2,7 @@ package fetcher
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"time"
@@ -98,7 +99,6 @@ func enrichAcceptedIndeedJobWithBrowser(ctx context.Context, browser *rod.Browse
 	}
 	if browser == nil {
 		stats.inc(&stats.applyFetchFailed)
-		stats.inc(&stats.applyFetchBlocked)
 		logDebug("identity enrichment apply/source pages: skipped Indeed browser fetch apply_url=%q browser unavailable", job.ApplyURL)
 		return
 	}
@@ -322,6 +322,10 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 		}(i)
 	}
 	wg.Wait()
+	beforePostProcessing := make([]jobIdentityPersistenceSnapshot, len(jobs))
+	for i := range jobs {
+		beforePostProcessing[i] = captureJobIdentityPersistenceSnapshot(jobs[i])
+	}
 	browserSearchChanged := enrichJobsFromBrowserCompanySearch(ctx, jobs, browser, llmEnrich, stats, progress)
 	copiedFields := propagateSameCompanyIdentity(jobs)
 	stats.addCopiedFields(copiedFields)
@@ -330,6 +334,9 @@ func enrichJobsFromApplyPagesWithLLMStoreAndProgress(ctx context.Context, jobs [
 	}
 	if browserSearchChanged > 0 || copiedFields > 0 {
 		for i := range jobs {
+			if beforePostProcessing[i] == captureJobIdentityPersistenceSnapshot(jobs[i]) {
+				continue
+			}
 			persistCompanyIdentityToStore(ctx, jobs[i], identityStore, stats)
 			if onJobEnriched != nil {
 				onJobEnriched(jobs[i])
@@ -381,6 +388,37 @@ func enrichJobsFromBrowserCompanySearch(ctx context.Context, jobs []Job, browser
 	}
 	logDebug("browser company search: complete accepted-job enrichment targets=%d changed_jobs=%d", len(targets), changed)
 	return changed
+}
+
+type jobIdentityPersistenceSnapshot struct {
+	Company  string
+	Website  string
+	Summary  string
+	Industry string
+	Identity string
+	Metadata string
+}
+
+func captureJobIdentityPersistenceSnapshot(job Job) jobIdentityPersistenceSnapshot {
+	return jobIdentityPersistenceSnapshot{
+		Company:  strings.TrimSpace(job.Company),
+		Website:  strings.TrimSpace(job.CompanyWebsite),
+		Summary:  strings.TrimSpace(job.CompanySummary),
+		Industry: strings.TrimSpace(job.CompanyIndustry),
+		Identity: stableJobIdentityJSON(CloneJobIdentityMetadata(job.CompanyIdentity)),
+		Metadata: stableJobIdentityJSON(domain.CloneJobMetadata(job.Metadata)),
+	}
+}
+
+func stableJobIdentityJSON(value any) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func hydrateCompanyIdentityFromStore(ctx context.Context, job *Job, identityStore PersistentCompanyIdentityStore, stats *acceptedEnrichmentStats) (CompanyIdentityRecord, bool) {

--- a/internal/fetcher/company_identity_browser.go
+++ b/internal/fetcher/company_identity_browser.go
@@ -48,7 +48,7 @@ func browserCompanySearchKey(company string) string {
 
 func jobNeedsBrowserCompanySearch(job Job) bool {
 	company := strings.TrimSpace(job.Company)
-	return company != "" && !strings.EqualFold(company, "Unknown") && !isKnownNonJobApplyURL(job.ApplyURL) && jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite)
+	return company != "" && !strings.EqualFold(company, "Unknown") && !isKnownNonJobApplyURL(job.ApplyURL) && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite)
 }
 
 func applyBrowserCompanySiteProfile(ctx context.Context, job *Job, profile *domain.CompanySiteProfile, llmEnrich jobIdentityPageEnrichFunc) {
@@ -62,7 +62,7 @@ func applyBrowserCompanySiteProfile(ctx context.Context, job *Job, profile *doma
 	}()
 
 	evidenceURL := firstNonEmptyString(profile.SearchURL, profile.WebsiteURL)
-	if website := normalizeCompanyWebsiteURL(profile.WebsiteURL); website != "" && jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if website := normalizeCompanyWebsiteURL(profile.WebsiteURL); website != "" && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		job.CompanyWebsite = website
 		setJobIdentityEvidence(job, "website", website, "browser_company_search", evidenceURL, "medium", false, "Website discovered from a browser search for the company.")
 	}

--- a/internal/fetcher/company_identity_cache.go
+++ b/internal/fetcher/company_identity_cache.go
@@ -57,8 +57,8 @@ func (c *CompanyIdentityCache) Set(company string, record CompanyIdentityRecord)
 }
 
 func (c *CompanyIdentityCache) IsIdentityComplete(job Job) bool {
-	return !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
-		!jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
+	return !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
+		!domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
 }
 
 func companyIdentityCacheKey(company string) string {
@@ -89,12 +89,12 @@ func ApplyCachedIdentity(job *Job, record CompanyIdentityRecord) {
 	if job == nil {
 		return
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" && trustedRecordEvidence(record.Identity, "website", record.Website) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" && trustedRecordEvidence(record.Identity, "website", record.Website) {
 		job.CompanyWebsite = record.Website
 		setCachedIdentityEvidence(job, "website", record.Website, copiedEvidence(record.Identity, "website"))
 	}
 
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && record.Summary != "" && trustedRecordEvidence(record.Identity, "summary", record.Summary) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && record.Summary != "" && trustedRecordEvidence(record.Identity, "summary", record.Summary) {
 		job.CompanySummary = record.Summary
 		setCachedIdentityEvidence(job, "summary", record.Summary, copiedEvidence(record.Identity, "summary"))
 	}
@@ -193,13 +193,13 @@ func trustedIdentityRecordFromJob(job Job) (CompanyIdentityRecord, int, int, int
 	websiteRank := 0
 	summaryRank := 0
 	industryRank := 0
-	if !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && trustedIdentityEvidence(job.CompanyIdentity, "website", job.CompanyWebsite) {
+	if !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && trustedIdentityEvidence(job.CompanyIdentity, "website", job.CompanyWebsite) {
 		record.Website = job.CompanyWebsite
 		w := *job.CompanyIdentity.Website
 		identity.Website = &w
 		websiteRank = identityEvidenceRank(&w)
 	}
-	if !jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && trustedIdentityEvidence(job.CompanyIdentity, "summary", job.CompanySummary) {
+	if !domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && trustedIdentityEvidence(job.CompanyIdentity, "summary", job.CompanySummary) {
 		record.Summary = job.CompanySummary
 		s := *job.CompanyIdentity.Summary
 		identity.Summary = &s
@@ -300,12 +300,12 @@ func applySameCompanyIdentity(job *Job, record CompanyIdentityRecord) int {
 		return 0
 	}
 	copied := 0
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" {
 		job.CompanyWebsite = record.Website
 		setCopiedSameCompanyEvidence(job, "website", record.Website, copiedEvidence(record.Identity, "website"))
 		copied++
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && record.Summary != "" {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && record.Summary != "" {
 		job.CompanySummary = record.Summary
 		setCopiedSameCompanyEvidence(job, "summary", record.Summary, copiedEvidence(record.Identity, "summary"))
 		copied++

--- a/internal/fetcher/company_identity_extract.go
+++ b/internal/fetcher/company_identity_extract.go
@@ -12,7 +12,7 @@ import (
 )
 
 func enrichJobIndustryFromExistingSummary(job *Job) {
-	if job == nil || strings.TrimSpace(job.CompanyIndustry) != "" || jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if job == nil || strings.TrimSpace(job.CompanyIndustry) != "" || domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		return
 	}
 	industry := inferCompanyIndustry(job.CompanySummary)
@@ -89,7 +89,7 @@ func enrichJobFromCompanySiteHTML(job *Job, rawHTML string, pageURL string, sour
 	if job == nil || strings.TrimSpace(rawHTML) == "" {
 		return
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		if summary := extractCompanyProfileSummary(rawHTML, job.Company); summary != "" {
 			job.CompanySummary = summary
 			setJobIdentityEvidence(job, "summary", summary, source, pageURL, "high", false, "Company summary extracted from company site.")
@@ -114,7 +114,7 @@ func enrichJobFromCompanySiteText(ctx context.Context, job *Job, text string, pa
 	if llmEnrich != nil {
 		applyLLMJobIdentityEnrichment(ctx, job, page, llmEnrich, "llm_"+source)
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && looksLikeCompanySummary(text, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && looksLikeCompanySummary(text, job.Company) {
 		summary := truncateAtSentence(text, 420)
 		job.CompanySummary = summary
 		setJobIdentityEvidence(job, "summary", summary, source, pageURL, "medium", false, "Company summary extracted from company site text.")
@@ -148,18 +148,18 @@ func enrichJobFromHTML(job *Job, rawHTML string, pageURL string) {
 	}
 	enrichJobFromStructuredJobPosting(job, rawHTML, pageURL)
 	enrichJobFromKnownJobBoardHTML(job, rawHTML, pageURL)
-	if jobCompensationMissing(job.Compensation) {
+	if domain.JobCompensationMissing(job.Compensation) {
 		if compensation := extractCompensationFromHTML(rawHTML); compensation != "" {
 			job.Compensation = compensation
 		}
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		if website := extractCompanyWebsiteFromHTML(rawHTML, pageURL, job.Company); website != "" {
 			job.CompanyWebsite = website
 			setJobIdentityEvidence(job, "website", website, "apply_page", pageURL, "medium", false, "Website extracted from apply page HTML.")
 		}
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		if summary := extractCompanySummaryFromHTML(rawHTML, job.Company); summary != "" {
 			job.CompanySummary = summary
 			setJobIdentityEvidence(job, "summary", summary, "apply_page", pageURL, "medium", false, "Company summary extracted from apply page HTML.")
@@ -188,15 +188,15 @@ func jobNeedsApplyPageEnrichment(job Job) bool {
 	}
 	return jobHasSourceCompanyProfile(job.ApplyURL) ||
 		jobCompanyMissingOrUnknown(job.Company) ||
-		jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
-		jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
+		domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
+		domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
 		jobCompanyIndustryNeedsEnrichment(job) ||
-		jobCompensationMissing(job.Compensation)
+		domain.JobCompensationMissing(job.Compensation)
 }
 
 func jobNeedsLLMIdentityEnrichment(job Job) bool {
-	return jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
-		jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
+	return domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) ||
+		domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) ||
 		jobCompanyIndustryNeedsEnrichment(job)
 }
 
@@ -204,8 +204,8 @@ func jobNeedsCompanyPageEnrichment(job Job) bool {
 	if isKnownNonJobApplyURL(job.ApplyURL) {
 		return false
 	}
-	return !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
-		(jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) || jobCompanyIndustryNeedsEnrichment(job))
+	return !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
+		(domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) || jobCompanyIndustryNeedsEnrichment(job))
 }
 
 func jobCompanyIndustryNeedsEnrichment(job Job) bool {

--- a/internal/fetcher/company_public_profile.go
+++ b/internal/fetcher/company_public_profile.go
@@ -134,7 +134,7 @@ func jobNeedsPublicProfileIndustry(job Job) bool {
 		strings.TrimSpace(job.Company) != "" &&
 		!strings.EqualFold(strings.TrimSpace(job.Company), "Unknown") &&
 		!isKnownNonJobApplyURL(job.ApplyURL) &&
-		!jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
+		!domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) &&
 		jobCompanyIndustryNeedsEnrichment(job)
 }
 
@@ -171,10 +171,6 @@ func discoverPublicProfileIndustry(ctx context.Context, job Job) *publicProfileI
 		logDebug("public profile industry: query candidates company=%q query=%q candidates=%d final_url=%q", job.Company, query, len(candidates), finalURL)
 		profileFetches := 0
 		for _, candidate := range candidates {
-			if industry := extractPublicProfileIndustryFromText(candidate.Snippet); industry != "" {
-				logDebug("public profile industry: snippet hit company=%q source=%q industry=%q url=%q", job.Company, candidate.Source, industry, candidate.URL)
-				return &publicProfileIndustryResult{Industry: industry, Source: candidate.Source, URL: candidate.URL}
-			}
 			if profileFetches >= 1 {
 				continue
 			}

--- a/internal/fetcher/company_public_profile_test.go
+++ b/internal/fetcher/company_public_profile_test.go
@@ -94,40 +94,6 @@ func TestCompanyPublicProfileEvidenceFromTextExtractsGlassdoorReviewMetrics(t *t
 	}
 }
 
-func TestEnrichJobsFromPublicProfileIndustryUsesSearchSnippet(t *testing.T) {
-	searchServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`
-<html><body>
-  <a href="https://www.linkedin.com/company/acme/">Acme | LinkedIn</a>
-  <span>Industry Software Development Company size 51-200 employees Headquarters Austin, Texas</span>
-</body></html>`))
-	}))
-	defer searchServer.Close()
-
-	restorePublicProfileTestHooks()
-	publicProfileSearchURLFunc = func(query string) string {
-		return searchServer.URL + "/search?q=" + url.QueryEscape(query)
-	}
-	fetchPublicProfileHTML = fetchApplyPage
-	defer restorePublicProfileTestHooks()
-
-	jobs := []Job{{
-		Company:        "Acme",
-		CompanyWebsite: "https://www.acme.com",
-		ApplyURL:       "https://jobs.acme.com/staff-platform-engineer",
-		Status:         "Unopened",
-	}}
-
-	jobs = enrichJobsFromPublicProfileIndustryWithProgress(context.Background(), jobs, nil)
-
-	if jobs[0].CompanyIndustry != "Software Development" {
-		t.Fatalf("CompanyIndustry = %q; want Software Development", jobs[0].CompanyIndustry)
-	}
-	if jobs[0].CompanyIdentity == nil || jobs[0].CompanyIdentity.Industry == nil || jobs[0].CompanyIdentity.Industry.Source != "public_profile_linkedin" {
-		t.Fatalf("CompanyIdentity.Industry = %#v; want public_profile_linkedin evidence", jobs[0].CompanyIdentity)
-	}
-}
-
 func TestEnrichJobsFromPublicProfileIndustryFetchesProfilePage(t *testing.T) {
 	profileHTML := `
 <html><body>

--- a/internal/fetcher/enrichment_stats.go
+++ b/internal/fetcher/enrichment_stats.go
@@ -45,6 +45,10 @@ type acceptedEnrichmentStats struct {
 	companyAboutBlocked     int
 	companyAboutEmpty       int
 
+	browserCompanySearchTargets int
+	browserCompanySearchSuccess int
+	browserCompanySearchFailed  int
+
 	llmIdentityCalls int
 	llmInputTokens   int
 	llmOutputTokens  int
@@ -103,7 +107,7 @@ func (s *acceptedEnrichmentStats) log(duration string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	logDebug(
-		"identity enrichment accepted stats: jobs=%d description_checks=%d local_cache_hits=%d persistent_cache hits=%d misses=%d failed=%d writes=%d write_failed=%d apply_fetches=%d/%d failed=%d blocked=%d empty=%d source_profiles attempts=%d cache_hits=%d fetches=%d success=%d failed=%d blocked=%d skipped=%d company_homepage attempts=%d success=%d failed=%d blocked=%d empty=%d company_about attempts=%d success=%d failed=%d blocked=%d empty=%d llm_identity_calls=%d token_usage=%s same_company_copied_fields=%d duration=%s",
+		"identity enrichment accepted stats: jobs=%d description_checks=%d local_cache_hits=%d persistent_cache hits=%d misses=%d failed=%d writes=%d write_failed=%d apply_fetches=%d/%d failed=%d blocked=%d empty=%d source_profiles attempts=%d cache_hits=%d fetches=%d success=%d failed=%d blocked=%d skipped=%d company_homepage attempts=%d success=%d failed=%d blocked=%d empty=%d company_about attempts=%d success=%d failed=%d blocked=%d empty=%d browser_company_search targets=%d success=%d failed=%d llm_identity_calls=%d token_usage=%s same_company_copied_fields=%d duration=%s",
 		s.jobs,
 		s.descriptionChecks,
 		s.localCacheHits,
@@ -134,6 +138,9 @@ func (s *acceptedEnrichmentStats) log(duration string) {
 		s.companyAboutFailed,
 		s.companyAboutBlocked,
 		s.companyAboutEmpty,
+		s.browserCompanySearchTargets,
+		s.browserCompanySearchSuccess,
+		s.browserCompanySearchFailed,
 		s.llmIdentityCalls,
 		formatAcceptedEnrichmentTokenUsageLocked(s),
 		s.sameCompanyCopiedFields,

--- a/internal/fetcher/identity_debug.go
+++ b/internal/fetcher/identity_debug.go
@@ -3,6 +3,8 @@ package fetcher
 import (
 	"strconv"
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 type jobIdentityDebugSnapshot struct {
@@ -95,10 +97,10 @@ func debugMissingIdentityFields(job Job) []string {
 	if jobCompanyMissingOrUnknown(job.Company) {
 		missing = append(missing, "company")
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		missing = append(missing, "website")
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		missing = append(missing, "summary")
 	}
 	if jobCompanyIndustryNeedsEnrichment(job) {
@@ -116,10 +118,10 @@ func logJobIdentityBatchSummary(stage string, jobs []Job, elapsed string) {
 		if jobCompanyMissingOrUnknown(job.Company) {
 			missingCompany++
 		}
-		if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+		if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 			missingWebsite++
 		}
-		if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+		if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 			missingSummary++
 		}
 		if jobCompanyIndustryNeedsEnrichment(job) {

--- a/internal/fetcher/job_board_identity.go
+++ b/internal/fetcher/job_board_identity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func enrichJobFromKnownJobBoardHTML(job *Job, rawHTML string, pageURL string) {
@@ -36,7 +37,7 @@ func enrichJobFromBuiltInJobHTML(job *Job, rawHTML string, pageURL string) {
 	}
 	applyURL = strings.TrimSpace(html.UnescapeString(applyURL))
 	job.EnsureSourceMetadata().ExternalApplyURL = applyURL
-	if !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		return
 	}
 	website := normalizeCompanyWebsiteURL(applyURL)
@@ -61,13 +62,13 @@ func isBuiltInJobURL(rawURL string) bool {
 func enrichJobFromYCombinatorJobHTML(job *Job, rawHTML string, pageURL string) {
 	company := extractYCombinatorCompanyName(rawHTML, pageURL)
 	setJobCompanyIfMissing(job, company)
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		if summary := extractYCombinatorCompanySummary(rawHTML, job.Company); summary != "" {
 			job.CompanySummary = summary
 			setJobIdentityEvidence(job, "summary", summary, "ycombinator_job_page", pageURL, "high", false, "Company summary extracted from Y Combinator job page.")
 		}
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		if website := extractYCombinatorCompanyWebsite(rawHTML, pageURL, job.Company); website != "" {
 			job.CompanyWebsite = website
 			setJobIdentityEvidence(job, "website", website, "ycombinator_job_page", pageURL, "high", false, "Company website extracted from Y Combinator job page.")
@@ -90,7 +91,7 @@ func enrichJobFromGreenhouseJobHTML(job *Job, rawHTML string, pageURL string) {
 		setJobCompanyIfMissing(job, company)
 	}
 	setJobCompanyIfMissing(job, companyNameFromGreenhouseURL(pageURL))
-	if !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		return
 	}
 	if logo == nil || logo.Length() == 0 {

--- a/internal/fetcher/job_description_enrichment.go
+++ b/internal/fetcher/job_description_enrichment.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func enrichJobFromDescription(job *Job) {
@@ -12,13 +14,13 @@ func enrichJobFromDescription(job *Job) {
 	if directApplyURL := extractDirectApplyURLFromHTML(job.Description, job.ApplyURL); directApplyURL != "" {
 		job.ApplyURL = directApplyURL
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		if website := extractCompanyWebsiteFromHTML(job.Description, originalApplyURL, job.Company); website != "" {
 			job.CompanyWebsite = website
 			setJobIdentityEvidence(job, "website", website, "job_description", originalApplyURL, "medium", false, "Website extracted from job description HTML.")
 		}
 	}
-	if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+	if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 		if summary := extractCompanySummaryFromHTML(job.Description, job.Company); summary != "" {
 			job.CompanySummary = summary
 			setJobIdentityEvidence(job, "summary", summary, "job_description", originalApplyURL, "medium", false, "Company summary extracted from job description HTML.")
@@ -33,7 +35,7 @@ func enrichJobFromDescription(job *Job) {
 		job.CompanyIndustry = summaryIndustry
 		setJobIdentityEvidence(job, "industry", summaryIndustry, "company_summary_inference", originalApplyURL, "low", true, "Industry inferred from company summary text.")
 	}
-	if compensation := extractCompensationFromHTML(job.Description); jobCompensationMissing(job.Compensation) && compensation != "" {
+	if compensation := extractCompensationFromHTML(job.Description); domain.JobCompensationMissing(job.Compensation) && compensation != "" {
 		job.Compensation = compensation
 	}
 }

--- a/internal/fetcher/job_identity_evidence.go
+++ b/internal/fetcher/job_identity_evidence.go
@@ -133,7 +133,7 @@ func shouldPreferApplyURLCompanyWebsite(job Job, inferred string) bool {
 	if strings.TrimSpace(inferred) == "" || strings.EqualFold(strings.TrimSpace(job.CompanyWebsite), inferred) {
 		return false
 	}
-	if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 		return true
 	}
 	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil {
@@ -141,28 +141,4 @@ func shouldPreferApplyURLCompanyWebsite(job Job, inferred string) bool {
 	}
 	source := strings.ToLower(strings.TrimSpace(job.CompanyIdentity.Website.Source))
 	return job.CompanyIdentity.Website.Provisional || source == "browser_company_search" || source == "source_payload"
-}
-
-func jobCompanyWebsiteMissingOrInvalid(website string) bool {
-	return domain.JobCompanyWebsiteMissingOrInvalid(website)
-}
-
-func JobCompanyWebsiteMissingOrInvalid(website string) bool {
-	return jobCompanyWebsiteMissingOrInvalid(website)
-}
-
-func jobCompanySummaryMissingOrInvalid(summary string, company string) bool {
-	return domain.JobCompanySummaryMissingOrInvalid(summary, company)
-}
-
-func JobCompanySummaryMissingOrInvalid(summary string, company string) bool {
-	return jobCompanySummaryMissingOrInvalid(summary, company)
-}
-
-func jobCompensationMissing(compensation string) bool {
-	return domain.JobCompensationMissing(compensation)
-}
-
-func JobCompensationMissing(compensation string) bool {
-	return jobCompensationMissing(compensation)
 }

--- a/internal/fetcher/job_identity_llm.go
+++ b/internal/fetcher/job_identity_llm.go
@@ -3,6 +3,8 @@ package fetcher
 import (
 	"context"
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 type jobIdentityPageEnrichFunc func(ctx context.Context, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error)
@@ -43,19 +45,19 @@ func applyLLMJobIdentityEnrichment(ctx context.Context, job *Job, page JobIdenti
 	if job == nil || llmEnrich == nil || strings.TrimSpace(page.Text) == "" || !jobNeedsLLMIdentityEnrichment(*job) {
 		return LLMTokenUsage{}
 	}
-	hadIdentityAnchor := !jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) || !jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
+	hadIdentityAnchor := !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) || !domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company)
 	result, usage, err := llmEnrich(ctx, *job, page)
 	if err != nil || result == nil {
 		return usage
 	}
 	acceptedIdentityAnchor := false
-	if website := strings.TrimSpace(result.CompanyWebsite); website != "" && jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && looksLikeCompanyWebsite(website, page.URL) {
+	if website := strings.TrimSpace(result.CompanyWebsite); website != "" && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && looksLikeCompanyWebsite(website, page.URL) {
 		website = normalizeCompanyWebsiteURL(website)
 		job.CompanyWebsite = website
 		setJobIdentityEvidence(job, "website", website, source, page.URL, confidenceOrDefault(result.WebsiteConfidence, "medium"), false, firstNonEmptyString(result.CompanyWebsiteReason, "Website extracted by LLM from supplied page text."))
 		acceptedIdentityAnchor = true
 	}
-	if summary := strings.TrimSpace(result.CompanySummary); summary != "" && jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && looksLikeCompanySummary(summary, job.Company) {
+	if summary := strings.TrimSpace(result.CompanySummary); summary != "" && domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) && looksLikeCompanySummary(summary, job.Company) {
 		job.CompanySummary = summary
 		setJobIdentityEvidence(job, "summary", summary, source, page.URL, confidenceOrDefault(result.SummaryConfidence, "medium"), false, firstNonEmptyString(result.CompanySummaryReason, "Company summary extracted by LLM from supplied page text."))
 		acceptedIdentityAnchor = true

--- a/internal/fetcher/linkedin_typeahead.go
+++ b/internal/fetcher/linkedin_typeahead.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -32,6 +33,13 @@ type linkedInTypeaheadCacheEntry struct {
 }
 
 type linkedInTypeaheadCache map[string]linkedInTypeaheadCacheEntry
+
+var linkedInTypeaheadMemoryCache = struct {
+	sync.Mutex
+	path   string
+	loaded bool
+	cache  linkedInTypeaheadCache
+}{}
 
 func refreshLinkedInCriteriaHints(ctx context.Context, criteria *CriteriaConfig) error {
 	if criteria == nil {
@@ -127,38 +135,75 @@ func saveLinkedInTypeaheadCacheEntry(kind string, query string, hit linkedInType
 }
 
 func loadLinkedInTypeaheadCache() (linkedInTypeaheadCache, error) {
-	if strings.TrimSpace(runtimeLinkedInTypeaheadCachePath) == "" {
+	cachePath := strings.TrimSpace(runtimeLinkedInTypeaheadCachePath)
+	if cachePath == "" {
 		return linkedInTypeaheadCache{}, nil
 	}
-	data, err := os.ReadFile(runtimeLinkedInTypeaheadCachePath)
+
+	linkedInTypeaheadMemoryCache.Lock()
+	if linkedInTypeaheadMemoryCache.loaded && linkedInTypeaheadMemoryCache.path == cachePath {
+		cache := cloneLinkedInTypeaheadCache(linkedInTypeaheadMemoryCache.cache)
+		linkedInTypeaheadMemoryCache.Unlock()
+		return cache, nil
+	}
+	linkedInTypeaheadMemoryCache.Unlock()
+
+	data, err := os.ReadFile(cachePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return linkedInTypeaheadCache{}, nil
+			cache := linkedInTypeaheadCache{}
+			storeLinkedInTypeaheadMemoryCache(cachePath, cache)
+			return cache, nil
 		}
 		return nil, err
 	}
 	var cache linkedInTypeaheadCache
 	if err := json.Unmarshal(data, &cache); err != nil {
-		return linkedInTypeaheadCache{}, nil
+		cache = linkedInTypeaheadCache{}
 	}
 	if cache == nil {
 		cache = linkedInTypeaheadCache{}
 	}
+	storeLinkedInTypeaheadMemoryCache(cachePath, cache)
 	return cache, nil
 }
 
 func saveLinkedInTypeaheadCache(cache linkedInTypeaheadCache) error {
-	if strings.TrimSpace(runtimeLinkedInTypeaheadCachePath) == "" {
+	cachePath := strings.TrimSpace(runtimeLinkedInTypeaheadCachePath)
+	if cachePath == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(runtimeLinkedInTypeaheadCachePath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(runtimeLinkedInTypeaheadCachePath, data, 0600)
+	if err := os.WriteFile(cachePath, data, 0600); err != nil {
+		return err
+	}
+	storeLinkedInTypeaheadMemoryCache(cachePath, cache)
+	return nil
+}
+
+func storeLinkedInTypeaheadMemoryCache(cachePath string, cache linkedInTypeaheadCache) {
+	linkedInTypeaheadMemoryCache.Lock()
+	linkedInTypeaheadMemoryCache.path = cachePath
+	linkedInTypeaheadMemoryCache.loaded = true
+	linkedInTypeaheadMemoryCache.cache = cloneLinkedInTypeaheadCache(cache)
+	linkedInTypeaheadMemoryCache.Unlock()
+}
+
+func cloneLinkedInTypeaheadCache(cache linkedInTypeaheadCache) linkedInTypeaheadCache {
+	if cache == nil {
+		return linkedInTypeaheadCache{}
+	}
+	clone := make(linkedInTypeaheadCache, len(cache))
+	for key, entry := range cache {
+		clone[key] = entry
+	}
+	return clone
 }
 
 func linkedInTypeaheadCacheKey(kind string, query string) string {

--- a/internal/fetcher/structured_job_posting.go
+++ b/internal/fetcher/structured_job_posting.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/domain"
 )
 
 func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string) {
@@ -38,7 +40,7 @@ func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string)
 			job.Title = title
 		}
 
-		if jobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
+		if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) {
 			if website := structuredHiringOrganizationWebsite(posting); website != "" && looksLikeCompanyWebsite(website, pageURL) {
 				website = normalizeCompanyWebsiteURL(website)
 				if candidateWebsiteMatchesCompany(website, job.Company) {
@@ -48,7 +50,7 @@ func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string)
 			}
 		}
 
-		if jobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
+		if domain.JobCompanySummaryMissingOrInvalid(job.CompanySummary, job.Company) {
 			if description := structuredStringField(posting, "description"); description != "" {
 				if summary := extractCompanySummaryFromHTML(description, job.Company); summary != "" {
 					job.CompanySummary = summary
@@ -57,7 +59,7 @@ func enrichJobFromStructuredJobPosting(job *Job, rawHTML string, pageURL string)
 			}
 		}
 
-		if jobCompensationMissing(job.Compensation) {
+		if domain.JobCompensationMissing(job.Compensation) {
 			if compensation := structuredJobPostingCompensation(posting); compensation != "" {
 				job.Compensation = compensation
 			}


### PR DESCRIPTION
Summary:
- Add browser-based enrichment for Indeed job details and public company profile pages.
- Reuse company-site and profile evidence to fill missing website, summary, industry, and metadata fields.
- Improve enrichment stats/debug output around identity evidence and public profile extraction.

Notes:
- This is the next split PR after #32 and only includes the Indeed/company-site enrichment commit.

Validation:
- `GOCACHE=/data/data/com.termux/files/usr/tmp/go-cache go test ./internal/fetcher`
- `make all`
