### PR TITLE
Tighten LLM job search and evaluation prompts

### DIFF
--- a/internal/llm/llm_enrichment.go
+++ b/internal/llm/llm_enrichment.go
@@ -19,6 +19,7 @@ import (
 
 const maxCompanyHealthRejectedEvidenceInPrompt = 12
 const maxCompanyHealthArticleTextChars = 6000
+const llmSearchSystemInstruction = "You are a JSON-only job search API. Return only a valid JSON array. Use empty strings for unknown required fields and do not invent missing facts."
 
 // LLMEvaluationResult holds the parsed JSON output from the LLM
 type LLMEvaluationResult struct {
@@ -183,10 +184,7 @@ func executeLLMSearch(ctx context.Context, llm llms.Model, prompt string) ([]Job
 
 func executeLLMSearchWithUsage(ctx context.Context, llm llms.Model, prompt string) ([]Job, LLMTokenUsage, error) {
 	fullPrompt := buildLLMSearchPrompt(prompt)
-
-	messages := []llms.MessageContent{
-		llms.TextParts(llms.ChatMessageTypeHuman, fullPrompt),
-	}
+	messages := buildLLMSearchMessages(fullPrompt)
 
 	logDebug("llm job search: generation start prompt_chars=%d", len(fullPrompt))
 	resp, err := llm.GenerateContent(ctx, messages, llmJSONCallOptions(0.2, 8192)...)
@@ -211,6 +209,13 @@ func executeLLMSearchWithUsage(ctx context.Context, llm llms.Model, prompt strin
 	return jobs, usage, nil
 }
 
+func buildLLMSearchMessages(prompt string) []llms.MessageContent {
+	return []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, llmSearchSystemInstruction),
+		llms.TextParts(llms.ChatMessageTypeHuman, prompt),
+	}
+}
+
 func buildLLMSearchPrompt(prompt string) string {
 	var fullPrompt strings.Builder
 	fullPrompt.WriteString(prompt)
@@ -220,6 +225,7 @@ func buildLLMSearchPrompt(prompt string) string {
 	fullPrompt.WriteString("If no real current direct application URLs can be verified from the available context, return an empty JSON array. ")
 	fullPrompt.WriteString("You must return your response ONLY as a valid JSON array of objects. ")
 	fullPrompt.WriteString("Each object must include these string keys: \"company\", \"title\", \"remote\", \"compensation\", \"apply_url\", and \"description\". ")
+	fullPrompt.WriteString("If any required string field is unavailable in the verified context, use an empty string for that field instead of guessing. ")
 	fullPrompt.WriteString("When available, include \"company_website\" for the actual company's website, not the job board or application URL, \"company_summary\" for a brief factual company summary, and \"company_industry\" for the company's industry. ")
 	fullPrompt.WriteString("For any list of reasons it matches, put them in a string array under the key \"why_matches\". ")
 	fullPrompt.WriteString("Do NOT wrap the JSON in markdown blocks, return ONLY the raw JSON array.")
@@ -838,7 +844,7 @@ func buildPrompt(job Job, criteria *CriteriaConfig) string {
 	promptBuilder.WriteString(`  "matches": boolean, // false only when explicit posted facts fail hard criteria` + "\n")
 	promptBuilder.WriteString(`  "compensation_extracted": string, // The clear compensation string, e.g. "$180k-$220k base"` + "\n")
 	promptBuilder.WriteString(`  "remote_eligibility": string, // E.g. "US-Remote", "Hybrid", "Onsite"` + "\n")
-	promptBuilder.WriteString(`  "why_it_matches": [string], // Array of bullet points explaining why it matches priority signals` + "\n")
+	promptBuilder.WriteString(`  "why_it_matches": [string], // Array of bullet points explaining matching signals and any missing facts that still need verification` + "\n")
 	promptBuilder.WriteString(`  "why_rejected": [string] // If matches is false, explain which explicit hard criteria failed` + "\n")
 	promptBuilder.WriteString("}\n")
 

--- a/internal/llm/llm_enrichment.go
+++ b/internal/llm/llm_enrichment.go
@@ -182,16 +182,14 @@ func executeLLMSearch(ctx context.Context, llm llms.Model, prompt string) ([]Job
 }
 
 func executeLLMSearchWithUsage(ctx context.Context, llm llms.Model, prompt string) ([]Job, LLMTokenUsage, error) {
-	// We append a JSON requirement so the Go app can parse the result,
-	// but we do absolutely no "prompt engineering" on how or where it searches.
-	fullPrompt := prompt + "\n\nCRITICAL SYSTEM INSTRUCTION: You must return your response ONLY as a valid JSON array of objects. Each object must include these string keys: \"company\", \"title\", \"remote\", \"compensation\", \"apply_url\", and \"description\". When available, include \"company_website\" for the actual company's website, not the job board or application URL, \"company_summary\" for a brief factual company summary, and \"company_industry\" for the company's industry. For any list of reasons it matches, put them in a string array under the key \"why_matches\". Do NOT wrap the JSON in markdown blocks, return ONLY the raw JSON array."
+	fullPrompt := buildLLMSearchPrompt(prompt)
 
 	messages := []llms.MessageContent{
 		llms.TextParts(llms.ChatMessageTypeHuman, fullPrompt),
 	}
 
 	logDebug("llm job search: generation start prompt_chars=%d", len(fullPrompt))
-	resp, err := llm.GenerateContent(ctx, messages, llmJSONCallOptions(0.7, 8192)...)
+	resp, err := llm.GenerateContent(ctx, messages, llmJSONCallOptions(0.2, 8192)...)
 	if err != nil {
 		logDebug("llm job search: generation failed: %v", err)
 		return nil, LLMTokenUsage{}, fmt.Errorf("LLM generation failed: %v", err)
@@ -211,6 +209,21 @@ func executeLLMSearchWithUsage(ctx context.Context, llm llms.Model, prompt strin
 	}
 	logDebug("llm job search: parsed jobs=%d response_chars=%d", len(jobs), len(resp.Choices[0].Content))
 	return jobs, usage, nil
+}
+
+func buildLLMSearchPrompt(prompt string) string {
+	var fullPrompt strings.Builder
+	fullPrompt.WriteString(prompt)
+	fullPrompt.WriteString("\n\nCRITICAL SYSTEM INSTRUCTION: ")
+	fullPrompt.WriteString("Use only real current job postings whose direct application URL is present in the prompt context or available through your search/tooling context. ")
+	fullPrompt.WriteString("Do not invent companies, roles, URLs, compensation, descriptions, company websites, or company summaries. ")
+	fullPrompt.WriteString("If no real current direct application URLs can be verified from the available context, return an empty JSON array. ")
+	fullPrompt.WriteString("You must return your response ONLY as a valid JSON array of objects. ")
+	fullPrompt.WriteString("Each object must include these string keys: \"company\", \"title\", \"remote\", \"compensation\", \"apply_url\", and \"description\". ")
+	fullPrompt.WriteString("When available, include \"company_website\" for the actual company's website, not the job board or application URL, \"company_summary\" for a brief factual company summary, and \"company_industry\" for the company's industry. ")
+	fullPrompt.WriteString("For any list of reasons it matches, put them in a string array under the key \"why_matches\". ")
+	fullPrompt.WriteString("Do NOT wrap the JSON in markdown blocks, return ONLY the raw JSON array.")
+	return fullPrompt.String()
 }
 
 func ExecuteLLMSearch(ctx context.Context, llm llms.Model, prompt string) ([]Job, error) {
@@ -813,14 +826,20 @@ func buildPrompt(job Job, criteria *CriteriaConfig) string {
 	fmt.Fprintf(&promptBuilder, "Compensation Raw: %s\n", job.Compensation)
 	fmt.Fprintf(&promptBuilder, "Description: %s\n\n", job.Description)
 
+	promptBuilder.WriteString("### Evaluation Rules:\n")
+	promptBuilder.WriteString("Set matches=false only when the posting explicitly conflicts with a hard criterion. ")
+	promptBuilder.WriteString("Do not reject solely because compensation, location, years of experience, or priority-signal details are missing or unclear. ")
+	promptBuilder.WriteString("When facts are missing but there is no explicit conflict, keep matches=true and mention what still needs verification in why_it_matches. ")
+	promptBuilder.WriteString("Use why_rejected only for explicit hard failures such as below-minimum compensation, unsupported work setting, excluded title or industry, or role mismatch.\n\n")
+
 	promptBuilder.WriteString("### Output Format:\n")
 	promptBuilder.WriteString("Instead of a text list, return ONLY valid JSON matching this schema:\n")
 	promptBuilder.WriteString("{\n")
-	promptBuilder.WriteString(`  "matches": boolean, // true if it meets all hard criteria, false otherwise` + "\n")
+	promptBuilder.WriteString(`  "matches": boolean, // false only when explicit posted facts fail hard criteria` + "\n")
 	promptBuilder.WriteString(`  "compensation_extracted": string, // The clear compensation string, e.g. "$180k-$220k base"` + "\n")
 	promptBuilder.WriteString(`  "remote_eligibility": string, // E.g. "US-Remote", "Hybrid", "Onsite"` + "\n")
 	promptBuilder.WriteString(`  "why_it_matches": [string], // Array of bullet points explaining why it matches priority signals` + "\n")
-	promptBuilder.WriteString(`  "why_rejected": [string] // If matches is false, explain which hard criteria failed` + "\n")
+	promptBuilder.WriteString(`  "why_rejected": [string] // If matches is false, explain which explicit hard criteria failed` + "\n")
 	promptBuilder.WriteString("}\n")
 
 	return promptBuilder.String()

--- a/internal/llm/llm_enrichment_test.go
+++ b/internal/llm/llm_enrichment_test.go
@@ -77,11 +77,33 @@ func TestBuildLLMSearchPromptRequiresVerifiedJobs(t *testing.T) {
 		"Use only real current job postings whose direct application URL is present in the prompt context or available through your search/tooling context.",
 		"Do not invent companies, roles, URLs, compensation, descriptions, company websites, or company summaries.",
 		"If no real current direct application URLs can be verified from the available context, return an empty JSON array.",
+		"If any required string field is unavailable in the verified context, use an empty string for that field instead of guessing.",
 		"return ONLY the raw JSON array",
 	} {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("buildLLMSearchPrompt() missing %q in:\n%s", expected, prompt)
 		}
+	}
+}
+
+func TestBuildLLMSearchMessagesUsesJSONOnlySystemInstruction(t *testing.T) {
+	messages := buildLLMSearchMessages("Find matching jobs.")
+
+	if len(messages) != 2 {
+		t.Fatalf("len(messages) = %d, want 2", len(messages))
+	}
+	if messages[0].Role != llms.ChatMessageTypeSystem {
+		t.Fatalf("messages[0].Role = %v, want system", messages[0].Role)
+	}
+	if messages[1].Role != llms.ChatMessageTypeHuman {
+		t.Fatalf("messages[1].Role = %v, want human", messages[1].Role)
+	}
+	systemText, ok := messages[0].Parts[0].(llms.TextContent)
+	if !ok {
+		t.Fatalf("messages[0].Parts[0] = %T, want llms.TextContent", messages[0].Parts[0])
+	}
+	if !strings.Contains(systemText.Text, "JSON-only job search API") {
+		t.Fatalf("system instruction = %q, want JSON-only job search API", systemText.Text)
 	}
 }
 

--- a/internal/llm/llm_enrichment_test.go
+++ b/internal/llm/llm_enrichment_test.go
@@ -61,9 +61,26 @@ func TestBuildPromptIncludesCriteria(t *testing.T) {
 		"Role families: devops_sre_systems",
 		"Priority signals: reliability, automation",
 		"### Job Posting to Evaluate:",
+		"Set matches=false only when the posting explicitly conflicts with a hard criterion.",
+		"Do not reject solely because compensation, location, years of experience, or priority-signal details are missing or unclear.",
 	} {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("buildPrompt() missing %q in:\n%s", expected, prompt)
+		}
+	}
+}
+
+func TestBuildLLMSearchPromptRequiresVerifiedJobs(t *testing.T) {
+	prompt := buildLLMSearchPrompt("Find matching jobs.")
+
+	for _, expected := range []string{
+		"Use only real current job postings whose direct application URL is present in the prompt context or available through your search/tooling context.",
+		"Do not invent companies, roles, URLs, compensation, descriptions, company websites, or company summaries.",
+		"If no real current direct application URLs can be verified from the available context, return an empty JSON array.",
+		"return ONLY the raw JSON array",
+	} {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("buildLLMSearchPrompt() missing %q in:\n%s", expected, prompt)
 		}
 	}
 }
@@ -479,7 +496,7 @@ func TestBuildCompanyHealthLLMPromptIncludesAllSmallRejectedEvidence(t *testing.
 		"news | Acme unrelated article | rejected: domain mismatch | https://news.example/1",
 		"hacker_news | Wrong Acme thread | rejected: company name mismatch",
 	} {
-		if !containsString(input.RejectedEvidence, expected) {
+		if !slices.Contains(input.RejectedEvidence, expected) {
 			t.Fatalf("input.RejectedEvidence = %#v, want to contain %q", input.RejectedEvidence, expected)
 		}
 	}
@@ -559,15 +576,6 @@ func parseCompanyHealthPromptInput(t *testing.T, prompt string) companyHealthLLM
 		t.Fatalf("json.Unmarshal(company health prompt input) error = %v", err)
 	}
 	return input
-}
-
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func rejectedEvidenceSummaryBySourceReason(summary []rejectedEvidenceOmissionSummary) map[string]int {


### PR DESCRIPTION
## What Changed
- Adds stricter job-search prompt requirements so LLM search returns only verified current postings with direct application URLs.
- Lowers LLM job-search temperature for more deterministic output.
- Clarifies job-evaluation instructions so missing details do not cause rejection unless posted facts explicitly fail hard criteria.

## Impact
LLM-assisted search and filtering should produce fewer hallucinated jobs and fewer false rejections when postings omit details that need follow-up.