### PR TITLE
feat(fetch): Implement job candidate caching and decision storage

### DIFF
--- a/docs/DATA_INVENTORY.md
+++ b/docs/DATA_INVENTORY.md
@@ -69,7 +69,7 @@ Stored by `internal/domain/company_identity.go` and the
 
 ### Job Candidates
 
-Stored by `internal/domain/job_candidate.go` and the `job_candidates` tables.
+Stored by `internal/domain/job_candidate.go` and the `job_candidates` table.
 These rows are not shown on the board unless the fetch flow accepts them.
 
 | Field | Used For | Notes |

--- a/docs/DATA_INVENTORY.md
+++ b/docs/DATA_INVENTORY.md
@@ -67,6 +67,36 @@ Stored by `internal/domain/company_identity.go` and the
 | `name_aliases` | identity lookup, health searches | Loaded from lookup table. |
 | `domain_aliases` | identity lookup | Loaded from lookup table. |
 
+### Job Candidates
+
+Stored by `internal/domain/job_candidate.go` and the `job_candidates` tables.
+These rows are not shown on the board unless the fetch flow accepts them.
+
+| Field | Used For | Notes |
+| --- | --- | --- |
+| `candidate_key` | candidate lookup, decision lookup, dedupe | Stable source identity from URL or company/title. |
+| `source`, `source_key` | debug/source reporting | Human-readable source and source identity. |
+| `apply_url`, `canonical_apply_url` | source reuse, posting checks | Keeps the discovered posting URL separate from normalized lookup. |
+| `company`, `title` | lookup/debug | Mirrors the normalized job shape. |
+| `job_json` | source-data reuse | Stores normalized candidate data so later fetches can reuse known fields. |
+| `active` | posting lifecycle | Allows later active checks to mark stale candidates without erasing evidence. |
+| `first_seen`, `last_seen` | pruning/freshness | Candidate cache retention is configurable. |
+
+### Candidate Decisions
+
+Stored by `internal/domain/job_candidate.go` and the
+`job_candidate_decisions` table.
+
+| Field | Used For | Notes |
+| --- | --- | --- |
+| `candidate_key` | candidate lookup | References the candidate row. |
+| `criteria_hash` | cache invalidation | Criteria edits naturally produce different decisions. |
+| `stage`, `decision_version` | matching invalidation | Separates deterministic filters from LLM filtering and lets rules change safely. |
+| `llm_provider`, `llm_model` | LLM decision invalidation | LLM decisions are reused only for the same provider/model path. |
+| `decision`, `reason` | fetch skipping/reporting | Rejected candidates can be skipped before repeating fit work. |
+| `job_json` | audit/debug context | Captures the job shape that produced the decision. |
+| `decided_at`, `expires_at` | freshness | Expiry is available for future decision TTLs. |
+
 ### Company Health
 
 Stored as `health_cache.payload_json`, so it can already retain rich structured
@@ -224,12 +254,15 @@ The current model has three different flexibility levels:
   evidence.
 - `company_identities.identity_evidence_json` is flexible, but most code treats
   it like fixed website/summary/industry evidence.
-- `jobs.company_identity_json` is typed as fixed website/summary/industry
-  evidence, and the top-level `jobs` table has no general metadata column.
+- `job_candidates.job_json` preserves normalized source facts for candidates
+  that may never become visible jobs.
+- `jobs.metadata_json` and `jobs.company_identity_json` preserve structured job
+  and identity metadata for accepted jobs.
 
 This means source adapters can often discover useful facts with nowhere clean to
-put them. Before expanding adapters heavily, the data model should decide where
-opportunistic facts live.
+put them. Candidate and job metadata give adapters a better place to store
+opportunistic facts, but source-specific fields should still be added only when
+they are useful to render, filter, search, score, or debug.
 
 Candidate buckets:
 
@@ -273,4 +306,3 @@ Add a clean place for opportunistic facts before adding many more one-off
 columns. The model should make it easy for any adapter to attach structured
 facts with evidence while still preserving the simple job table fields used by
 the current UI.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,9 +91,12 @@ Fetch limits can be adjusted in `config.yaml`:
 fetch:
   candidate_limit_per_source: 15
   accepted_limit: 0
