### PR TITLE
ci(workflows): Add Go tools caching and build provenance attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,13 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Cache Go tools
+        uses: actions/cache@v4
+        with:
+          path: .tools
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+
       - name: Run merge gate
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .tools
-          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-go-tools-${{ hashFiles('Makefile', 'go.mod') }}
 
       - name: Run merge gate
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
         with:
           path: .tools
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-go-tools-
 
       - name: Run merge gate
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           path: .tools
           key: ${{ runner.os }}-${{ runner.arch }}-go-tools-${{ hashFiles('Makefile', 'go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-go-tools-
 
       - name: Run merge gate
         run: make check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Cache Go tools
+        uses: actions/cache@v4
+        with:
+          path: .tools
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+
       - name: Run release gate
         env:
           RELEASE_TAG: ${{ env.JOBSCOUT_RELEASE_TAG }}
@@ -171,6 +179,10 @@ jobs:
       - resolve-release
       - gate
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     env:
       JOBSCOUT_RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       JOBSCOUT_CHECKOUT_REF: ${{ needs.resolve-release.outputs.checkout_ref }}
@@ -218,6 +230,11 @@ jobs:
           RELEASE_GOOS: ${{ matrix.goos }}
           RELEASE_GOARCH: ${{ matrix.goarch }}
         run: make release
+
+      - name: Generate build provenance attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: 'dist/jobscout_${{ env.JOBSCOUT_RELEASE_TAG }}_${{ matrix.goos }}_${{ matrix.goarch }}.*'
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .tools
-          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-go-tools-${{ hashFiles('Makefile', 'go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-go-tools-
 
       - name: Run release gate
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,8 +164,6 @@ jobs:
         with:
           path: .tools
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-go-tools-
 
       - name: Run release gate
         env:


### PR DESCRIPTION
Adds Go tool caching to CI and release workflows to speed up setup, and adds release provenance attestations for stronger supply chain verification.

Changes:
- Cache Go tools in `ci.yml` and `release.yml`
- Generate build provenance attestations with `actions/attest@v4`
- Update release permissions for OIDC tokens, attestations, and repo content access