### PR TITLE
Add command-mode fetch controls

### DIFF
--- a/internal/tuiapp/command_mode.go
+++ b/internal/tuiapp/command_mode.go
@@ -2,13 +2,25 @@ package tuiapp
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+
+	"github.com/wallentx/jobscout/internal/config"
 )
 
 type operatorCommandResult struct {
 	Title          string
 	Message        string
 	HealthIdentity CompanyHealthContext
+	FetchOptions   *operatorFetchOptions
+}
+
+type operatorFetchOptions struct {
+	SourceSelectionSet      bool
+	SourceSelection         []string
+	CandidateLimitPerSource *int
+	AcceptedLimit           *int
+	DisableLLM              bool
 }
 
 type operatorCommandSpec struct {
@@ -44,11 +56,16 @@ var operatorCommandSpecs = []operatorCommandSpec{
 		Execute: executeHealthCommand,
 	},
 	{
+		Name:    "fetch",
+		Execute: executeFetchCommand,
+	},
+	{
 		Name:    "help",
 		Aliases: []string{"?"},
 		Execute: operatorCommandHelp,
 		Completions: []operatorCommandCompletionSpec{
 			{Label: "debug", Insert: "debug"},
+			{Label: "fetch", Insert: "fetch"},
 			{Label: "health", Insert: "health"},
 		},
 	},
@@ -100,11 +117,14 @@ func operatorCommandCompletions(input string) []operatorCommandCompletion {
 	if spec.Name == "health" {
 		return healthCommandCompletions(input)
 	}
+	if spec.Name == "fetch" {
+		return fetchCommandCompletions(input)
+	}
 
 	var completions []operatorCommandCompletion
 	for _, completion := range spec.Completions {
 		insert := completion.Insert
-		if fuzzyMatchOperatorCommand(rest, completion.Label) || fuzzyMatchOperatorCommand(rest, strings.TrimSpace(insert)) {
+		if matchOperatorCommandCompletion(rest, completion.Label, strings.TrimSpace(insert)) {
 			completions = append(completions, operatorCommandCompletion{
 				Label: completion.Label,
 				Value: spec.Name + " " + insert,
@@ -121,11 +141,11 @@ func healthCommandCompletions(input string) []operatorCommandCompletion {
 		return nil
 	}
 	rest = strings.TrimLeft(rest, " \t")
-	if strings.TrimSpace(rest) == "" || healthCommandAwaitingFlagValue(rest) {
+	if strings.TrimSpace(rest) == "" || healthCommandAwaitingFlagValue(rest) || commandCurrentTokenRequiresValue(rest, healthFlagRequiresValue) {
 		return nil
 	}
 
-	base, prefix, ok := healthCommandFlagCompletionContext(rest)
+	base, prefix, ok := commandFlagCompletionContext(rest)
 	if !ok || !healthRestHasCompany(rest) {
 		return nil
 	}
@@ -140,7 +160,7 @@ func healthCommandCompletions(input string) []operatorCommandCompletion {
 		if flag.Label == "--website" && usedFlags["--website"] {
 			continue
 		}
-		if fuzzyMatchOperatorCommand(prefix, flag.Label) {
+		if matchOperatorCommandCompletion(prefix, flag.Label, flag.Insert) {
 			completions = append(completions, operatorCommandCompletion{
 				Label: flag.Label,
 				Value: "health " + base + flag.Insert,
@@ -150,20 +170,156 @@ func healthCommandCompletions(input string) []operatorCommandCompletion {
 	return completions
 }
 
-func healthCommandFlagCompletionContext(rest string) (base string, prefix string, ok bool) {
+func fetchCommandCompletions(input string) []operatorCommandCompletion {
+	input = strings.TrimLeft(input, " \t")
+	command, rest, hasRest := splitOperatorCommandInput(input)
+	if !hasRest || !strings.EqualFold(command, "fetch") {
+		return nil
+	}
+	rest = strings.TrimLeft(rest, " \t")
+
+	if base, prefix, ok := fetchCommandSourceValueCompletionContext(rest); ok {
+		return fetchCommandSourceCompletions(base, prefix)
+	}
+	if fetchCommandAwaitingNonSourceValue(rest) {
+		return nil
+	}
+
+	base, prefix, ok := commandFlagCompletionContext(rest)
+	if !ok {
+		return nil
+	}
+
+	flags := []operatorCommandCompletionSpec{
+		{Label: "--sources", Insert: "--sources"},
+		{Label: "--candidate-limit", Insert: "--candidate-limit"},
+		{Label: "--accepted-limit", Insert: "--accepted-limit"},
+		{Label: "--no-llm", Insert: "--no-llm"},
+	}
+	usedFlags := fetchCommandUsedFlags(rest)
+	completions := make([]operatorCommandCompletion, 0, len(flags))
+	for _, flag := range flags {
+		if flag.Label != "--sources" && usedFlags[flag.Label] {
+			continue
+		}
+		if matchOperatorCommandCompletion(prefix, flag.Label, flag.Insert) {
+			completions = append(completions, operatorCommandCompletion{
+				Label: flag.Label,
+				Value: "fetch " + base + flag.Insert,
+			})
+		}
+	}
+	return completions
+}
+
+func fetchCommandSourceCompletions(base string, prefix string) []operatorCommandCompletion {
+	sources := []string{"rss", "site", "llm", "llm_web", "all"}
+	completions := make([]operatorCommandCompletion, 0, len(sources))
+	for _, source := range sources {
+		if !matchOperatorCommandCompletion(prefix, source, source) {
+			continue
+		}
+		completions = append(completions, operatorCommandCompletion{
+			Label: source,
+			Value: "fetch " + base + source,
+		})
+	}
+	return completions
+}
+
+func fetchCommandSourceValueCompletionContext(rest string) (base string, prefix string, ok bool) {
+	base, valuePrefix, flag, ok := commandValueCompletionContext(rest)
+	if !ok || flag != "--sources" {
+		return "", "", false
+	}
+	comma := strings.LastIndex(valuePrefix, ",")
+	if comma == -1 {
+		return base, valuePrefix, true
+	}
+	return base + valuePrefix[:comma+1], valuePrefix[comma+1:], true
+}
+
+func fetchCommandAwaitingNonSourceValue(rest string) bool {
+	_, _, flag, ok := commandValueCompletionContext(rest)
+	return ok && flag != "--sources"
+}
+
+func commandFlagCompletionContext(rest string) (base string, prefix string, ok bool) {
 	if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") {
 		return rest, "", true
 	}
 	trimmedRight := strings.TrimRight(rest, " \t")
 	tokenStart := strings.LastIndexAny(trimmedRight, " \t")
 	if tokenStart == -1 {
+		if strings.HasPrefix(trimmedRight, "-") {
+			return "", trimmedRight, true
+		}
 		return "", "", false
 	}
 	current := trimmedRight[tokenStart+1:]
-	if !strings.HasPrefix(current, "--") {
+	if !strings.HasPrefix(current, "-") {
 		return "", "", false
 	}
 	return trimmedRight[:tokenStart+1], current, true
+}
+
+func commandCurrentTokenRequiresValue(rest string, requiresValue func(string) bool) bool {
+	if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") {
+		return false
+	}
+	args, err := parseOperatorCommandLine(rest)
+	if err != nil || len(args) == 0 {
+		return false
+	}
+	last := args[len(args)-1]
+	if strings.Contains(last, "=") {
+		return false
+	}
+	return requiresValue(last)
+}
+
+func commandValueCompletionContext(rest string) (base string, prefix string, flag string, ok bool) {
+	trimmedRight := strings.TrimRight(rest, " \t")
+	args, err := parseOperatorCommandLine(rest)
+	if err != nil || len(args) == 0 {
+		return "", "", "", false
+	}
+
+	if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") {
+		lastFlag, _, _ := strings.Cut(args[len(args)-1], "=")
+		if !fetchFlagRequiresValue(lastFlag) {
+			return "", "", "", false
+		}
+		return rest, "", lastFlag, true
+	}
+
+	last := args[len(args)-1]
+	flag, value, hasValue := strings.Cut(last, "=")
+	if hasValue && fetchFlagRequiresValue(flag) {
+		start := strings.LastIndex(trimmedRight, last)
+		if start == -1 {
+			return "", "", "", false
+		}
+		return trimmedRight[:start] + flag + "=", value, flag, true
+	}
+	if fetchFlagRequiresValue(last) {
+		return trimmedRight + " ", "", last, true
+	}
+	if strings.HasPrefix(last, "-") {
+		return "", "", "", false
+	}
+	if len(args) < 2 {
+		return "", "", "", false
+	}
+	previousFlag, _, _ := strings.Cut(args[len(args)-2], "=")
+	if !fetchFlagRequiresValue(previousFlag) {
+		return "", "", "", false
+	}
+	start := strings.LastIndex(trimmedRight, last)
+	if start == -1 {
+		return "", "", "", false
+	}
+	return trimmedRight[:start], last, previousFlag, true
 }
 
 func healthCommandAwaitingFlagValue(rest string) bool {
@@ -207,6 +363,16 @@ func healthFlagRequiresValue(flag string) bool {
 	}
 }
 
+func fetchFlagRequiresValue(flag string) bool {
+	flag, _, _ = strings.Cut(strings.TrimSpace(flag), "=")
+	switch flag {
+	case "--sources", "--candidate-limit", "--accepted-limit":
+		return true
+	default:
+		return false
+	}
+}
+
 func healthCommandUsedFlags(rest string) map[string]bool {
 	used := make(map[string]bool)
 	args, err := parseOperatorCommandLine(rest)
@@ -219,6 +385,25 @@ func healthCommandUsedFlags(rest string) map[string]bool {
 		}
 		flag, _, _ := strings.Cut(arg, "=")
 		used[flag] = true
+	}
+	return used
+}
+
+func fetchCommandUsedFlags(rest string) map[string]bool {
+	used := make(map[string]bool)
+	args, err := parseOperatorCommandLine(rest)
+	if err != nil {
+		return used
+	}
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--") {
+			continue
+		}
+		flag, _, _ := strings.Cut(arg, "=")
+		switch flag {
+		case "--sources", "--candidate-limit", "--accepted-limit", "--no-llm":
+			used[flag] = true
+		}
 	}
 	return used
 }
@@ -261,6 +446,15 @@ func fuzzyMatchOperatorCommand(pattern string, candidate string) bool {
 		}
 	}
 	return next >= len(pattern)
+}
+
+func matchOperatorCommandCompletion(pattern string, label string, insert string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if strings.HasPrefix(pattern, "-") {
+		needle := strings.ToLower(pattern)
+		return strings.HasPrefix(strings.ToLower(label), needle) || strings.HasPrefix(strings.ToLower(insert), needle)
+	}
+	return fuzzyMatchOperatorCommand(pattern, label) || fuzzyMatchOperatorCommand(pattern, insert)
 }
 
 func (m *model) applyOperatorCommandCompletion() {
@@ -344,15 +538,21 @@ func (m model) operatorCommandGhostHint() string {
 }
 
 func operatorCommandGhostHint(input string) string {
-	input = strings.TrimLeft(input, " \t")
-	command, rest, hasRest := splitOperatorCommandInput(input)
-	if !strings.EqualFold(command, "health") {
+	if len(operatorCommandCompletions(input)) > 0 {
 		return ""
 	}
+	input = strings.TrimLeft(input, " \t")
+	command, rest, hasRest := splitOperatorCommandInput(input)
 	if !hasRest {
 		return ""
 	}
 	rest = strings.TrimLeft(rest, " \t")
+	if strings.EqualFold(command, "fetch") {
+		return fetchCommandValueHint(rest)
+	}
+	if !strings.EqualFold(command, "health") {
+		return ""
+	}
 	if strings.TrimSpace(rest) == "" {
 		return "<company>"
 	}
@@ -360,6 +560,24 @@ func operatorCommandGhostHint(input string) string {
 		return hint
 	}
 	return ""
+}
+
+func fetchCommandValueHint(rest string) string {
+	_, prefix, flag, ok := commandValueCompletionContext(rest)
+	if !ok {
+		return ""
+	}
+	if strings.TrimSpace(prefix) != "" {
+		return ""
+	}
+	switch flag {
+	case "--candidate-limit":
+		return commandValueHintText(rest, strconv.Itoa(config.DefaultAppConfig().Fetch.CandidateLimitPerSource))
+	case "--accepted-limit":
+		return commandValueHintText(rest, strconv.Itoa(config.DefaultAppConfig().Fetch.AcceptedLimit))
+	default:
+		return ""
+	}
 }
 
 func healthCommandValueHint(rest string) string {
@@ -377,18 +595,28 @@ func healthCommandValueHint(rest string) string {
 	}
 	switch flag {
 	case "--aka":
-		if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") || hasValue {
-			return "<name>"
-		}
-		return " <name>"
+		return commandValueHintText(rest, "<name>")
 	case "--website":
-		if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") || hasValue {
-			return "<url>"
-		}
-		return " <url>"
+		return commandValueHintText(rest, "<url>")
 	default:
 		return ""
 	}
+}
+
+func commandValueHintText(rest string, hint string) string {
+	if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") || strings.Contains(lastOperatorCommandToken(rest), "=") {
+		return hint
+	}
+	return " " + hint
+}
+
+func lastOperatorCommandToken(input string) string {
+	input = strings.TrimRight(input, " \t")
+	idx := strings.LastIndexAny(input, " \t")
+	if idx == -1 {
+		return input
+	}
+	return input[idx+1:]
 }
 
 func parseOperatorCommandLine(input string) ([]string, error) {
@@ -463,6 +691,16 @@ func operatorCommandHelp(args []string) (operatorCommandResult, error) {
 			}, "\n"),
 		}, nil
 	}
+	if len(args) > 0 && strings.EqualFold(args[0], "fetch") {
+		return operatorCommandResult{
+			Title: "Command Help",
+			Message: strings.Join([]string{
+				"fetch [--sources <list>] [--candidate-limit <n>] [--accepted-limit <n>] [--no-llm]",
+				"Run a one-shot job fetch with optional source and limit overrides.",
+				"Sources: rss, site, llm, llm_web, all.",
+			}, "\n"),
+		}, nil
+	}
 	return operatorCommandResult{
 		Title: "Commands",
 		Message: strings.Join([]string{
@@ -470,9 +708,148 @@ func operatorCommandHelp(args []string) (operatorCommandResult, error) {
 			"debug on      Enable debug output",
 			"debug off     Disable debug output",
 			"debug path    Set debug log path",
+			"fetch         Fetch jobs with optional overrides",
 			"health        Fetch company health info",
 		}, "\n"),
 	}, nil
+}
+
+func executeFetchCommand(args []string) (operatorCommandResult, error) {
+	options, err := parseFetchCommandOptions(args)
+	if err != nil {
+		return operatorCommandResult{}, err
+	}
+	return operatorCommandResult{FetchOptions: &options}, nil
+}
+
+func parseFetchCommandOptions(args []string) (operatorFetchOptions, error) {
+	var options operatorFetchOptions
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		if arg == "" {
+			continue
+		}
+		flag, value, hasValue := strings.Cut(arg, "=")
+		switch flag {
+		case "--sources":
+			if !hasValue {
+				i++
+				if i >= len(args) {
+					return operatorFetchOptions{}, fmt.Errorf("usage: fetch [--sources <list>] [--candidate-limit <n>] [--accepted-limit <n>] [--no-llm]")
+				}
+				value = args[i]
+			}
+			sources, allSources, err := parseFetchCommandSources(value)
+			if err != nil {
+				return operatorFetchOptions{}, err
+			}
+			options.SourceSelectionSet = true
+			if allSources {
+				options.SourceSelection = nil
+			} else {
+				options.SourceSelection = appendFetchCommandSources(options.SourceSelection, sources...)
+			}
+		case "--candidate-limit":
+			limit, err := parseFetchCommandNonNegativeInt(flag, value, hasValue, args, &i)
+			if err != nil {
+				return operatorFetchOptions{}, err
+			}
+			options.CandidateLimitPerSource = &limit
+		case "--accepted-limit":
+			limit, err := parseFetchCommandNonNegativeInt(flag, value, hasValue, args, &i)
+			if err != nil {
+				return operatorFetchOptions{}, err
+			}
+			options.AcceptedLimit = &limit
+		case "--no-llm":
+			if hasValue {
+				return operatorFetchOptions{}, fmt.Errorf("--no-llm does not accept a value")
+			}
+			options.DisableLLM = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return operatorFetchOptions{}, fmt.Errorf("unknown fetch option %q", flag)
+			}
+			return operatorFetchOptions{}, fmt.Errorf("unexpected fetch argument %q", arg)
+		}
+	}
+	if options.DisableLLM && fetchCommandSourcesRequireLLM(options.SourceSelection) {
+		return operatorFetchOptions{}, fmt.Errorf("--no-llm cannot be combined with llm or llm_web sources")
+	}
+	return options, nil
+}
+
+func parseFetchCommandNonNegativeInt(flag string, value string, hasValue bool, args []string, idx *int) (int, error) {
+	if !hasValue {
+		*idx = *idx + 1
+		if *idx >= len(args) {
+			return 0, fmt.Errorf("%s requires a non-negative integer", flag)
+		}
+		value = args[*idx]
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("%s requires a non-negative integer", flag)
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, fmt.Errorf("%s requires a non-negative integer", flag)
+	}
+	return parsed, nil
+}
+
+func parseFetchCommandSources(value string) ([]string, bool, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return nil, false, fmt.Errorf("--sources requires a comma-separated source list")
+	}
+	var sources []string
+	for _, part := range strings.Split(raw, ",") {
+		source := strings.TrimSpace(strings.ToLower(strings.ReplaceAll(part, "-", "_")))
+		if source == "" {
+			continue
+		}
+		switch source {
+		case "rss", "site", "llm", "llm_web":
+			sources = appendFetchCommandSources(sources, source)
+		case "all":
+			return nil, true, nil
+		default:
+			return nil, false, fmt.Errorf("--sources includes unsupported source %q; valid sources are rss, site, llm, llm_web, all", strings.TrimSpace(part))
+		}
+	}
+	if len(sources) == 0 {
+		return nil, false, fmt.Errorf("--sources requires at least one source")
+	}
+	return sources, false, nil
+}
+
+func appendFetchCommandSources(sources []string, additions ...string) []string {
+	for _, source := range additions {
+		if source == "all" {
+			return nil
+		}
+		seen := false
+		for _, existing := range sources {
+			if existing == source {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			sources = append(sources, source)
+		}
+	}
+	return sources
+}
+
+func fetchCommandSourcesRequireLLM(sources []string) bool {
+	for _, source := range sources {
+		if source == "llm" || source == "llm_web" {
+			return true
+		}
+	}
+	return false
 }
 
 func executeHealthCommand(args []string) (operatorCommandResult, error) {

--- a/internal/tuiapp/command_mode.go
+++ b/internal/tuiapp/command_mode.go
@@ -40,6 +40,21 @@ type operatorCommandCompletion struct {
 	Value string
 }
 
+type fetchCommandHintDefaults struct {
+	CandidateLimitPerSource string
+	AcceptedLimit           string
+}
+
+var defaultFetchCommandHintValues = newFetchCommandHintDefaults()
+
+func newFetchCommandHintDefaults() fetchCommandHintDefaults {
+	fetch := config.DefaultAppConfig().Fetch
+	return fetchCommandHintDefaults{
+		CandidateLimitPerSource: strconv.Itoa(fetch.CandidateLimitPerSource),
+		AcceptedLimit:           strconv.Itoa(fetch.AcceptedLimit),
+	}
+}
+
 var operatorCommandSpecs = []operatorCommandSpec{
 	{
 		Name:    "debug",
@@ -572,9 +587,9 @@ func fetchCommandValueHint(rest string) string {
 	}
 	switch flag {
 	case "--candidate-limit":
-		return commandValueHintText(rest, strconv.Itoa(config.DefaultAppConfig().Fetch.CandidateLimitPerSource))
+		return commandValueHintText(rest, defaultFetchCommandHintValues.CandidateLimitPerSource)
 	case "--accepted-limit":
-		return commandValueHintText(rest, strconv.Itoa(config.DefaultAppConfig().Fetch.AcceptedLimit))
+		return commandValueHintText(rest, defaultFetchCommandHintValues.AcceptedLimit)
 	default:
 		return ""
 	}

--- a/internal/tuiapp/command_mode_test.go
+++ b/internal/tuiapp/command_mode_test.go
@@ -126,6 +126,31 @@ func TestExecuteOperatorHealthCommandRequiresCompany(t *testing.T) {
 	}
 }
 
+func TestExecuteOperatorFetchCommandParsesOverrides(t *testing.T) {
+	result, err := executeOperatorCommand(`fetch --sources rss,site --sources llm --candidate-limit 7 --accepted-limit=3 --no-llm`)
+	if err == nil {
+		t.Fatal("executeOperatorCommand(fetch) error = nil; want --no-llm source conflict")
+	}
+
+	result, err = executeOperatorCommand(`fetch --sources rss,site --candidate-limit 7 --accepted-limit=3`)
+	if err != nil {
+		t.Fatalf("executeOperatorCommand(fetch) error = %v", err)
+	}
+	if result.FetchOptions == nil {
+		t.Fatal("FetchOptions = nil; want parsed fetch options")
+	}
+	options := result.FetchOptions
+	if !options.SourceSelectionSet || strings.Join(options.SourceSelection, ",") != "rss,site" {
+		t.Fatalf("SourceSelection = set:%t %#v; want rss,site", options.SourceSelectionSet, options.SourceSelection)
+	}
+	if options.CandidateLimitPerSource == nil || *options.CandidateLimitPerSource != 7 {
+		t.Fatalf("CandidateLimitPerSource = %#v; want 7", options.CandidateLimitPerSource)
+	}
+	if options.AcceptedLimit == nil || *options.AcceptedLimit != 3 {
+		t.Fatalf("AcceptedLimit = %#v; want 3", options.AcceptedLimit)
+	}
+}
+
 func TestCommandInputTabCompletesAllowlistedSubcommand(t *testing.T) {
 	writeTestJobsFile(t)
 	m := initialModel()
@@ -425,6 +450,63 @@ func TestCommandModeHealthPoolShowsSelectableFlagsAfterCompany(t *testing.T) {
 	}
 }
 
+func TestCommandModeFetchPoolShowsSelectableFlagsAfterDash(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("fetch -")
+	m.commandTypedInput = "fetch -"
+
+	labels := commandCompletionLabels(m.operatorCommandPool())
+	want := []string{"--sources", "--candidate-limit", "--accepted-limit", "--no-llm"}
+	if strings.Join(labels, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("operatorCommandPool labels = %#v; want %#v", labels, want)
+	}
+	if hint := m.operatorCommandGhostHint(); hint != "" {
+		t.Fatalf("operatorCommandGhostHint() = %q; want no hint while completions are available", hint)
+	}
+}
+
+func TestCommandModeFetchSourceValueCompletion(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("fetch --sources si")
+	m.commandTypedInput = "fetch --sources si"
+
+	labels := commandCompletionLabels(m.operatorCommandPool())
+	if strings.Join(labels, "\x00") != "site" {
+		t.Fatalf("operatorCommandPool labels = %#v; want site", labels)
+	}
+}
+
+func TestCommandModeFetchLimitHintsOnlyForMissingValues(t *testing.T) {
+	if hint := operatorCommandGhostHint("fetch --candidate-limit"); hint != " 15" {
+		t.Fatalf("operatorCommandGhostHint(candidate flag) = %q; want default limit hint", hint)
+	}
+	if hint := operatorCommandGhostHint("fetch --candidate-limit "); hint != "15" {
+		t.Fatalf("operatorCommandGhostHint(candidate flag space) = %q; want default limit hint", hint)
+	}
+	if hint := operatorCommandGhostHint("fetch --candidate-limit 1"); hint != "" {
+		t.Fatalf("operatorCommandGhostHint(candidate value typed) = %q; want no hint", hint)
+	}
+	if hint := operatorCommandGhostHint("fetch --sources "); hint != "" {
+		t.Fatalf("operatorCommandGhostHint(sources) = %q; want source completions instead of hint", hint)
+	}
+}
+
 func TestCommandModeHealthPoolHidesDuplicateWebsiteFlag(t *testing.T) {
 	m := model{
 		termWidth:     100,
@@ -580,6 +662,29 @@ func TestCommandModeHelpMentionsTabSelection(t *testing.T) {
 	rendered := ansi.Strip(m.View())
 	if !strings.Contains(rendered, "Tab Select/Cycle") {
 		t.Fatalf("command mode help missing tab selection hint:\n%s", rendered)
+	}
+}
+
+func TestCommandModeResultLineDoesNotChangeViewHeight(t *testing.T) {
+	base := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	base.commandInput.Focus()
+	base.commandInput.SetValue("debug status")
+
+	withResult := base
+	withResult.commandResultTitle = "Debug"
+	withResult.commandResultMessage = "Debug is off."
+
+	baseLines := strings.Count(ansi.Strip(base.View()), "\n")
+	resultLines := strings.Count(ansi.Strip(withResult.View()), "\n")
+	if resultLines != baseLines {
+		t.Fatalf("command view lines with result = %d; want %d", resultLines, baseLines)
 	}
 }
 

--- a/internal/tuiapp/command_mode_test.go
+++ b/internal/tuiapp/command_mode_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -504,6 +505,21 @@ func TestCommandModeFetchLimitHintsOnlyForMissingValues(t *testing.T) {
 	}
 	if hint := operatorCommandGhostHint("fetch --sources "); hint != "" {
 		t.Fatalf("operatorCommandGhostHint(sources) = %q; want source completions instead of hint", hint)
+	}
+}
+
+func TestCommandInputInlineViewSuppressesGhostWhenCursorInsideValue(t *testing.T) {
+	m := model{commandInput: newOperatorCommandInput()}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("fetch --candidate-limit 15")
+	m.commandInput.SetCursor(len([]rune("fetch --candidate-limit ")))
+
+	rendered := ansi.Strip(m.commandInputInlineView("15", lipgloss.NewStyle()))
+	if strings.Contains(rendered, "fetch --candidate-limit 1515") {
+		t.Fatalf("commandInputInlineView duplicated ghost inside value: %q", rendered)
+	}
+	if !strings.Contains(rendered, "fetch --candidate-limit 15") {
+		t.Fatalf("commandInputInlineView() = %q; want original input text", rendered)
 	}
 }
 

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -20,14 +20,53 @@ const llmJobFilteringTimeout = 180 * time.Second
 
 var filterJobsWithLLM = llmpkg.FilterJobsWithLLM
 
+type fetchRunOptions struct {
+	DisableLLM              bool
+	SourceSelectionSet      bool
+	SourceSelection         []string
+	CandidateLimitPerSource *int
+	AcceptedLimit           *int
+}
+
+func defaultFetchRunOptions(disableLLM bool) fetchRunOptions {
+	return fetchRunOptions{
+		DisableLLM:              disableLLM,
+		SourceSelectionSet:      len(runtimeSourceSelection) > 0,
+		SourceSelection:         append([]string(nil), runtimeSourceSelection...),
+		CandidateLimitPerSource: cloneRuntimeIntPtr(runtimeCandidateLimitPerSource),
+		AcceptedLimit:           cloneRuntimeIntPtr(runtimeAcceptedLimit),
+	}
+}
+
+func commandFetchRunOptions(sessionDisableLLM bool, commandOptions operatorFetchOptions) fetchRunOptions {
+	runOptions := defaultFetchRunOptions(sessionDisableLLM || commandOptions.DisableLLM)
+	if commandOptions.SourceSelectionSet {
+		runOptions.SourceSelectionSet = true
+		runOptions.SourceSelection = append([]string(nil), commandOptions.SourceSelection...)
+	}
+	if commandOptions.CandidateLimitPerSource != nil {
+		runOptions.CandidateLimitPerSource = cloneRuntimeIntPtr(commandOptions.CandidateLimitPerSource)
+	}
+	if commandOptions.AcceptedLimit != nil {
+		runOptions.AcceptedLimit = cloneRuntimeIntPtr(commandOptions.AcceptedLimit)
+	}
+	return runOptions
+}
+
 func sessionFetchConfig(disableLLM bool, appCfg *AppConfig) *AppConfig {
+	return fetchConfigForRun(appCfg, defaultFetchRunOptions(disableLLM))
+}
+
+func fetchConfigForRun(appCfg *AppConfig, runOptions fetchRunOptions) *AppConfig {
 	if appCfg == nil {
 		return nil
 	}
 	cfgCopy := *appCfg
-	config.ApplyFetchSourceSelection(&cfgCopy, runtimeSourceSelection)
-	config.ApplyFetchLimitOverrides(&cfgCopy, runtimeCandidateLimitPerSource, runtimeAcceptedLimit)
-	if disableLLM {
+	if runOptions.SourceSelectionSet && len(runOptions.SourceSelection) > 0 {
+		config.ApplyFetchSourceSelection(&cfgCopy, runOptions.SourceSelection)
+	}
+	config.ApplyFetchLimitOverrides(&cfgCopy, runOptions.CandidateLimitPerSource, runOptions.AcceptedLimit)
+	if runOptions.DisableLLM {
 		cfgCopy.LLM.Enabled = false
 		cfgCopy.LLM.JobSearch = false
 		cfgCopy.LLM.JobFiltering = false
@@ -37,12 +76,16 @@ func sessionFetchConfig(disableLLM bool, appCfg *AppConfig) *AppConfig {
 }
 
 func fetchStartMessage(disableLLM bool) string {
+	return fetchStartMessageForOptions(defaultFetchRunOptions(disableLLM))
+}
+
+func fetchStartMessageForOptions(runOptions fetchRunOptions) string {
 	appCfg, err := config.LoadAppConfig(runtimeConfigPath)
 	if err != nil {
 		return "Fetching jobs with your current configuration..."
 	}
-	appCfg = sessionFetchConfig(disableLLM, appCfg)
-	if disableLLM {
+	appCfg = fetchConfigForRun(appCfg, runOptions)
+	if runOptions.DisableLLM {
 		if appCfg.Sources.Enabled {
 			return "Starting configured source search with LLM disabled for this session..."
 		}
@@ -222,6 +265,10 @@ func waitForFetchProgress(ch <-chan string) tea.Cmd {
 }
 
 func fetchJobsCmd(disableLLM bool, existingJobs []Job, progressCh chan<- string) tea.Cmd {
+	return fetchJobsWithOptionsCmd(defaultFetchRunOptions(disableLLM), existingJobs, progressCh)
+}
+
+func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, progressCh chan<- string) tea.Cmd {
 	return func() tea.Msg {
 		fetchStart := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
@@ -232,7 +279,7 @@ func fetchJobsCmd(disableLLM bool, existingJobs []Job, progressCh chan<- string)
 		if err != nil {
 			return fetchJobsMsg{err: fmt.Errorf("failed to load config: %v", err)}
 		}
-		appCfg = sessionFetchConfig(disableLLM, appCfg)
+		appCfg = fetchConfigForRun(appCfg, runOptions)
 
 		criteriaCfg, err := config.LoadCriteriaConfig(runtimeConfigPath)
 		if err != nil {

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -194,6 +194,30 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.openCompanyHealthIdentityOverlay(identity, true, fmt.Sprintf("Loading health for %s...", company), nil, "")
 				return m, tea.Batch(loadCompanyHealthWithIdentity(identity, false), m.restartLoadingIndicator())
 			}
+			if result.FetchOptions != nil {
+				if m.fetchingJobs {
+					m.commandResultTitle = "Command Failed"
+					m.commandResultMessage = "A fetch is already running."
+					m.commandResultError = true
+					return m, nil
+				}
+				runOptions := commandFetchRunOptions(m.sessionLLMDisabled, *result.FetchOptions)
+				progressCh := make(chan string, 8)
+				m.fetchingJobs = true
+				m.fetchProgress = progressCh
+				m.isCommanding = false
+				m.commandInput.Blur()
+				m.commandResultTitle = ""
+				m.commandResultMessage = ""
+				m.commandResultError = false
+				m.activeFetch = activeFetchState{
+					expanded:     true,
+					animProgress: 1.0,
+					title:        "Fetching Jobs",
+					progress:     fetchStartMessageForOptions(runOptions),
+				}
+				return m, tea.Batch(fetchJobsWithOptionsCmd(runOptions, append([]Job(nil), m.allJobs...), progressCh), waitForFetchProgress(progressCh), m.restartLoadingIndicator())
+			}
 			m.commandResultTitle = result.Title
 			m.commandResultMessage = result.Message
 			m.commandResultError = false

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -234,16 +234,8 @@ func (m model) commandInputInlineView(ghost string, ghostStyle lipgloss.Style) s
 	if valueWidth := lipgloss.Width(input.Value()); valueWidth > 0 {
 		input.Width = valueWidth
 	}
-	if ghost != "" && input.Position() < len([]rune(input.Value())) {
-		value := []rune(input.Value())
-		position := input.Position()
-		if position < 0 {
-			position = 0
-		}
-		return string(value[:position]) + ghostStyle.Render(ghost) + string(value[position:])
-	}
 	view := input.View()
-	if ghost != "" {
+	if ghost != "" && input.Position() >= len([]rune(input.Value())) {
 		view += ghostStyle.Render(ghost)
 	}
 	return view

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -111,11 +111,10 @@ func (m model) View() string {
 		if m.commandResultMessage != "" {
 			resultBody := strings.ReplaceAll(m.commandResultMessage, "\n", " • ")
 			lines = append(lines, commandResultTitleStyle.Render(m.commandResultTitle)+helpValueStyle.Render(" ")+commandResultBodyStyle.Render(resultBody))
+		} else {
+			lines = append(lines, " ")
 		}
-		commandLine := commandStyle.Render(":") + " " + m.commandInputInlineView()
-		if ghost := m.operatorCommandGhostHint(); ghost != "" {
-			commandLine += commandHintStyle.Render(ghost)
-		}
+		commandLine := commandStyle.Render(":") + " " + m.commandInputInlineView(m.operatorCommandGhostHint(), commandHintStyle)
 		lines = append(lines, commandLine)
 		lines = append(lines, commandHintStyle.Render("Tab Select/Cycle • Space Confirm • Enter Run • Esc Cancel"))
 		if pool := m.operatorCommandPool(); len(pool) > 0 {
@@ -230,10 +229,22 @@ func (m model) View() string {
 	return viewWithOverlays
 }
 
-func (m model) commandInputInlineView() string {
+func (m model) commandInputInlineView(ghost string, ghostStyle lipgloss.Style) string {
 	input := m.commandInput
 	if valueWidth := lipgloss.Width(input.Value()); valueWidth > 0 {
 		input.Width = valueWidth
 	}
-	return input.View()
+	if ghost != "" && input.Position() < len([]rune(input.Value())) {
+		value := []rune(input.Value())
+		position := input.Position()
+		if position < 0 {
+			position = 0
+		}
+		return string(value[:position]) + ghostStyle.Render(ghost) + string(value[position:])
+	}
+	view := input.View()
+	if ghost != "" {
+		view += ghostStyle.Render(ghost)
+	}
+	return view
 }


### PR DESCRIPTION
## What Changed
- Adds a command-mode fetch command with tab-completed options for sources, candidate limit, accepted limit, and no-LLM mode.
- Wires command-mode fetch execution into the existing fetch flow instead of duplicating the fetch implementation.
- Keeps command status messages stable in the view and expands command-mode tests around completion and option parsing.

## Impact
Users can run targeted fetches from command mode without editing config or leaving the TUI, which makes source testing and limited fetch runs faster.