+  candidate_cache_days: 30
 ```
 
-Use `0` to disable either cap.
+Use `0` to disable the candidate or accepted-result caps. Set
+`candidate_cache_days` to a positive number to override the 30-day retention for
+fetched candidate data and fit decisions.
 
 ## Job Sources
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type LLMWebSearchConfig struct {
 type FetchConfig struct {
 	CandidateLimitPerSource int `yaml:"candidate_limit_per_source,omitempty"`
 	AcceptedLimit           int `yaml:"accepted_limit,omitempty"`
+	CandidateCacheDays      int `yaml:"candidate_cache_days,omitempty"`
 }
 
 type SourcesConfig struct {
@@ -131,6 +132,7 @@ func defaultAppConfig() AppConfig {
 
 	cfg.Fetch.CandidateLimitPerSource = 15
 	cfg.Fetch.AcceptedLimit = 0
+	cfg.Fetch.CandidateCacheDays = 30
 	cfg.Sources.Enabled = true
 	cfg.Sources.BuiltinsEnabled = true
 	cfg.Sources.RSS.Enabled = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,6 +81,9 @@ func TestDefaultFetchPolicyLimitsSiteCandidateEvaluation(t *testing.T) {
 	if cfg.Fetch.AcceptedLimit != 0 {
 		t.Fatalf("default fetch accepted_limit = %d; want 0 for unlimited", cfg.Fetch.AcceptedLimit)
 	}
+	if cfg.Fetch.CandidateCacheDays != 30 {
+		t.Fatalf("default fetch candidate_cache_days = %d; want 30", cfg.Fetch.CandidateCacheDays)
+	}
 }
 
 func TestModelOptionsForProviderIncludesCurrentOpenAITextModels(t *testing.T) {

--- a/internal/domain/job_candidate.go
+++ b/internal/domain/job_candidate.go
@@ -1,0 +1,118 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	CandidateDecisionAccepted = "accepted"
+	CandidateDecisionRejected = "rejected"
+
+	CandidateDecisionStageDeterministic = "deterministic"
+	CandidateDecisionStageLLMFiltering  = "llm_job_filtering"
+
+	CandidateDecisionVersionDeterministic = "deterministic:v1"
+	CandidateDecisionVersionLLMFiltering  = "llm_job_filtering:v1"
+)
+
+type JobCandidate struct {
+	Key               string    `json:"key"`
+	Source            string    `json:"source,omitempty"`
+	SourceKey         string    `json:"source_key,omitempty"`
+	ApplyURL          string    `json:"apply_url,omitempty"`
+	CanonicalApplyURL string    `json:"canonical_apply_url,omitempty"`
+	Company           string    `json:"company,omitempty"`
+	Title             string    `json:"title,omitempty"`
+	Job               Job       `json:"job"`
+	Active            bool      `json:"active"`
+	FirstSeen         time.Time `json:"first_seen,omitempty"`
+	LastSeen          time.Time `json:"last_seen,omitempty"`
+}
+
+type JobCandidateDecisionKey struct {
+	CandidateKey    string
+	CriteriaHash    string
+	Stage           string
+	DecisionVersion string
+	LLMProvider     string
+	LLMModel        string
+}
+
+type JobCandidateDecision struct {
+	JobCandidateDecisionKey
+	Decision  string
+	Reason    string
+	Job       Job
+	DecidedAt time.Time
+	ExpiresAt time.Time
+}
+
+func CriteriaHash(criteria *CriteriaConfig) string {
+	if criteria == nil {
+		return "none"
+	}
+	normalized := *criteria
+	normalizeStringSlice(&normalized.Filters.TitleRequires)
+	normalizeStringSlice(&normalized.Filters.TitleIncludes)
+	normalizeStringSlice(&normalized.Filters.TitleExcludes)
+	normalizeStringSlice(&normalized.Filters.IndustryIncludes)
+	normalizeStringSlice(&normalized.Filters.IndustryExcludes)
+	normalizeRoleFamilySlice(&normalized.RoleFamilies)
+	normalizeStringSlice(&normalized.ResolvedSourceIDs)
+	normalizeStringSlice(&normalized.PrioritySignals)
+
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return "invalid"
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:16])
+}
+
+func normalizeStringSlice(values *[]string) {
+	if values == nil || len(*values) == 0 {
+		return
+	}
+	normalized := make([]string, 0, len(*values))
+	seen := make(map[string]struct{}, len(*values))
+	for _, value := range *values {
+		value = strings.ToLower(strings.Join(strings.Fields(value), " "))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	*values = normalized
+}
+
+func normalizeRoleFamilySlice(values *[]RoleFamilyID) {
+	if values == nil || len(*values) == 0 {
+		return
+	}
+	normalized := make([]RoleFamilyID, 0, len(*values))
+	seen := make(map[RoleFamilyID]struct{}, len(*values))
+	for _, value := range *values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i] < normalized[j]
+	})
+	*values = normalized
+}

--- a/internal/fetcher/builtin_listing_test.go
+++ b/internal/fetcher/builtin_listing_test.go
@@ -123,7 +123,7 @@ func TestParseBuiltInSiteSearchHTMLRecordsExistingListingCard(t *testing.T) {
 		ApplyURL: "https://builtin.com/job/staff-devops-engineer/7934986",
 	}})
 
-	jobs, filtered, handled, err := parseBuiltInSiteSearchHTML(context.Background(), rawHTML, "https://builtin.com/jobs/remote?search=staff", "Site Search: Built In", "https://builtin.com/jobs/remote", criteria, nil, nil, existing, nil)
+	jobs, filtered, handled, err := parseBuiltInSiteSearchHTML(context.Background(), rawHTML, "https://builtin.com/jobs/remote?search=staff", "Site Search: Built In", "https://builtin.com/jobs/remote", criteria, nil, nil, existing, nil, nil)
 
 	if err != nil {
 		t.Fatalf("parseBuiltInSiteSearchHTML() error = %v, want nil", err)

--- a/internal/fetcher/candidate_cache.go
+++ b/internal/fetcher/candidate_cache.go
@@ -1,0 +1,411 @@
+package fetcher
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/wallentx/jobscout/internal/domain"
+	"github.com/wallentx/jobscout/internal/storage"
+)
+
+const (
+	defaultCandidateCacheDays = 30
+)
+
+var deterministicCandidateDecisionReasons = map[string]struct{}{
+	"title excludes":     {},
+	"title requirements": {},
+	"title includes":     {},
+	"industry excludes":  {},
+	"pay":                {},
+	"work setting":       {},
+}
+
+func candidateCacheRetention(appCfg *AppConfig) time.Duration {
+	days := defaultCandidateCacheDays
+	if appCfg != nil && appCfg.Fetch.CandidateCacheDays > 0 {
+		days = appCfg.Fetch.CandidateCacheDays
+	}
+	return time.Duration(days) * 24 * time.Hour
+}
+
+func pruneCandidateCache(ctx context.Context, store storage.CandidateStore, appCfg *AppConfig) {
+	if store == nil {
+		return
+	}
+	cutoff := time.Now().Add(-candidateCacheRetention(appCfg))
+	removed, err := store.PruneJobCandidateCache(ctx, cutoff)
+	if err != nil {
+		logDebug("candidate cache: prune failed: %v", err)
+		return
+	}
+	if removed > 0 {
+		logDebug("candidate cache: pruned %d candidates older than %s", removed, cutoff.Format(time.RFC3339))
+	}
+}
+
+func upsertJobCandidates(ctx context.Context, store storage.CandidateStore, jobs []Job) {
+	upsertJobCandidatesWithActive(ctx, store, jobs, true)
+}
+
+func upsertJobCandidatesWithActive(ctx context.Context, store storage.CandidateStore, jobs []Job, active bool) {
+	if store == nil || len(jobs) == 0 {
+		return
+	}
+	candidates := make([]domain.JobCandidate, 0, len(jobs))
+	now := time.Now()
+	for _, job := range jobs {
+		candidate, ok := jobCandidateFromJob(job, now, active)
+		if ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	if err := store.UpsertJobCandidates(ctx, candidates); err != nil {
+		logDebug("candidate cache: failed to store %d candidates: %v", len(candidates), err)
+		return
+	}
+	logDebug("candidate cache: stored %d candidates", len(candidates))
+}
+
+func RecordAcceptedJobCandidates(ctx context.Context, store storage.CandidateStore, jobs []Job) {
+	upsertJobCandidates(ctx, store, jobs)
+}
+
+func RecordInactiveJobCandidates(ctx context.Context, store storage.CandidateStore, jobs []Job) {
+	upsertJobCandidatesWithActive(ctx, store, jobs, false)
+}
+
+func jobCandidateFromJob(job Job, now time.Time, active bool) (domain.JobCandidate, bool) {
+	key := strings.TrimSpace(fetchedJobDedupeKey(job))
+	if key == "" {
+		return domain.JobCandidate{}, false
+	}
+	sourceKey := key
+	canonicalApplyURL := ""
+	if strings.HasPrefix(key, "url:") {
+		canonicalApplyURL = strings.TrimPrefix(key, "url:")
+	} else if strings.TrimSpace(job.ApplyURL) != "" {
+		canonicalApplyURL = canonicalURLVisitKey(job.ApplyURL)
+	}
+	return domain.JobCandidate{
+		Key:               key,
+		Source:            strings.TrimSpace(job.Source),
+		SourceKey:         sourceKey,
+		ApplyURL:          strings.TrimSpace(job.ApplyURL),
+		CanonicalApplyURL: canonicalApplyURL,
+		Company:           strings.TrimSpace(job.Company),
+		Title:             strings.TrimSpace(job.Title),
+		Job:               job,
+		Active:            active,
+		FirstSeen:         now,
+		LastSeen:          now,
+	}, true
+}
+
+func hydrateJobsFromCandidateCache(ctx context.Context, store storage.CandidateStore, jobs []Job) []Job {
+	if store == nil || len(jobs) == 0 {
+		return jobs
+	}
+	hits := 0
+	for i := range jobs {
+		key := strings.TrimSpace(fetchedJobDedupeKey(jobs[i]))
+		if key == "" {
+			continue
+		}
+		candidate, err := store.GetJobCandidate(ctx, key)
+		if err != nil {
+			logDebug("candidate cache: lookup failed key=%q: %v", key, err)
+			continue
+		}
+		if candidate == nil {
+			continue
+		}
+		before := jobs[i]
+		domain.MergeJobIdentityFields(&jobs[i], candidate.Job)
+		if jobChangedByCandidateHydration(before, jobs[i]) {
+			hits++
+		}
+	}
+	if hits > 0 {
+		logDebug("candidate cache: hydrated %d jobs from cached normalized source data", hits)
+	}
+	return jobs
+}
+
+func jobChangedByCandidateHydration(before Job, after Job) bool {
+	return before.CompanyWebsite != after.CompanyWebsite ||
+		before.CompanySummary != after.CompanySummary ||
+		before.CompanyIndustry != after.CompanyIndustry ||
+		before.Compensation != after.Compensation ||
+		before.Description != after.Description ||
+		!reflect.DeepEqual(before.Metadata, after.Metadata)
+}
+
+func applyCachedDeterministicRejects(ctx context.Context, store storage.CandidateStore, criteria *CriteriaConfig, jobs []Job, summary *FetchSummary) []Job {
+	key := deterministicCandidateDecisionKey(criteria)
+	kept, rejected := filterCachedRejectedJobs(ctx, store, key, jobs)
+	if len(rejected) == 0 {
+		return jobs
+	}
+	if summary != nil {
+		if summary.Filtered == nil {
+			summary.Filtered = make(map[string][]Job)
+		}
+		summary.Filtered["cached rejection"] = append(summary.Filtered["cached rejection"], rejected...)
+	}
+	logDebug("candidate cache: skipped %d candidates with cached deterministic rejections", len(rejected))
+	return kept
+}
+
+func deterministicCandidateDecisionKey(criteria *CriteriaConfig) domain.JobCandidateDecisionKey {
+	return domain.JobCandidateDecisionKey{
+		CriteriaHash:    domain.CriteriaHash(criteria),
+		Stage:           domain.CandidateDecisionStageDeterministic,
+		DecisionVersion: domain.CandidateDecisionVersionDeterministic,
+	}
+}
+
+func cachedDeterministicRejectedJob(ctx context.Context, store storage.CandidateStore, criteria *CriteriaConfig, job Job) (Job, bool) {
+	if store == nil {
+		return Job{}, false
+	}
+	key := deterministicCandidateDecisionKey(criteria)
+	key.CandidateKey = strings.TrimSpace(fetchedJobDedupeKey(job))
+	if key.CandidateKey == "" {
+		return Job{}, false
+	}
+	decision, err := store.GetJobCandidateDecision(ctx, key)
+	if err != nil {
+		logDebug("candidate cache: decision lookup failed key=%q stage=%q: %v", key.CandidateKey, key.Stage, err)
+		return Job{}, false
+	}
+	if decision == nil || decision.Decision != domain.CandidateDecisionRejected {
+		return Job{}, false
+	}
+	cached := job
+	if !jobLooksUsableForCachedRejection(cached) {
+		if candidate, err := store.GetJobCandidate(ctx, key.CandidateKey); err == nil && candidate != nil {
+			cached = candidate.Job
+		} else if err != nil {
+			logDebug("candidate cache: candidate lookup failed key=%q: %v", key.CandidateKey, err)
+		}
+	}
+	if !jobLooksUsableForCachedRejection(cached) && jobLooksUsableForCachedRejection(decision.Job) {
+		cached = decision.Job
+	}
+	if strings.TrimSpace(cached.Source) == "" {
+		cached.Source = strings.TrimSpace(job.Source)
+	}
+	if strings.TrimSpace(cached.ApplyURL) == "" {
+		cached.ApplyURL = strings.TrimSpace(job.ApplyURL)
+	}
+	if reason := strings.TrimSpace(decision.Reason); reason != "" {
+		cached.WhyMatches = append(cached.WhyMatches, "Cached rejection: "+reason)
+	}
+	return cached, true
+}
+
+func jobLooksUsableForCachedRejection(job Job) bool {
+	return strings.TrimSpace(job.Company) != "" &&
+		!siteSearchCompanyMissingOrInvalid(job.Company) &&
+		strings.TrimSpace(job.Title) != ""
+}
+
+func recordDeterministicCandidateDecisions(ctx context.Context, store storage.CandidateStore, criteria *CriteriaConfig, accepted []Job, filtered map[string][]Job) {
+	if store == nil {
+		return
+	}
+	criteriaHash := domain.CriteriaHash(criteria)
+	decisions := make([]domain.JobCandidateDecision, 0, len(accepted)+countFilteredJobs(filtered))
+	for _, job := range accepted {
+		if decision, ok := jobCandidateDecision(job, criteriaHash, domain.CandidateDecisionStageDeterministic, domain.CandidateDecisionVersionDeterministic, "", "", domain.CandidateDecisionAccepted, ""); ok {
+			decisions = append(decisions, decision)
+		}
+	}
+	for reason, jobs := range filtered {
+		if _, ok := deterministicCandidateDecisionReasons[reason]; !ok {
+			continue
+		}
+		for _, job := range jobs {
+			if decision, ok := jobCandidateDecision(job, criteriaHash, domain.CandidateDecisionStageDeterministic, domain.CandidateDecisionVersionDeterministic, "", "", domain.CandidateDecisionRejected, reason); ok {
+				decisions = append(decisions, decision)
+			}
+		}
+	}
+	upsertJobCandidateDecisions(ctx, store, decisions, "deterministic")
+}
+
+func ApplyCachedLLMFilterDecisions(ctx context.Context, store storage.CandidateStore, appCfg *AppConfig, criteria *CriteriaConfig, jobs []Job, summary *FetchSummary) []Job {
+	signature, ok := llmFilteringDecisionSignature(appCfg)
+	if !ok {
+		return jobs
+	}
+	key := domain.JobCandidateDecisionKey{
+		CriteriaHash:    domain.CriteriaHash(criteria),
+		Stage:           domain.CandidateDecisionStageLLMFiltering,
+		DecisionVersion: domain.CandidateDecisionVersionLLMFiltering,
+		LLMProvider:     signature.provider,
+		LLMModel:        signature.model,
+	}
+	kept, rejected := filterCachedRejectedJobs(ctx, store, key, jobs)
+	if len(rejected) == 0 {
+		return jobs
+	}
+	if summary != nil {
+		if summary.Filtered == nil {
+			summary.Filtered = make(map[string][]Job)
+		}
+		summary.Filtered["cached llm rejection"] = append(summary.Filtered["cached llm rejection"], rejected...)
+	}
+	logDebug("candidate cache: skipped %d candidates with cached LLM filter rejections", len(rejected))
+	return kept
+}
+
+func RecordLLMFilterCandidateDecisions(ctx context.Context, store storage.CandidateStore, appCfg *AppConfig, criteria *CriteriaConfig, before []Job, after []Job, notices []string) {
+	if store == nil || len(before) == 0 || len(notices) > 0 {
+		return
+	}
+	signature, ok := llmFilteringDecisionSignature(appCfg)
+	if !ok {
+		return
+	}
+	criteriaHash := domain.CriteriaHash(criteria)
+	afterKeys := make(map[string]struct{}, len(after))
+	for _, job := range after {
+		if key := strings.TrimSpace(fetchedJobDedupeKey(job)); key != "" {
+			afterKeys[key] = struct{}{}
+		}
+	}
+	decisions := make([]domain.JobCandidateDecision, 0, len(before))
+	for _, job := range before {
+		key := strings.TrimSpace(fetchedJobDedupeKey(job))
+		if key == "" {
+			continue
+		}
+		decision := domain.CandidateDecisionRejected
+		reason := "llm job filtering"
+		if _, ok := afterKeys[key]; ok {
+			decision = domain.CandidateDecisionAccepted
+			reason = ""
+		}
+		if candidateDecision, ok := jobCandidateDecision(job, criteriaHash, domain.CandidateDecisionStageLLMFiltering, domain.CandidateDecisionVersionLLMFiltering, signature.provider, signature.model, decision, reason); ok {
+			decisions = append(decisions, candidateDecision)
+		}
+	}
+	upsertJobCandidateDecisions(ctx, store, decisions, "llm filtering")
+}
+
+func filterCachedRejectedJobs(ctx context.Context, store storage.CandidateStore, key domain.JobCandidateDecisionKey, jobs []Job) ([]Job, []Job) {
+	if store == nil || len(jobs) == 0 {
+		return jobs, nil
+	}
+	kept := make([]Job, 0, len(jobs))
+	rejected := make([]Job, 0)
+	for _, job := range jobs {
+		candidateKey := strings.TrimSpace(fetchedJobDedupeKey(job))
+		if candidateKey == "" {
+			kept = append(kept, job)
+			continue
+		}
+		key.CandidateKey = candidateKey
+		decision, err := store.GetJobCandidateDecision(ctx, key)
+		if err != nil {
+			logDebug("candidate cache: decision lookup failed key=%q stage=%q: %v", candidateKey, key.Stage, err)
+			kept = append(kept, job)
+			continue
+		}
+		if decision != nil && decision.Decision == domain.CandidateDecisionRejected {
+			if strings.TrimSpace(decision.Reason) != "" {
+				job.WhyMatches = append(job.WhyMatches, "Cached rejection: "+decision.Reason)
+			}
+			rejected = append(rejected, job)
+			continue
+		}
+		kept = append(kept, job)
+	}
+	return kept, rejected
+}
+
+func jobCandidateDecision(job Job, criteriaHash string, stage string, version string, provider string, model string, decision string, reason string) (domain.JobCandidateDecision, bool) {
+	candidate, ok := jobCandidateFromJob(job, time.Now(), true)
+	if !ok {
+		return domain.JobCandidateDecision{}, false
+	}
+	return domain.JobCandidateDecision{
+		JobCandidateDecisionKey: domain.JobCandidateDecisionKey{
+			CandidateKey:    candidate.Key,
+			CriteriaHash:    strings.TrimSpace(criteriaHash),
+			Stage:           strings.TrimSpace(stage),
+			DecisionVersion: strings.TrimSpace(version),
+			LLMProvider:     strings.ToLower(strings.TrimSpace(provider)),
+			LLMModel:        strings.TrimSpace(model),
+		},
+		Decision:  strings.TrimSpace(decision),
+		Reason:    strings.TrimSpace(reason),
+		Job:       job,
+		DecidedAt: time.Now(),
+	}, true
+}
+
+func upsertJobCandidateDecisions(ctx context.Context, store storage.CandidateStore, decisions []domain.JobCandidateDecision, label string) {
+	if store == nil || len(decisions) == 0 {
+		return
+	}
+	candidates := make([]domain.JobCandidate, 0, len(decisions))
+	now := time.Now()
+	for _, decision := range decisions {
+		candidate, ok := jobCandidateFromJob(decision.Job, now, true)
+		if ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if err := store.UpsertJobCandidates(ctx, candidates); err != nil {
+		logDebug("candidate cache: failed to store %s candidates before decisions: %v", label, err)
+		return
+	}
+	if err := store.UpsertJobCandidateDecisions(ctx, decisions); err != nil {
+		logDebug("candidate cache: failed to store %s decisions: %v", label, err)
+		return
+	}
+	logDebug("candidate cache: stored %d %s decisions", len(decisions), label)
+}
+
+type llmFilteringSignature struct {
+	provider string
+	model    string
+}
+
+func llmFilteringDecisionSignature(appCfg *AppConfig) (llmFilteringSignature, bool) {
+	if appCfg == nil || !appCfg.LLM.Enabled || !appCfg.LLM.JobFiltering {
+		return llmFilteringSignature{}, false
+	}
+	provider := strings.ToLower(strings.TrimSpace(appCfg.LLM.Provider))
+	if provider == "" {
+		return llmFilteringSignature{}, false
+	}
+	model := strings.TrimSpace(appCfg.LLM.Model)
+	if appCfg.LLM.Providers != nil {
+		providerCfg := appCfg.LLM.Providers[provider]
+		providerModel := strings.TrimSpace(providerCfg.Model)
+		if providerCfg.Models != nil {
+			providerModel = firstNonEmptyString(providerCfg.Models["llm_job_filtering"], providerModel)
+		}
+		model = firstNonEmptyString(providerModel, model)
+	}
+	if appCfg.LLM.Models != nil {
+		model = firstNonEmptyString(appCfg.LLM.Models["llm_job_filtering"], model)
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return llmFilteringSignature{}, false
+	}
+	return llmFilteringSignature{
+		provider: provider,
+		model:    model,
+	}, true
+}

--- a/internal/fetcher/candidate_cache_test.go
+++ b/internal/fetcher/candidate_cache_test.go
@@ -1,0 +1,61 @@
+package fetcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wallentx/jobscout/internal/domain"
+	appruntime "github.com/wallentx/jobscout/internal/runtime"
+)
+
+func TestApplyCachedLLMFilterDecisionsSkipsRejectedCandidate(t *testing.T) {
+	ctx := context.Background()
+	store := appruntime.InMemoryStores().Candidates
+	appCfg := defaultAppConfig()
+	criteria := defaultCriteriaConfig()
+	job := Job{
+		Company:     "DropCo",
+		Title:       "Platform Engineer",
+		Source:      "Site Search: Example",
+		ApplyURL:    "https://jobs.example/dropco/platform-engineer",
+		Description: "Platform engineering role.",
+	}
+	candidate, ok := jobCandidateFromJob(job, time.Now(), true)
+	if !ok {
+		t.Fatal("jobCandidateFromJob() ok = false, want true")
+	}
+	if err := store.UpsertJobCandidate(ctx, candidate); err != nil {
+		t.Fatalf("UpsertJobCandidate() error = %v", err)
+	}
+	signature, ok := llmFilteringDecisionSignature(&appCfg)
+	if !ok {
+		t.Fatal("llmFilteringDecisionSignature() ok = false, want true")
+	}
+	if err := store.UpsertJobCandidateDecision(ctx, domain.JobCandidateDecision{
+		JobCandidateDecisionKey: domain.JobCandidateDecisionKey{
+			CandidateKey:    candidate.Key,
+			CriteriaHash:    domain.CriteriaHash(&criteria),
+			Stage:           domain.CandidateDecisionStageLLMFiltering,
+			DecisionVersion: domain.CandidateDecisionVersionLLMFiltering,
+			LLMProvider:     signature.provider,
+			LLMModel:        signature.model,
+		},
+		Decision:  domain.CandidateDecisionRejected,
+		Reason:    "llm job filtering",
+		Job:       job,
+		DecidedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("UpsertJobCandidateDecision() error = %v", err)
+	}
+	summary := newFetchSummary()
+
+	got := ApplyCachedLLMFilterDecisions(ctx, store, &appCfg, &criteria, []Job{job}, &summary)
+
+	if len(got) != 0 {
+		t.Fatalf("ApplyCachedLLMFilterDecisions() len = %d; want 0", len(got))
+	}
+	if len(summary.Filtered["cached llm rejection"]) != 1 {
+		t.Fatalf("summary.Filtered[cached llm rejection] len = %d; want 1", len(summary.Filtered["cached llm rejection"]))
+	}
+}

--- a/internal/fetcher/company_identity_cache.go
+++ b/internal/fetcher/company_identity_cache.go
@@ -89,7 +89,7 @@ func ApplyCachedIdentity(job *Job, record CompanyIdentityRecord) {
 	if job == nil {
 		return
 	}
-	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" && trustedRecordEvidence(record.Identity, "website", record.Website) {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" && trustedRecordEvidence(record.Identity, "website", record.Website) && !recordWebsiteEvidenceBlocked(record) {
 		job.CompanyWebsite = record.Website
 		setCachedIdentityEvidence(job, "website", record.Website, copiedEvidence(record.Identity, "website"))
 	}
@@ -193,7 +193,7 @@ func trustedIdentityRecordFromJob(job Job) (CompanyIdentityRecord, int, int, int
 	websiteRank := 0
 	summaryRank := 0
 	industryRank := 0
-	if !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && trustedIdentityEvidence(job.CompanyIdentity, "website", job.CompanyWebsite) {
+	if !domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && trustedIdentityEvidence(job.CompanyIdentity, "website", job.CompanyWebsite) && !jobWebsiteEvidenceBlocked(job) {
 		record.Website = job.CompanyWebsite
 		w := *job.CompanyIdentity.Website
 		identity.Website = &w
@@ -300,7 +300,7 @@ func applySameCompanyIdentity(job *Job, record CompanyIdentityRecord) int {
 		return 0
 	}
 	copied := 0
-	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" {
+	if domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && record.Website != "" && !recordWebsiteEvidenceBlocked(record) {
 		job.CompanyWebsite = record.Website
 		setCopiedSameCompanyEvidence(job, "website", record.Website, copiedEvidence(record.Identity, "website"))
 		copied++
@@ -316,6 +316,20 @@ func applySameCompanyIdentity(job *Job, record CompanyIdentityRecord) int {
 		copied++
 	}
 	return copied
+}
+
+func recordWebsiteEvidenceBlocked(record CompanyIdentityRecord) bool {
+	if record.Identity == nil || record.Identity.Website == nil {
+		return false
+	}
+	return sourceProfileWebsiteCandidateBlocked(record.Website, record.Identity.Website.URL)
+}
+
+func jobWebsiteEvidenceBlocked(job Job) bool {
+	if job.CompanyIdentity == nil || job.CompanyIdentity.Website == nil {
+		return false
+	}
+	return sourceProfileWebsiteCandidateBlocked(job.CompanyWebsite, job.CompanyIdentity.Website.URL)
 }
 
 func copiedEvidence(identity *domain.JobIdentityMetadata, field string) *domain.JobIdentityEvidence {

--- a/internal/fetcher/company_profile_extract.go
+++ b/internal/fetcher/company_profile_extract.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/wallentx/jobscout/internal/domain"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 func extractSourceCompanyProfileURL(rawHTML string, pageURL string) string {
@@ -109,8 +111,14 @@ func applyCompanyPublicProfileEvidence(job *Job, evidence domain.CompanyPublicPr
 }
 
 func extractCompanyWebsiteFromHTML(rawHTML string, applyURL string, company string) string {
-	if website := extractStructuredCompanyWebsite(rawHTML); website != "" && looksLikeCompanyWebsite(website, applyURL) {
+	if website := extractLinkedInCompanyProfileWebsite(rawHTML, applyURL); website != "" {
 		return normalizeCompanyWebsiteURL(website)
+	}
+	if website := extractStructuredCompanyWebsite(rawHTML); website != "" && looksLikeCompanyWebsite(website, applyURL) {
+		website = normalizeCompanyWebsiteURL(website)
+		if structuredCompanyWebsiteAllowed(website, applyURL, company) {
+			return website
+		}
 	}
 	if website := extractLabeledHref(rawHTML, applyURL, []string{"url", "website", "company website", "view company", "home page", "learn more about us"}); website != "" {
 		return normalizeCompanyWebsiteURL(website)
@@ -128,11 +136,28 @@ func extractCompanyWebsiteFromHTML(rawHTML string, applyURL string, company stri
 		if !looksLikeCompanyWebsite(href, applyURL) {
 			continue
 		}
-		if strings.Contains(strings.ToLower(rawHTML), "url:</strong>") {
+		if strings.Contains(strings.ToLower(rawHTML), "url:</strong>") && candidateWebsiteMatchesCompany(href, company) {
 			return normalizeCompanyWebsiteURL(href)
 		}
 	}
 	return ""
+}
+
+func extractLinkedInCompanyProfileWebsite(rawHTML string, profileURL string) string {
+	if publicProfileSource(profileURL) != "linkedin" {
+		return ""
+	}
+	return extractLabeledHref(rawHTML, profileURL, []string{"website"})
+}
+
+func structuredCompanyWebsiteAllowed(website string, pageURL string, company string) bool {
+	if sourceProfileWebsiteCandidateBlocked(website, pageURL) {
+		return false
+	}
+	if publicProfileSource(pageURL) != "" {
+		return candidateWebsiteMatchesCompany(website, company)
+	}
+	return true
 }
 
 func companyWebsiteFromProfileLinks(links []pageLink, profileURL string, company string) string {
@@ -316,36 +341,88 @@ func cleanCompanyProfileSummary(summary string, company string) string {
 }
 
 func extractLabeledHref(rawHTML string, applyURL string, labels []string) string {
-	for _, href := range extractHTMLHrefs(rawHTML) {
+	doc, err := newHTMLDocument(rawHTML)
+	if err != nil {
+		return ""
+	}
+	best := ""
+	bestScore := 0
+	doc.Find("a[href]").Each(func(_ int, selection *goquery.Selection) {
+		if bestScore >= 10 {
+			return
+		}
+		href, _ := selection.Attr("href")
 		candidate := decodeProfileExternalLink(resolveURL(applyURL, href))
 		if !looksLikeCompanyWebsite(candidate, applyURL) {
-			continue
+			return
 		}
-		needle := strings.ToLower(href)
-		idx := strings.Index(strings.ToLower(rawHTML), needle)
-		if idx < 0 {
-			needle = strings.ToLower(candidate)
-			idx = strings.Index(strings.ToLower(rawHTML), needle)
+		if sourceProfileWebsiteCandidateBlocked(candidate, applyURL) {
+			return
 		}
-		if idx < 0 {
-			continue
+		score := scoreLabeledHrefContext(visibleLinkContext(selection), labels)
+		if score <= bestScore {
+			return
 		}
-		start := idx - 200
-		if start < 0 {
-			start = 0
-		}
-		end := idx + len(href) + 200
-		if end > len(rawHTML) {
-			end = len(rawHTML)
-		}
-		contextText := strings.ToLower(normalizeHTMLText(rawHTML[start:end]))
-		for _, label := range labels {
-			if strings.Contains(contextText, strings.ToLower(label)) {
-				return candidate
-			}
+		bestScore = score
+		best = candidate
+	})
+	return best
+}
+
+func visibleLinkContext(selection *goquery.Selection) string {
+	if selection == nil {
+		return ""
+	}
+	parts := make([]string, 0, 5)
+	add := func(text string) {
+		text = NormalizeWhitespace(text)
+		if text != "" {
+			parts = append(parts, text)
 		}
 	}
-	return ""
+	add(selection.Text())
+	for node := selection.Parent(); node != nil && node.Length() > 0 && len(parts) < 5; node = node.Parent() {
+		if node.Is("body") || node.Is("html") {
+			break
+		}
+		add(node.Text())
+	}
+	selection.PrevAllFiltered("dt,div,span,p,h2,h3,h4,label").EachWithBreak(func(_ int, sibling *goquery.Selection) bool {
+		add(sibling.Text())
+		return len(parts) < 5
+	})
+	return NormalizeWhitespace(strings.Join(parts, " "))
+}
+
+func scoreLabeledHrefContext(context string, labels []string) int {
+	context = strings.ToLower(NormalizeWhitespace(context))
+	if context == "" {
+		return 0
+	}
+	score := 0
+	for _, label := range labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if label != "" && strings.Contains(context, label) {
+			score += 10
+		}
+	}
+	return score
+}
+
+func sourceProfileWebsiteCandidateBlocked(candidate string, pageURL string) bool {
+	if publicProfileSource(pageURL) != "linkedin" && !isLinkedInJobURL(pageURL) {
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(candidate))
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	return isLinkedInAssetHost(parsed.Hostname())
+}
+
+func isLinkedInAssetHost(host string) bool {
+	host = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(host), "www."))
+	return host == "licdn.com" || strings.HasSuffix(host, ".licdn.com")
 }
 
 func decodeProfileExternalLink(rawURL string) string {

--- a/internal/fetcher/fetched_job_dedupe.go
+++ b/internal/fetcher/fetched_job_dedupe.go
@@ -83,6 +83,9 @@ func fetchedJobDedupeKey(job Job) string {
 	if key := builtInJobDedupeKey(job.ApplyURL); key != "" {
 		return key
 	}
+	if key := linkedInJobDedupeKey(job.ApplyURL); key != "" {
+		return key
+	}
 	if key := canonicalApplyURLDedupeKeyForJob(job); key != "" {
 		return key
 	}
@@ -105,6 +108,21 @@ func builtInJobDedupeKey(rawURL string) string {
 	return "builtin:" + id
 }
 
+func linkedInJobDedupeKey(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" || !isLinkedInHost(parsed.Hostname()) {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) < 3 || !strings.EqualFold(parts[0], "jobs") || !strings.EqualFold(parts[1], "view") {
+		return ""
+	}
+	if id := trailingNumericSuffix(parts[2]); id != "" {
+		return "linkedin:" + id
+	}
+	return ""
+}
+
 func canonicalApplyURLDedupeKeyForJob(job Job) string {
 	rawURL := job.ApplyURL
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
@@ -122,6 +140,25 @@ func canonicalApplyURLDedupeKeyForJob(job Job) string {
 		return ""
 	}
 	return "url:" + parsed.String()
+}
+
+func trailingNumericSuffix(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	end := len(value)
+	start := end
+	for start > 0 && value[start-1] >= '0' && value[start-1] <= '9' {
+		start--
+	}
+	if start == end {
+		return ""
+	}
+	if start > 0 && value[start-1] != '-' && value[start-1] != '/' {
+		return ""
+	}
+	return value[start:end]
 }
 
 func canonicalApplyURLLooksJobSpecific(parsed *url.URL, job Job) bool {

--- a/internal/fetcher/fetched_job_dedupe_test.go
+++ b/internal/fetcher/fetched_job_dedupe_test.go
@@ -59,6 +59,35 @@ func TestDedupeFetchedJobsUsesCanonicalApplyURL(t *testing.T) {
 	}
 }
 
+func TestDedupeFetchedJobsUsesLinkedInJobIDIgnoringTrackingQuery(t *testing.T) {
+	jobs := []Job{
+		{
+			Company:  "Innergy",
+			Title:    "Principal DevOps Engineer",
+			ApplyURL: "https://www.linkedin.com/jobs/view/principal-devops-engineer-at-innergy-4413760287?position=11&pageNum=0&refId=first&trackingId=first",
+		},
+		{
+			Company:         "Innergy",
+			Title:           "Principal DevOps Engineer",
+			ApplyURL:        "https://www.linkedin.com/jobs/view/principal-devops-engineer-at-innergy-4413760287?position=36&pageNum=0&refId=second&trackingId=second",
+			CompanyWebsite:  "https://www.innergy.com",
+			CompanyIndustry: "Energy",
+		},
+	}
+
+	deduped, duplicates := dedupeFetchedJobs(jobs)
+
+	if len(deduped) != 1 {
+		t.Fatalf("dedupeFetchedJobs(...) deduped len = %d; want 1", len(deduped))
+	}
+	if len(duplicates) != 1 {
+		t.Fatalf("dedupeFetchedJobs(...) duplicates len = %d; want 1", len(duplicates))
+	}
+	if deduped[0].CompanyWebsite != "https://www.innergy.com" {
+		t.Fatalf("deduped[0].CompanyWebsite = %q; want merged duplicate website", deduped[0].CompanyWebsite)
+	}
+}
+
 func TestDedupeFetchedJobsUsesCanonicalApplyURLAcrossIdentityDrift(t *testing.T) {
 	jobs := []Job{
 		{

--- a/internal/fetcher/job_fetcher.go
+++ b/internal/fetcher/job_fetcher.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/wallentx/jobscout/internal/storage"
 )
 
 const (
@@ -20,13 +21,18 @@ const (
 )
 
 func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, progress func(string), existingJobs ...[]Job) ([]Job, FetchSummary, error) {
-	fetchStart := time.Now()
-	var allFetched []Job
-	summary := newFetchSummary()
 	var existing []Job
 	if len(existingJobs) > 0 {
 		existing = existingJobs[0]
 	}
+	return fetchAllJobsWithCandidateCache(ctx, appCfg, criteriaCfg, progress, existing, nil)
+}
+
+func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, progress func(string), existingJobs []Job, candidateStore storage.CandidateStore) ([]Job, FetchSummary, error) {
+	fetchStart := time.Now()
+	var allFetched []Job
+	summary := newFetchSummary()
+	existing := existingJobs
 	existingIndex := newExistingJobIndex(existing)
 	defer func() {
 		logDebug(
@@ -44,6 +50,7 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 		}
 		return allFetched, summary, nil
 	}
+	pruneCandidateCache(ctx, candidateStore, appCfg)
 	if err := refreshLinkedInCriteriaHints(ctx, criteriaCfg); err != nil {
 		logDebug("linkedin criteria hint refresh failed: %v", err)
 	}
@@ -419,7 +426,7 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 			runBounded(ctx, len(tasks), maxConcurrentSiteSearchFetch, func(i int) {
 				task := tasks[i]
 				reportFetchProgress(progress, "Searching site target: %s", strings.TrimSpace(task.site))
-				results[i] = fetchSiteSearchTask(ctx, task, criteriaCfg, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches, blockedSiteDetails, candidateLimiter)
+				results[i] = fetchSiteSearchTask(ctx, task, criteriaCfg, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches, blockedSiteDetails, candidateLimiter, candidateStore)
 			})
 
 			for i, result := range results {
@@ -460,6 +467,16 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 	}()
 
 	wg.Wait()
+
+	if candidateStore != nil {
+		allFetched = hydrateJobsFromCandidateCache(ctx, candidateStore, allFetched)
+		upsertJobCandidates(ctx, candidateStore, allFetched)
+		for _, jobs := range summary.Filtered {
+			upsertJobCandidates(ctx, candidateStore, jobs)
+		}
+		allFetched = applyCachedDeterministicRejects(ctx, candidateStore, criteriaCfg, allFetched, &summary)
+		recordDeterministicCandidateDecisions(ctx, candidateStore, criteriaCfg, allFetched, summary.Filtered)
+	}
 
 	var skippedExisting []Job
 	allFetched, skippedExisting = skipExistingFetchedJobs(allFetched, existingIndex)
@@ -632,6 +649,10 @@ func FetchAllJobsSkippingExisting(ctx context.Context, appCfg *AppConfig, criter
 	return fetchAllJobs(ctx, appCfg, criteriaCfg, progress, existingJobs)
 }
 
+func FetchAllJobsSkippingExistingWithCandidateCache(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, existingJobs []Job, progress func(string), candidateStore storage.CandidateStore) ([]Job, FetchSummary, error) {
+	return fetchAllJobsWithCandidateCache(ctx, appCfg, criteriaCfg, progress, existingJobs, candidateStore)
+}
+
 type sourceFetchResult struct {
 	jobs     []Job
 	filtered map[string][]Job
@@ -707,7 +728,7 @@ func normalizedSiteSearchHost(rawURL string) string {
 	return strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www.")
 }
 
-func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *CriteriaConfig, ensureBrowser func() (*rod.Browser, error), browserSem chan struct{}, builtInDetails *builtInDetailCache, builtInProfiles *sourceProfileEnricher, existing *existingJobIndex, blocked *siteSearchBlocklist, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter) sourceFetchResult {
+func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *CriteriaConfig, ensureBrowser func() (*rod.Browser, error), browserSem chan struct{}, builtInDetails *builtInDetailCache, builtInProfiles *sourceProfileEnricher, existing *existingJobIndex, blocked *siteSearchBlocklist, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter, candidateStore storage.CandidateStore) sourceFetchResult {
 	var jobs []Job
 	var filtered map[string][]Job
 	var err error
@@ -723,7 +744,7 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 		return sourceFetchResult{}
 	}
 	logDebug("site search %s query %d/%d: trying static handler", task.site, task.queryIndex+1, task.queryCount)
-	jobs, filtered, handled, err = fetchBuiltInSiteSearch(ctx, task.targetURL, task.sourceName, task.site, criteria, builtInDetails, builtInProfiles, existing, candidateLimiter)
+	jobs, filtered, handled, err = fetchBuiltInSiteSearch(ctx, task.targetURL, task.sourceName, task.site, criteria, builtInDetails, builtInProfiles, existing, candidateLimiter, candidateStore)
 	if handled {
 		logDebug("site search %s query %d/%d: static handler completed with %d accepted and %d filtered", task.site, task.queryIndex+1, task.queryCount, len(jobs), countFilteredJobs(filtered))
 	} else if err != nil {
@@ -756,7 +777,7 @@ func fetchSiteSearchTask(ctx context.Context, task siteSearchTask, criteria *Cri
 			var browser *rod.Browser
 			browser, err = ensureBrowser()
 			if err == nil {
-				jobs, filtered, detailNotice, err = fetchGenericSiteSearch(ctx, browser, task.site, task.targetURL, task.sourceName, criteria, detailBlocked, candidateLimiter)
+				jobs, filtered, detailNotice, err = fetchGenericSiteSearch(ctx, browser, task.site, task.targetURL, task.sourceName, criteria, detailBlocked, candidateLimiter, candidateStore)
 				if detailNotice != "" {
 					logDebug("site search %s query %d/%d: %s", task.site, task.queryIndex+1, task.queryCount, detailNotice)
 				}

--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -1547,6 +1547,37 @@ func TestEnrichJobFromCompanyProfileHTMLExtractsLinkedInWebsite(t *testing.T) {
 	}
 }
 
+func TestEnrichJobFromCompanyProfileHTMLIgnoresLinkedInAssetWebsite(t *testing.T) {
+	job := Job{Company: "Procore Technologies"}
+	rawHTML := `
+<html>
+<head>
+  <meta property="og:type" content="website">
+  <link rel="icon" href="https://static.licdn.com/aero-v1/sc/h/al2o9zrvru7aqj8e1x2rzsrca">
+</head>
+<body>
+  <section>
+    <h2>About us</h2>
+    <p>Procore Technologies builds construction management software.</p>
+    <dl>
+      <dt>Website</dt>
+      <dd><a href="https://www.procore.com">https://www.procore.com</a></dd>
+      <dt>Industry</dt>
+      <dd>Software Development</dd>
+      <dt>Company size</dt>
+      <dd>1,001-5,000 employees</dd>
+    </dl>
+  </section>
+</body>
+</html>`
+
+	enrichJobFromCompanyProfileHTML(&job, rawHTML, "https://www.linkedin.com/company/procore-technologies")
+
+	if job.CompanyWebsite != "https://www.procore.com" {
+		t.Fatalf("CompanyWebsite = %q; want https://www.procore.com", job.CompanyWebsite)
+	}
+}
+
 func TestEnrichJobFromCompanyProfileHTMLRealWorkFromAnywhere(t *testing.T) {
 	job := Job{
 		Company:         "Circle",

--- a/internal/fetcher/job_identity_llm.go
+++ b/internal/fetcher/job_identity_llm.go
@@ -51,7 +51,7 @@ func applyLLMJobIdentityEnrichment(ctx context.Context, job *Job, page JobIdenti
 		return usage
 	}
 	acceptedIdentityAnchor := false
-	if website := strings.TrimSpace(result.CompanyWebsite); website != "" && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && looksLikeCompanyWebsite(website, page.URL) {
+	if website := strings.TrimSpace(result.CompanyWebsite); website != "" && domain.JobCompanyWebsiteMissingOrInvalid(job.CompanyWebsite) && looksLikeCompanyWebsite(website, page.URL) && !sourceProfileWebsiteCandidateBlocked(website, page.URL) {
 		website = normalizeCompanyWebsiteURL(website)
 		job.CompanyWebsite = website
 		setJobIdentityEvidence(job, "website", website, source, page.URL, confidenceOrDefault(result.WebsiteConfidence, "medium"), false, firstNonEmptyString(result.CompanyWebsiteReason, "Website extracted by LLM from supplied page text."))

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/wallentx/jobscout/internal/domain"
+	"github.com/wallentx/jobscout/internal/storage"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
@@ -145,7 +146,7 @@ func FindSiteSearchBrowserBinary() string {
 	return findSiteSearchBrowserBinary()
 }
 
-func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target string, targetURL string, sourceName string, criteria *CriteriaConfig, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, string, error) {
+func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target string, targetURL string, sourceName string, criteria *CriteriaConfig, detailBlocked *siteSearchBlocklist, candidateLimiter *siteCandidateLimiter, candidateStore storage.CandidateStore) ([]Job, map[string][]Job, string, error) {
 	candidates, err := probeSiteSearchCandidates(ctx, browser, targetURL, criteria)
 	if err != nil {
 		logDebug("site search %s: browser candidate probe failed: %v", target, err)
@@ -198,6 +199,11 @@ func fetchGenericSiteSearch(ctx context.Context, browser *rod.Browser, target st
 		}
 		job.SetDateAdded(time.Now().Unix())
 		enrichJobFromDescription(&job)
+		if cached, ok := cachedDeterministicRejectedJob(ctx, candidateStore, criteria, job); ok {
+			logDebug("site search %s: skipped cached deterministic rejection %s - %s", target, cached.Company, cached.Title)
+			filtered["cached rejection"] = append(filtered["cached rejection"], cached)
+			continue
+		}
 		if reason := titleScopeFilterReason(job.Title, criteria); reason != "" {
 			logDebug("site search %s: filtered candidate %s - %s before detail enrichment: %s", target, job.Company, job.Title, reason)
 			filtered[reason] = append(filtered[reason], job)
@@ -523,7 +529,7 @@ func builtInDetailResultForSource(result builtInDetailResult, sourceName string)
 	return result
 }
 
-func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, bool, error) {
+func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter, candidateStore storage.CandidateStore) ([]Job, map[string][]Job, bool, error) {
 	parsed, err := url.Parse(strings.TrimSpace(targetURL))
 	if err != nil || parsed.Host == "" || !isBuiltInHost(parsed.Hostname()) {
 		return nil, nil, false, nil
@@ -537,10 +543,10 @@ func fetchBuiltInSiteSearch(ctx context.Context, targetURL string, sourceName st
 		}
 		return nil, nil, true, err
 	}
-	return parseBuiltInSiteSearchHTML(ctx, rawHTML, finalURL, sourceName, sourceKey, criteria, detailCache, profileEnricher, existing, candidateLimiter)
+	return parseBuiltInSiteSearchHTML(ctx, rawHTML, finalURL, sourceName, sourceKey, criteria, detailCache, profileEnricher, existing, candidateLimiter, candidateStore)
 }
 
-func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter) ([]Job, map[string][]Job, bool, error) {
+func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL string, sourceName string, sourceKey string, criteria *CriteriaConfig, detailCache *builtInDetailCache, profileEnricher *sourceProfileEnricher, existing *existingJobIndex, candidateLimiter *siteCandidateLimiter, candidateStore storage.CandidateStore) ([]Job, map[string][]Job, bool, error) {
 	hrefs := extractHTMLHrefs(rawHTML)
 	listingJobs, cardCount := extractBuiltInListingJobs(rawHTML, finalURL, sourceName, criteria)
 	if cardCount > 0 {
@@ -550,7 +556,13 @@ func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL st
 			listingJobs = listingJobs[:keptCount]
 			logDebug("site search built-in %s: candidate limit kept=%d skipped=%d", finalURL, keptCount, len(skippedByLimit))
 		}
-		acceptedListingJobs, cardFiltered := filterBuiltInListingJobsWithProfiles(listingJobs, criteria)
+		listingJobs, cachedRejected := filterBuiltInListingJobsWithCachedRejects(ctx, candidateStore, criteria, listingJobs)
+		cardFiltered := make(map[string][]Job)
+		if len(cachedRejected) > 0 {
+			cardFiltered["cached rejection"] = append(cardFiltered["cached rejection"], cachedRejected...)
+		}
+		acceptedListingJobs, profileFiltered := filterBuiltInListingJobsWithProfiles(listingJobs, criteria)
+		cardFiltered = mergeFiltered(cardFiltered, profileFiltered)
 		if len(skippedByLimit) > 0 {
 			if cardFiltered == nil {
 				cardFiltered = make(map[string][]Job)
@@ -584,6 +596,11 @@ func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL st
 		logDebug("site search built-in %s: candidate limit kept=%d skipped=%d", finalURL, keptCount, len(links)-keptCount)
 		links = links[:keptCount]
 	}
+	preFiltered := make(map[string][]Job)
+	links, cachedRejected := filterBuiltInDetailLinksWithCachedRejects(ctx, candidateStore, criteria, sourceName, links)
+	if len(cachedRejected) > 0 {
+		preFiltered["cached rejection"] = append(preFiltered["cached rejection"], cachedRejected...)
+	}
 	logDebug("site search built-in %s: found %d job detail links", finalURL, len(links))
 
 	results := make([]builtInDetailResult, len(links))
@@ -601,7 +618,7 @@ func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL st
 	wg.Wait()
 
 	jobs := make([]Job, 0, len(links))
-	filtered := make(map[string][]Job)
+	filtered := preFiltered
 	for _, result := range results {
 		if !result.ok {
 			continue
@@ -618,6 +635,53 @@ func parseBuiltInSiteSearchHTML(ctx context.Context, rawHTML string, finalURL st
 	}
 	logDebug("site search built-in %s: accepted %d; filtered %d", finalURL, len(jobs), countFilteredJobs(filtered))
 	return jobs, filtered, true, nil
+}
+
+func filterBuiltInListingJobsWithCachedRejects(ctx context.Context, store storage.CandidateStore, criteria *CriteriaConfig, listingJobs []builtInListingJob) ([]builtInListingJob, []Job) {
+	if store == nil || len(listingJobs) == 0 {
+		return listingJobs, nil
+	}
+	kept := make([]builtInListingJob, 0, len(listingJobs))
+	rejected := make([]Job, 0)
+	for _, listingJob := range listingJobs {
+		cached, ok := cachedDeterministicRejectedJob(ctx, store, criteria, listingJob.job)
+		if ok {
+			rejected = append(rejected, cached)
+			continue
+		}
+		kept = append(kept, listingJob)
+	}
+	if len(rejected) > 0 {
+		logDebug("site search built-in listing cache: skipped %d cached deterministic rejections", len(rejected))
+	}
+	return kept, rejected
+}
+
+func filterBuiltInDetailLinksWithCachedRejects(ctx context.Context, store storage.CandidateStore, criteria *CriteriaConfig, sourceName string, links []string) ([]string, []Job) {
+	if store == nil || len(links) == 0 {
+		return links, nil
+	}
+	kept := make([]string, 0, len(links))
+	rejected := make([]Job, 0)
+	for _, link := range links {
+		job := Job{
+			Source:       sourceName,
+			ApplyURL:     link,
+			Status:       "Unopened",
+			Compensation: "Not listed",
+		}
+		job.SetDateAdded(time.Now().Unix())
+		cached, ok := cachedDeterministicRejectedJob(ctx, store, criteria, job)
+		if ok {
+			rejected = append(rejected, cached)
+			continue
+		}
+		kept = append(kept, link)
+	}
+	if len(rejected) > 0 {
+		logDebug("site search built-in detail cache: skipped %d cached deterministic rejections", len(rejected))
+	}
+	return kept, rejected
 }
 
 func skipExistingBuiltInListingJobs(listingJobs []builtInListingJob, existing *existingJobIndex) ([]builtInListingJob, []Job) {

--- a/internal/runtime/memory_stores.go
+++ b/internal/runtime/memory_stores.go
@@ -181,10 +181,145 @@ func normalizeMemoryDomain(raw string) string {
 	return strings.TrimPrefix(parsed.Hostname(), "www.")
 }
 
+type memoryCandidateStore struct {
+	mu         sync.Mutex
+	candidates map[string]domain.JobCandidate
+	decisions  map[domain.JobCandidateDecisionKey]domain.JobCandidateDecision
+}
+
+func (s *memoryCandidateStore) UpsertJobCandidate(ctx context.Context, candidate domain.JobCandidate) error {
+	return s.UpsertJobCandidates(ctx, []domain.JobCandidate{candidate})
+}
+
+func (s *memoryCandidateStore) UpsertJobCandidates(ctx context.Context, candidates []domain.JobCandidate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.candidates == nil {
+		s.candidates = make(map[string]domain.JobCandidate)
+	}
+	for _, candidate := range candidates {
+		key := strings.TrimSpace(candidate.Key)
+		if key == "" {
+			continue
+		}
+		now := time.Now()
+		if candidate.FirstSeen.IsZero() {
+			if existing, ok := s.candidates[key]; ok && !existing.FirstSeen.IsZero() {
+				candidate.FirstSeen = existing.FirstSeen
+			} else {
+				candidate.FirstSeen = now
+			}
+		}
+		if candidate.LastSeen.IsZero() {
+			candidate.LastSeen = now
+		}
+		candidate.Key = key
+		candidate.Job.Metadata = domain.NormalizeJobMetadata(candidate.Job.Metadata)
+		s.candidates[key] = candidate
+	}
+	return nil
+}
+
+func (s *memoryCandidateStore) GetJobCandidate(ctx context.Context, candidateKey string) (*domain.JobCandidate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	candidate, ok := s.candidates[strings.TrimSpace(candidateKey)]
+	if !ok {
+		return nil, nil
+	}
+	candidate.Job.Metadata = domain.NormalizeJobMetadata(domain.CloneJobMetadata(candidate.Job.Metadata))
+	return &candidate, nil
+}
+
+func (s *memoryCandidateStore) UpsertJobCandidateDecision(ctx context.Context, decision domain.JobCandidateDecision) error {
+	return s.UpsertJobCandidateDecisions(ctx, []domain.JobCandidateDecision{decision})
+}
+
+func (s *memoryCandidateStore) UpsertJobCandidateDecisions(ctx context.Context, decisions []domain.JobCandidateDecision) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.decisions == nil {
+		s.decisions = make(map[domain.JobCandidateDecisionKey]domain.JobCandidateDecision)
+	}
+	for _, decision := range decisions {
+		key := normalizeMemoryCandidateDecisionKey(decision.JobCandidateDecisionKey)
+		if key.CandidateKey == "" || key.CriteriaHash == "" || key.Stage == "" || key.DecisionVersion == "" {
+			continue
+		}
+		if strings.TrimSpace(decision.Decision) == "" {
+			continue
+		}
+		if decision.DecidedAt.IsZero() {
+			decision.DecidedAt = time.Now()
+		}
+		decision.JobCandidateDecisionKey = key
+		decision.Job.Metadata = domain.NormalizeJobMetadata(decision.Job.Metadata)
+		s.decisions[key] = decision
+	}
+	return nil
+}
+
+func (s *memoryCandidateStore) GetJobCandidateDecision(ctx context.Context, key domain.JobCandidateDecisionKey) (*domain.JobCandidateDecision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key = normalizeMemoryCandidateDecisionKey(key)
+	decision, ok := s.decisions[key]
+	if !ok {
+		return nil, nil
+	}
+	if !decision.ExpiresAt.IsZero() && decision.ExpiresAt.Before(time.Now()) {
+		return nil, nil
+	}
+	decision.Job.Metadata = domain.NormalizeJobMetadata(domain.CloneJobMetadata(decision.Job.Metadata))
+	return &decision, nil
+}
+
+func (s *memoryCandidateStore) PruneJobCandidateCache(ctx context.Context, olderThan time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if olderThan.IsZero() {
+		return 0, nil
+	}
+	removed := 0
+	for key, candidate := range s.candidates {
+		if candidate.LastSeen.Before(olderThan) {
+			delete(s.candidates, key)
+			removed++
+		}
+	}
+	for key := range s.decisions {
+		if _, ok := s.candidates[key.CandidateKey]; !ok {
+			delete(s.decisions, key)
+		}
+	}
+	return removed, nil
+}
+
+func normalizeMemoryCandidateDecisionKey(key domain.JobCandidateDecisionKey) domain.JobCandidateDecisionKey {
+	return domain.JobCandidateDecisionKey{
+		CandidateKey:    strings.TrimSpace(key.CandidateKey),
+		CriteriaHash:    strings.TrimSpace(key.CriteriaHash),
+		Stage:           strings.TrimSpace(key.Stage),
+		DecisionVersion: strings.TrimSpace(key.DecisionVersion),
+		LLMProvider:     strings.ToLower(strings.TrimSpace(key.LLMProvider)),
+		LLMModel:        strings.TrimSpace(key.LLMModel),
+	}
+}
+
 func InMemoryStores() Stores {
+	candidateStore := &memoryCandidateStore{
+		candidates: make(map[string]domain.JobCandidate),
+		decisions:  make(map[domain.JobCandidateDecisionKey]domain.JobCandidateDecision),
+	}
 	return Stores{
 		Jobs:            &memoryJobStore{},
 		Health:          &memoryHealthStore{cache: make(storage.HealthCache)},
 		CompanyIdentity: &memoryCompanyIdentityStore{identities: make(map[string]domain.CompanyIdentity)},
+		Candidates:      candidateStore,
 	}
 }

--- a/internal/runtime/stores.go
+++ b/internal/runtime/stores.go
@@ -12,6 +12,7 @@ type Stores struct {
 	Jobs            storage.JobStore
 	Health          storage.HealthStore
 	CompanyIdentity storage.CompanyIdentityStore
+	Candidates      storage.CandidateStore
 }
 
 func DeleteSQLiteDatabase(paths Paths) ([]string, error) {
@@ -48,6 +49,7 @@ func OpenStores(paths Paths) (Stores, func(), error) {
 			Jobs:            sqliteStore,
 			Health:          sqliteStore,
 			CompanyIdentity: sqliteStore,
+			Candidates:      sqliteStore,
 		}, func() {
 			_ = sqliteStore.Close()
 		}, nil

--- a/internal/storage/aliases.go
+++ b/internal/storage/aliases.go
@@ -9,3 +9,6 @@ type CompanyMetadata = domain.CompanyMetadata
 type JobIdentityMetadata = domain.JobIdentityMetadata
 type JobIdentityEvidence = domain.JobIdentityEvidence
 type CompanyHealthResult = domain.CompanyHealthResult
+type JobCandidate = domain.JobCandidate
+type JobCandidateDecision = domain.JobCandidateDecision
+type JobCandidateDecisionKey = domain.JobCandidateDecisionKey

--- a/internal/storage/sqlite_store.go
+++ b/internal/storage/sqlite_store.go
@@ -157,6 +157,49 @@ func (s *SQLiteStore) ensureMigrations() error {
 				ALTER TABLE jobs ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '';
 			`,
 		},
+		{
+			version: 7,
+			sql: `
+				CREATE TABLE IF NOT EXISTS job_candidates (
+					candidate_key TEXT PRIMARY KEY,
+					source TEXT NOT NULL DEFAULT '',
+					source_key TEXT NOT NULL DEFAULT '',
+					apply_url TEXT NOT NULL DEFAULT '',
+					canonical_apply_url TEXT NOT NULL DEFAULT '',
+					company TEXT NOT NULL DEFAULT '',
+					title TEXT NOT NULL DEFAULT '',
+					job_json TEXT NOT NULL,
+					active INTEGER NOT NULL DEFAULT 1,
+					first_seen_epoch INTEGER NOT NULL,
+					last_seen_epoch INTEGER NOT NULL
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_job_candidates_source ON job_candidates(source);
+				CREATE INDEX IF NOT EXISTS idx_job_candidates_last_seen ON job_candidates(last_seen_epoch DESC);
+				CREATE INDEX IF NOT EXISTS idx_job_candidates_company_title ON job_candidates(company, title);
+
+				CREATE TABLE IF NOT EXISTS job_candidate_decisions (
+					candidate_key TEXT NOT NULL,
+					criteria_hash TEXT NOT NULL,
+					stage TEXT NOT NULL,
+					decision_version TEXT NOT NULL,
+					llm_provider TEXT NOT NULL DEFAULT '',
+					llm_model TEXT NOT NULL DEFAULT '',
+					decision TEXT NOT NULL,
+					reason TEXT NOT NULL DEFAULT '',
+					job_json TEXT NOT NULL DEFAULT '',
+					decided_at_epoch INTEGER NOT NULL,
+					expires_at_epoch INTEGER NOT NULL DEFAULT 0,
+					PRIMARY KEY(candidate_key, criteria_hash, stage, decision_version, llm_provider, llm_model),
+					FOREIGN KEY(candidate_key) REFERENCES job_candidates(candidate_key) ON DELETE CASCADE
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_job_candidate_decisions_lookup
+					ON job_candidate_decisions(criteria_hash, stage, decision_version, llm_provider, llm_model, decision);
+				CREATE INDEX IF NOT EXISTS idx_job_candidate_decisions_decided_at
+					ON job_candidate_decisions(decided_at_epoch DESC);
+			`,
+		},
 	}
 
 	for _, migration := range migrations {
@@ -760,6 +803,349 @@ func (s *SQLiteStore) loadCompanyIdentityAliases(ctx context.Context, identity *
 		return fmt.Errorf("iterate company identity aliases for %s: %w", identity.Key, err)
 	}
 	return nil
+}
+
+func (s *SQLiteStore) UpsertJobCandidate(ctx context.Context, candidate domain.JobCandidate) error {
+	return s.UpsertJobCandidates(ctx, []domain.JobCandidate{candidate})
+}
+
+func (s *SQLiteStore) UpsertJobCandidates(ctx context.Context, candidates []domain.JobCandidate) error {
+	if len(candidates) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin upsert job candidates: %w", err)
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO job_candidates (
+			candidate_key,
+			source,
+			source_key,
+			apply_url,
+			canonical_apply_url,
+			company,
+			title,
+			job_json,
+			active,
+			first_seen_epoch,
+			last_seen_epoch
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(candidate_key) DO UPDATE SET
+			source = excluded.source,
+			source_key = excluded.source_key,
+			apply_url = excluded.apply_url,
+			canonical_apply_url = excluded.canonical_apply_url,
+			company = excluded.company,
+			title = excluded.title,
+			job_json = excluded.job_json,
+			active = excluded.active,
+			last_seen_epoch = excluded.last_seen_epoch
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare upsert job candidates: %w", err)
+	}
+	defer func() {
+		_ = stmt.Close()
+	}()
+
+	for _, candidate := range candidates {
+		candidate.Key = strings.TrimSpace(candidate.Key)
+		if candidate.Key == "" {
+			continue
+		}
+		now := time.Now()
+		firstSeen := candidate.FirstSeen
+		if firstSeen.IsZero() {
+			firstSeen = now
+		}
+		lastSeen := candidate.LastSeen
+		if lastSeen.IsZero() {
+			lastSeen = now
+		}
+		if lastSeen.Before(firstSeen) {
+			lastSeen = firstSeen
+		}
+		candidate.Job.Metadata = domain.NormalizeJobMetadata(candidate.Job.Metadata)
+		payload, err := json.Marshal(candidate.Job)
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("marshal job candidate %s: %w", candidate.Key, err)
+		}
+		active := 0
+		if candidate.Active {
+			active = 1
+		}
+		if _, err := stmt.ExecContext(
+			ctx,
+			candidate.Key,
+			strings.TrimSpace(candidate.Source),
+			strings.TrimSpace(candidate.SourceKey),
+			strings.TrimSpace(candidate.ApplyURL),
+			strings.TrimSpace(candidate.CanonicalApplyURL),
+			strings.TrimSpace(candidate.Company),
+			strings.TrimSpace(candidate.Title),
+			string(payload),
+			active,
+			firstSeen.Unix(),
+			lastSeen.Unix(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("upsert job candidate %s: %w", candidate.Key, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit upsert job candidates: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetJobCandidate(ctx context.Context, candidateKey string) (*domain.JobCandidate, error) {
+	candidateKey = strings.TrimSpace(candidateKey)
+	if candidateKey == "" {
+		return nil, nil
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT
+			candidate_key,
+			source,
+			source_key,
+			apply_url,
+			canonical_apply_url,
+			company,
+			title,
+			job_json,
+			active,
+			first_seen_epoch,
+			last_seen_epoch
+		FROM job_candidates
+		WHERE candidate_key = ?
+	`, candidateKey)
+	candidate, err := scanJobCandidate(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get job candidate %s: %w", candidateKey, err)
+	}
+	return candidate, nil
+}
+
+func scanJobCandidate(row *sql.Row) (*domain.JobCandidate, error) {
+	var candidate domain.JobCandidate
+	var jobJSON string
+	var active int
+	var firstSeenEpoch int64
+	var lastSeenEpoch int64
+	if err := row.Scan(
+		&candidate.Key,
+		&candidate.Source,
+		&candidate.SourceKey,
+		&candidate.ApplyURL,
+		&candidate.CanonicalApplyURL,
+		&candidate.Company,
+		&candidate.Title,
+		&jobJSON,
+		&active,
+		&firstSeenEpoch,
+		&lastSeenEpoch,
+	); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(jobJSON) != "" {
+		if err := json.Unmarshal([]byte(jobJSON), &candidate.Job); err != nil {
+			return nil, err
+		}
+		candidate.Job.Metadata = domain.NormalizeJobMetadata(candidate.Job.Metadata)
+	}
+	candidate.Active = active != 0
+	candidate.FirstSeen = time.Unix(firstSeenEpoch, 0)
+	candidate.LastSeen = time.Unix(lastSeenEpoch, 0)
+	return &candidate, nil
+}
+
+func (s *SQLiteStore) UpsertJobCandidateDecision(ctx context.Context, decision domain.JobCandidateDecision) error {
+	return s.UpsertJobCandidateDecisions(ctx, []domain.JobCandidateDecision{decision})
+}
+
+func (s *SQLiteStore) UpsertJobCandidateDecisions(ctx context.Context, decisions []domain.JobCandidateDecision) error {
+	if len(decisions) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin upsert job candidate decisions: %w", err)
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO job_candidate_decisions (
+			candidate_key,
+			criteria_hash,
+			stage,
+			decision_version,
+			llm_provider,
+			llm_model,
+			decision,
+			reason,
+			job_json,
+			decided_at_epoch,
+			expires_at_epoch
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(candidate_key, criteria_hash, stage, decision_version, llm_provider, llm_model)
+		DO UPDATE SET
+			decision = excluded.decision,
+			reason = excluded.reason,
+			job_json = excluded.job_json,
+			decided_at_epoch = excluded.decided_at_epoch,
+			expires_at_epoch = excluded.expires_at_epoch
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare upsert job candidate decisions: %w", err)
+	}
+	defer func() {
+		_ = stmt.Close()
+	}()
+
+	for _, decision := range decisions {
+		key := normalizeCandidateDecisionKey(decision.JobCandidateDecisionKey)
+		if key.CandidateKey == "" || key.CriteriaHash == "" || key.Stage == "" || key.DecisionVersion == "" {
+			continue
+		}
+		decisionText := strings.TrimSpace(decision.Decision)
+		if decisionText == "" {
+			continue
+		}
+		decidedAt := decision.DecidedAt
+		if decidedAt.IsZero() {
+			decidedAt = time.Now()
+		}
+		expiresAtEpoch := int64(0)
+		if !decision.ExpiresAt.IsZero() {
+			expiresAtEpoch = decision.ExpiresAt.Unix()
+		}
+		decision.Job.Metadata = domain.NormalizeJobMetadata(decision.Job.Metadata)
+		payload, err := json.Marshal(decision.Job)
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("marshal job candidate decision %s: %w", key.CandidateKey, err)
+		}
+		if _, err := stmt.ExecContext(
+			ctx,
+			key.CandidateKey,
+			key.CriteriaHash,
+			key.Stage,
+			key.DecisionVersion,
+			key.LLMProvider,
+			key.LLMModel,
+			decisionText,
+			strings.TrimSpace(decision.Reason),
+			string(payload),
+			decidedAt.Unix(),
+			expiresAtEpoch,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("upsert job candidate decision %s: %w", key.CandidateKey, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit upsert job candidate decisions: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetJobCandidateDecision(ctx context.Context, key domain.JobCandidateDecisionKey) (*domain.JobCandidateDecision, error) {
+	key = normalizeCandidateDecisionKey(key)
+	if key.CandidateKey == "" || key.CriteriaHash == "" || key.Stage == "" || key.DecisionVersion == "" {
+		return nil, nil
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT
+			candidate_key,
+			criteria_hash,
+			stage,
+			decision_version,
+			llm_provider,
+			llm_model,
+			decision,
+			reason,
+			job_json,
+			decided_at_epoch,
+			expires_at_epoch
+		FROM job_candidate_decisions
+		WHERE candidate_key = ?
+			AND criteria_hash = ?
+			AND stage = ?
+			AND decision_version = ?
+			AND llm_provider = ?
+			AND llm_model = ?
+	`, key.CandidateKey, key.CriteriaHash, key.Stage, key.DecisionVersion, key.LLMProvider, key.LLMModel)
+
+	var decision domain.JobCandidateDecision
+	var jobJSON string
+	var decidedAtEpoch int64
+	var expiresAtEpoch int64
+	if err := row.Scan(
+		&decision.CandidateKey,
+		&decision.CriteriaHash,
+		&decision.Stage,
+		&decision.DecisionVersion,
+		&decision.LLMProvider,
+		&decision.LLMModel,
+		&decision.Decision,
+		&decision.Reason,
+		&jobJSON,
+		&decidedAtEpoch,
+		&expiresAtEpoch,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get job candidate decision %s: %w", key.CandidateKey, err)
+	}
+	if expiresAtEpoch > 0 && time.Unix(expiresAtEpoch, 0).Before(time.Now()) {
+		return nil, nil
+	}
+	if strings.TrimSpace(jobJSON) != "" {
+		if err := json.Unmarshal([]byte(jobJSON), &decision.Job); err != nil {
+			return nil, fmt.Errorf("decode job candidate decision %s job: %w", key.CandidateKey, err)
+		}
+		decision.Job.Metadata = domain.NormalizeJobMetadata(decision.Job.Metadata)
+	}
+	decision.DecidedAt = time.Unix(decidedAtEpoch, 0)
+	if expiresAtEpoch > 0 {
+		decision.ExpiresAt = time.Unix(expiresAtEpoch, 0)
+	}
+	return &decision, nil
+}
+
+func (s *SQLiteStore) PruneJobCandidateCache(ctx context.Context, olderThan time.Time) (int, error) {
+	if olderThan.IsZero() {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM job_candidates
+		WHERE last_seen_epoch < ?
+	`, olderThan.Unix())
+	if err != nil {
+		return 0, fmt.Errorf("prune job candidate cache: %w", err)
+	}
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count pruned job candidates: %w", err)
+	}
+	return int(removed), nil
+}
+
+func normalizeCandidateDecisionKey(key domain.JobCandidateDecisionKey) domain.JobCandidateDecisionKey {
+	return domain.JobCandidateDecisionKey{
+		CandidateKey:    strings.TrimSpace(key.CandidateKey),
+		CriteriaHash:    strings.TrimSpace(key.CriteriaHash),
+		Stage:           strings.TrimSpace(key.Stage),
+		DecisionVersion: strings.TrimSpace(key.DecisionVersion),
+		LLMProvider:     strings.ToLower(strings.TrimSpace(key.LLMProvider)),
+		LLMModel:        strings.TrimSpace(key.LLMModel),
+	}
 }
 
 func normalizeCompanyKey(company string) string {

--- a/internal/storage/sqlite_store_test.go
+++ b/internal/storage/sqlite_store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -207,6 +208,85 @@ func TestSQLiteStoreDeleteHealth(t *testing.T) {
 	}
 	if len(loadedCache) != 0 {
 		t.Fatalf("LoadHealthCache() = %#v, want empty after DeleteHealth calls", loadedCache)
+	}
+}
+
+func TestSQLiteStoreJobCandidateCacheRoundTrip(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	now := time.Now().Add(-time.Hour)
+
+	candidate := JobCandidate{
+		Key:               "url:https://jobs.example/acme/platform-engineer",
+		Source:            "Site Search: Example",
+		SourceKey:         "url:https://jobs.example/acme/platform-engineer",
+		ApplyURL:          "https://jobs.example/acme/platform-engineer",
+		CanonicalApplyURL: "https://jobs.example/acme/platform-engineer",
+		Company:           "Acme",
+		Title:             "Platform Engineer",
+		Job: Job{
+			Company:        "Acme",
+			CompanyWebsite: "https://www.acme.example",
+			Title:          "Platform Engineer",
+			ApplyURL:       "https://jobs.example/acme/platform-engineer",
+			Source:         "Site Search: Example",
+		},
+		Active:    true,
+		FirstSeen: now,
+		LastSeen:  now,
+	}
+	if err := store.UpsertJobCandidate(ctx, candidate); err != nil {
+		t.Fatalf("UpsertJobCandidate() error = %v", err)
+	}
+
+	loaded, err := store.GetJobCandidate(ctx, candidate.Key)
+	if err != nil {
+		t.Fatalf("GetJobCandidate() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetJobCandidate() = nil, want candidate")
+	}
+	if loaded.Job.CompanyWebsite != "https://www.acme.example" {
+		t.Fatalf("loaded candidate website = %q; want cached website", loaded.Job.CompanyWebsite)
+	}
+
+	decision := JobCandidateDecision{
+		JobCandidateDecisionKey: JobCandidateDecisionKey{
+			CandidateKey:    candidate.Key,
+			CriteriaHash:    "criteria123",
+			Stage:           "deterministic",
+			DecisionVersion: "deterministic:v1",
+		},
+		Decision:  "rejected",
+		Reason:    "title excludes",
+		Job:       candidate.Job,
+		DecidedAt: now,
+	}
+	if err := store.UpsertJobCandidateDecision(ctx, decision); err != nil {
+		t.Fatalf("UpsertJobCandidateDecision() error = %v", err)
+	}
+
+	loadedDecision, err := store.GetJobCandidateDecision(ctx, decision.JobCandidateDecisionKey)
+	if err != nil {
+		t.Fatalf("GetJobCandidateDecision() error = %v", err)
+	}
+	if loadedDecision == nil || loadedDecision.Decision != "rejected" || loadedDecision.Reason != "title excludes" {
+		t.Fatalf("GetJobCandidateDecision() = %#v; want rejected title-excludes decision", loadedDecision)
+	}
+
+	removed, err := store.PruneJobCandidateCache(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("PruneJobCandidateCache() error = %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("PruneJobCandidateCache() removed = %d; want 1", removed)
+	}
+	loaded, err = store.GetJobCandidate(ctx, candidate.Key)
+	if err != nil {
+		t.Fatalf("GetJobCandidate() after prune error = %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("GetJobCandidate() after prune = %#v; want nil", loaded)
 	}
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -26,6 +26,16 @@ type CompanyIdentityStore interface {
 	GetCompanyIdentity(ctx context.Context, companyName string, websiteOrDomain string) (*domain.CompanyIdentity, error)
 }
 
+type CandidateStore interface {
+	UpsertJobCandidate(ctx context.Context, candidate domain.JobCandidate) error
+	UpsertJobCandidates(ctx context.Context, candidates []domain.JobCandidate) error
+	GetJobCandidate(ctx context.Context, candidateKey string) (*domain.JobCandidate, error)
+	UpsertJobCandidateDecision(ctx context.Context, decision domain.JobCandidateDecision) error
+	UpsertJobCandidateDecisions(ctx context.Context, decisions []domain.JobCandidateDecision) error
+	GetJobCandidateDecision(ctx context.Context, key domain.JobCandidateDecisionKey) (*domain.JobCandidateDecision, error)
+	PruneJobCandidateCache(ctx context.Context, olderThan time.Time) (int, error)
+}
+
 type NoopCompanyIdentityStore struct{}
 
 func (NoopCompanyIdentityStore) UpsertCompanyIdentity(ctx context.Context, identity domain.CompanyIdentity) error {

--- a/internal/tuiapp/aliases.go
+++ b/internal/tuiapp/aliases.go
@@ -26,6 +26,7 @@ type HealthCacheEntry = storage.HealthCacheEntry
 type JobStore = storage.JobStore
 type HealthStore = storage.HealthStore
 type CompanyIdentityStore = storage.CompanyIdentityStore
+type CandidateStore = storage.CandidateStore
 type LLMAuthConfig = config.LLMAuthConfig
 type LLMConfig = config.LLMConfig
 type LLMProviderConfig = config.LLMProviderConfig

--- a/internal/tuiapp/background_task.go
+++ b/internal/tuiapp/background_task.go
@@ -329,6 +329,7 @@ func enrichAcceptedFetchCmd(taskID int, disableLLM bool, jobs []Job, progressCh 
 				jobCh <- job
 			}
 		})
+		fetcher.RecordAcceptedJobCandidates(ctx, runtimeCandidateStore, enriched)
 
 		return acceptedFetchEnrichedMsg{
 			taskID: taskID,

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -221,7 +221,7 @@ func applyOptionalLLMJobFilteringWithFreshTimeout(appCfg *AppConfig, criteriaCfg
 func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, existingJobs []Job, progress func(string)) ([]Job, FetchSummary, error) {
 	fetcher.ConfigureLLM(llmpkg.InitConfiguredLLMForTask, llmpkg.ExecuteLLMSearch, llmpkg.EnrichJobIdentityWithLLMUsage)
 	fetcher.ConfigureLLMWebSearch(llmpkg.ExecuteLLMWebSearch)
-	return fetcher.FetchAllJobsSkippingExisting(ctx, appCfg, criteriaCfg, existingJobs, progress)
+	return fetcher.FetchAllJobsSkippingExistingWithCandidateCache(ctx, appCfg, criteriaCfg, existingJobs, progress, runtimeCandidateStore)
 }
 
 func setupPreviewNotice(existingCount int, previewCount int, added int) string {
@@ -308,6 +308,7 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 			time.Since(sourceFetchStart).Round(time.Millisecond),
 		)
 
+		newJobs = fetcher.ApplyCachedLLMFilterDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, newJobs, &summary)
 		if llmJobFilteringShouldRun(appCfg, newJobs) {
 			select {
 			case progressCh <- "Running LLM job filtering before review...":
@@ -323,6 +324,7 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 		recordLLMJobFilteringBypassReasons(appCfg, criteriaCfg, &summary, beforeLLMFilter)
 		llmFilterStart := time.Now()
 		newJobs, notices := applyOptionalLLMJobFilteringWithFreshTimeout(appCfg, criteriaCfg, newJobs)
+		fetcher.RecordLLMFilterCandidateDecisions(context.Background(), runtimeCandidateStore, appCfg, criteriaCfg, beforeLLMFilter, newJobs, notices)
 		recordLLMJobFilteringOutcome(appCfg, &summary, beforeLLMFilter, newJobs, notices)
 		summary.Notices = append(summary.Notices, notices...)
 		logDebug(

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -324,7 +324,7 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 		recordLLMJobFilteringBypassReasons(appCfg, criteriaCfg, &summary, beforeLLMFilter)
 		llmFilterStart := time.Now()
 		newJobs, notices := applyOptionalLLMJobFilteringWithFreshTimeout(appCfg, criteriaCfg, newJobs)
-		fetcher.RecordLLMFilterCandidateDecisions(context.Background(), runtimeCandidateStore, appCfg, criteriaCfg, beforeLLMFilter, newJobs, notices)
+		fetcher.RecordLLMFilterCandidateDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, beforeLLMFilter, newJobs, notices)
 		recordLLMJobFilteringOutcome(appCfg, &summary, beforeLLMFilter, newJobs, notices)
 		summary.Notices = append(summary.Notices, notices...)
 		logDebug(

--- a/internal/tuiapp/posting_validation.go
+++ b/internal/tuiapp/posting_validation.go
@@ -97,7 +97,8 @@ func (m model) handlePostingValidationCompleteMsg(msg postingValidationCompleteM
 	}
 
 	selectedKey := m.selectedJobKey()
-	expired := m.expireInactivePostings(msg.results)
+	expiredJobs := m.expireInactivePostings(msg.results)
+	expired := len(expiredJobs)
 
 	m.backgroundTask.active = false
 	m.backgroundTask.expanded = false
@@ -109,6 +110,7 @@ func (m model) handlePostingValidationCompleteMsg(msg postingValidationCompleteM
 			m.showNotice("Posting Check Save Failed", err.Error(), false)
 			return m, nil
 		}
+		fetcher.RecordInactiveJobCandidates(context.Background(), runtimeCandidateStore, expiredJobs)
 	}
 
 	m.applyFilterAndSort()
@@ -123,9 +125,9 @@ func (m model) handlePostingValidationCompleteMsg(msg postingValidationCompleteM
 	return m, nil
 }
 
-func (m *model) expireInactivePostings(results []postingValidationResult) int {
+func (m *model) expireInactivePostings(results []postingValidationResult) []Job {
 	if len(results) == 0 {
-		return 0
+		return nil
 	}
 
 	inactive := make(map[string]string, len(results))
@@ -136,10 +138,10 @@ func (m *model) expireInactivePostings(results []postingValidationResult) int {
 		inactive[result.key] = result.reason
 	}
 	if len(inactive) == 0 {
-		return 0
+		return nil
 	}
 
-	expired := 0
+	expired := make([]Job, 0, len(inactive))
 	for i := range m.allJobs {
 		job := m.allJobs[i]
 		if !postingValidationStatus(job.Status) {
@@ -150,7 +152,7 @@ func (m *model) expireInactivePostings(results []postingValidationResult) int {
 			continue
 		}
 		m.allJobs[i].Status = "Expired"
-		expired++
+		expired = append(expired, m.allJobs[i])
 		if reason != "" {
 			logDebug("posting validation expired company=%q title=%q apply_url=%q reason=%q", job.Company, job.Title, job.ApplyURL, reason)
 		}

--- a/internal/tuiapp/runtime.go
+++ b/internal/tuiapp/runtime.go
@@ -24,6 +24,9 @@ func ConfigureRuntime(options appruntime.Options, stores appruntime.Stores, buil
 	if stores.CompanyIdentity != nil {
 		runtimeCompanyIdentityStore = stores.CompanyIdentity
 	}
+	if stores.Candidates != nil {
+		runtimeCandidateStore = stores.Candidates
+	}
 }
 
 func NewModel() tea.Model {

--- a/internal/tuiapp/runtime_state.go
+++ b/internal/tuiapp/runtime_state.go
@@ -31,6 +31,7 @@ var defaultRuntimeStores = appruntime.InMemoryStores()
 var runtimeJobStore JobStore = defaultRuntimeStores.Jobs
 var runtimeHealthStore HealthStore = defaultRuntimeStores.Health
 var runtimeCompanyIdentityStore CompanyIdentityStore = storage.NoopCompanyIdentityStore{}
+var runtimeCandidateStore CandidateStore = defaultRuntimeStores.Candidates
 var runtimeUpdateChecker = updatecheck.CheckLatestRelease
 
 func loadRuntimeJobs() ([]Job, error)  { return runtimeJobStore.LoadJobs() }


### PR DESCRIPTION
Adds a local job candidate cache to the fetch pipeline to bypass redundant page crawling, metadata extraction, and LLM filtering.

## What Changed

- Job Candidate & Decision Models: Introduces  JobCandidate  and  JobCandidateDecision  domain records.
- Normalized Criteria Hashing: Normalizes and hashes the current  CriteriaConfig  so that cached decisions automatically invalidate if search criteria change.
- Metadata Hydration: Hydrates newly fetched jobs with cached details (websites, summaries, industries, descriptions) to avoid scraping pages multiple times.
- Filter Bypassing: Instantly skips job candidates previously rejected deterministically or by an LLM model under the current criteria.
- Eviction Policies: Implements automatic SQLite pruning based on a customizable cache retention setting (defaulting to 30 days).

## Impact

Successive fetches run significantly faster by skipping expensive page crawls and redundant LLM filtering evaluations, dramatically reducing network traffic and API token costs.