### PR TITLE
refactor(fetch): context-scoped LLMService, cache structs, salary filter

### DIFF
--- a/internal/fetcher/job_fetcher.go
+++ b/internal/fetcher/job_fetcher.go
@@ -93,13 +93,14 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 
 	// 1. Fetch via LLM job search when enabled.
 	if appCfg.LLM.Enabled && appCfg.LLM.JobSearch {
-		if fetchAllJobsInitConfiguredLLM == nil || fetchAllJobsExecuteLLMSearch == nil {
+		llmSvc := getLLMService(ctx)
+		if !llmSvc.IsAvailable(ctx, "llm_job_search") {
 			mu.Lock()
 			setFetchSearchStatus(&summary, fetchSearchLLM, "disabled: LLM job search runner unavailable")
 			mu.Unlock()
 		} else {
 			reportFetchProgress(progress, "Preparing LLM job search...")
-			llm, restoreAuth, initErr := fetchAllJobsInitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
+			llm, restoreAuth, initErr := llmSvc.InitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
 			if initErr == nil {
 				defer restoreAuth()
 				promptBytes, err := fetchAllJobsReadFile(runtimeSearchPromptPath)
@@ -110,7 +111,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 					mu.Unlock()
 				} else {
 					reportFetchProgress(progress, "Running LLM job search...")
-					jobs, err := fetchAllJobsExecuteLLMSearch(ctx, llm, string(promptBytes))
+					jobs, err := llmSvc.ExecuteSearch(ctx, llm, string(promptBytes))
 					if err != nil {
 						mu.Lock()
 						summary.Notices = append(summary.Notices, fmt.Sprintf("LLM job search failed: %v", err))
@@ -155,7 +156,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		switch {
 		case !appCfg.LLM.Enabled:
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "disabled: LLM is disabled in config")
-		case fetchAllJobsExecuteLLMWebSearch == nil && (fetchAllJobsInitConfiguredLLM == nil || fetchAllJobsExecuteLLMSearch == nil):
+		case !getLLMService(ctx).IsAvailable(ctx, "llm_web_search"):
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "disabled: LLM search runner unavailable")
 		case len(effectiveSources.LLMWebTargets) == 0:
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "enabled, but no llm_web targets were configured or resolved")
@@ -508,15 +509,8 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 }
 
 func executeLLMWebSearchForFetch(ctx context.Context, appCfg *AppConfig, prompt string) ([]Job, error) {
-	if fetchAllJobsExecuteLLMWebSearch != nil {
-		return fetchAllJobsExecuteLLMWebSearch(ctx, appCfg, prompt)
-	}
-	llm, restoreAuth, err := fetchAllJobsInitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize: %w", err)
-	}
-	defer restoreAuth()
-	return fetchAllJobsExecuteLLMSearch(ctx, llm, prompt)
+	llmSvc := getLLMService(ctx)
+	return llmSvc.ExecuteWebSearch(ctx, appCfg, prompt)
 }
 
 func markLLMWebJobsForValidation(jobs []Job) {

--- a/internal/fetcher/job_fetcher.go
+++ b/internal/fetcher/job_fetcher.go
@@ -94,13 +94,13 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 	// 1. Fetch via LLM job search when enabled.
 	if appCfg.LLM.Enabled && appCfg.LLM.JobSearch {
 		llmSvc := getLLMService(ctx)
-		if !llmSvc.IsAvailable(ctx, "llm_job_search") {
+		if !llmSvc.IsAvailable(ctx, LLMTaskJobSearch) {
 			mu.Lock()
 			setFetchSearchStatus(&summary, fetchSearchLLM, "disabled: LLM job search runner unavailable")
 			mu.Unlock()
 		} else {
 			reportFetchProgress(progress, "Preparing LLM job search...")
-			llm, restoreAuth, initErr := llmSvc.InitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
+			llm, restoreAuth, initErr := llmSvc.InitConfiguredLLM(ctx, appCfg, LLMTaskJobSearch)
 			if initErr == nil {
 				defer restoreAuth()
 				promptBytes, err := fetchAllJobsReadFile(runtimeSearchPromptPath)
@@ -156,7 +156,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		switch {
 		case !appCfg.LLM.Enabled:
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "disabled: LLM is disabled in config")
-		case !getLLMService(ctx).IsAvailable(ctx, "llm_web_search"):
+		case !getLLMService(ctx).IsAvailable(ctx, LLMTaskWebSearch):
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "disabled: LLM search runner unavailable")
 		case len(effectiveSources.LLMWebTargets) == 0:
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "enabled, but no llm_web targets were configured or resolved")

--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -378,8 +378,8 @@ func TestFetchAllJobsLLMWebParseErrorIsSkipped(t *testing.T) {
 	prevSearch := fetchAllJobsExecuteLLMSearch
 	prevWebSearch := fetchAllJobsExecuteLLMWebSearch
 	fetchAllJobsInitConfiguredLLM = func(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error) {
-		if task != llmTaskJobSearch {
-			t.Fatalf("fetchAllJobsInitConfiguredLLM task = %q, want %q", task, llmTaskJobSearch)
+		if task != LLMTaskJobSearch {
+			t.Fatalf("fetchAllJobsInitConfiguredLLM task = %q, want %q", task, LLMTaskJobSearch)
 		}
 		return fakeLLMModel{}, func() {}, nil
 	}
@@ -634,8 +634,8 @@ func TestFetchAllJobsLLMSearchRepairsIdentityBeforeValidation(t *testing.T) {
 	if applyGETRequests == 0 {
 		t.Fatal("fetchAllJobs() did not fetch the apply page for llm_job_search identity repair")
 	}
-	if len(initTasks) != 1 || initTasks[0] != llmTaskJobSearch {
-		t.Fatalf("fetchAllJobs() initialized LLM tasks %#v, want only %q", initTasks, llmTaskJobSearch)
+	if len(initTasks) != 1 || initTasks[0] != LLMTaskJobSearch {
+		t.Fatalf("fetchAllJobs() initialized LLM tasks %#v, want only %q", initTasks, LLMTaskJobSearch)
 	}
 	if got, want := jobs[0].CompanyWebsite, "https://www.acme.com"; got != want {
 		t.Fatalf("jobs[0].CompanyWebsite = %q, want %q", got, want)
@@ -2249,8 +2249,8 @@ func TestFetchAllJobsCombinesLLMAndRSSSources(t *testing.T) {
 	prevIdentity := fetchAllJobsEnrichJobIdentity
 	prevReadFile := fetchAllJobsReadFile
 	fetchAllJobsInitConfiguredLLM = func(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error) {
-		if task != llmTaskJobSearch && task != llmTaskJobIdentity {
-			t.Fatalf("fetchAllJobsInitConfiguredLLM task = %q, want %q or %q", task, llmTaskJobSearch, llmTaskJobIdentity)
+		if task != LLMTaskJobSearch && task != llmTaskJobIdentity {
+			t.Fatalf("fetchAllJobsInitConfiguredLLM task = %q, want %q or %q", task, LLMTaskJobSearch, llmTaskJobIdentity)
 		}
 		return fakeLLMModel{}, func() {}, nil
 	}

--- a/internal/fetcher/job_filter.go
+++ b/internal/fetcher/job_filter.go
@@ -106,14 +106,18 @@ func extractAndCheckSalary(text string, minBase int) bool {
 	// Remove commas for easier parsing: "$180,000" -> "$180000"
 	cleanText := strings.ReplaceAll(text, ",", "")
 
+	foundAnyNumber := false
+
 	// Look for explicitly high numbers (e.g., 180000)
 	reFull := regexp.MustCompile(`\b[1-9]\d{4,5}\b`)
 	matchesFull := reFull.FindAllString(cleanText, -1)
 	for _, m := range matchesFull {
 		var val int
-		_, _ = fmt.Sscanf(m, "%d", &val)
-		if val >= minBase {
-			return true
+		if _, err := fmt.Sscanf(m, "%d", &val); err == nil {
+			foundAnyNumber = true
+			if val >= minBase {
+				return true
+			}
 		}
 	}
 
@@ -122,14 +126,22 @@ func extractAndCheckSalary(text string, minBase int) bool {
 	matchesK := reK.FindAllStringSubmatch(cleanText, -1)
 	for _, m := range matchesK {
 		var val int
-		_, _ = fmt.Sscanf(m[1], "%d", &val)
-		if val*1000 >= minBase {
-			return true
+		if _, err := fmt.Sscanf(m[1], "%d", &val); err == nil {
+			foundAnyNumber = true
+			if val*1000 >= minBase {
+				return true
+			}
 		}
 	}
 
-	// We couldn't definitively prove it meets the criteria.
-	// We return false, meaning we aggressively filter out jobs missing compensation details.
+	// If we did not discover any numerical salary figures (e.g., "Competitive", "Depends on Experience"),
+	// we keep the job to avoid aggressively discarding unlisted opportunities.
+	if !foundAnyNumber {
+		return true
+	}
+
+	// If numerical figures were found, but ALL of them are strictly below the threshold,
+	// then we definitively prove it fails the criteria and filter it out.
 	return false
 }
 

--- a/internal/fetcher/job_filter_test.go
+++ b/internal/fetcher/job_filter_test.go
@@ -2,6 +2,43 @@ package fetcher
 
 import "testing"
 
+func TestExtractAndCheckSalary(t *testing.T) {
+	tests := []struct {
+		text    string
+		minBase int
+		want    bool
+	}{
+		{
+			text:    "Competitive / DOE",
+			minBase: 120000,
+			want:    true,
+		},
+		{
+			text:    "$90K - $150K",
+			minBase: 120000,
+			want:    true,
+		},
+		{
+			text:    "$80K - $95K",
+			minBase: 120000,
+			want:    false,
+		},
+		{
+			text:    "$118,000 - $231,000 USD/year",
+			minBase: 120000,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			if got := extractAndCheckSalary(tt.text, tt.minBase); got != tt.want {
+				t.Fatalf("extractAndCheckSalary(%q, %d) = %t; want %t", tt.text, tt.minBase, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestJobMatchesWorkSettings(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/fetcher/job_identity_enricher.go
+++ b/internal/fetcher/job_identity_enricher.go
@@ -7,10 +7,11 @@ import (
 )
 
 func newJobIdentityLLMEnricher(ctx context.Context, appCfg *AppConfig) (jobIdentityPageEnrichFunc, func(), string) {
-	if appCfg == nil || !appCfg.LLM.Enabled || fetchAllJobsInitConfiguredLLM == nil || fetchAllJobsEnrichJobIdentity == nil {
+	llmSvc := getLLMService(ctx)
+	if appCfg == nil || !appCfg.LLM.Enabled || !llmSvc.IsAvailable(ctx, "llm_job_enrichment") {
 		return nil, nil, ""
 	}
-	llm, restoreAuth, err := fetchAllJobsInitConfiguredLLM(ctx, appCfg, llmTaskJobIdentity)
+	llm, restoreAuth, err := llmSvc.InitConfiguredLLM(ctx, appCfg, llmTaskJobIdentity)
 	if err != nil {
 		return nil, nil, fmt.Sprintf("LLM job identity enrichment skipped: %v", err)
 	}
@@ -18,7 +19,7 @@ func newJobIdentityLLMEnricher(ctx context.Context, appCfg *AppConfig) (jobIdent
 	enrich := func(ctx context.Context, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error) {
 		mu.Lock()
 		defer mu.Unlock()
-		return fetchAllJobsEnrichJobIdentity(ctx, llm, job, page)
+		return llmSvc.EnrichJobIdentity(ctx, llm, job, page)
 	}
 	return enrich, restoreAuth, ""
 }

--- a/internal/fetcher/job_identity_enricher.go
+++ b/internal/fetcher/job_identity_enricher.go
@@ -8,7 +8,7 @@ import (
 
 func newJobIdentityLLMEnricher(ctx context.Context, appCfg *AppConfig) (jobIdentityPageEnrichFunc, func(), string) {
 	llmSvc := getLLMService(ctx)
-	if appCfg == nil || !appCfg.LLM.Enabled || !llmSvc.IsAvailable(ctx, "llm_job_enrichment") {
+	if appCfg == nil || !appCfg.LLM.Enabled || !llmSvc.IsAvailable(ctx, LLMTaskJobEnrichment) {
 		return nil, nil, ""
 	}
 	llm, restoreAuth, err := llmSvc.InitConfiguredLLM(ctx, appCfg, llmTaskJobIdentity)

--- a/internal/fetcher/linkedin_typeahead.go
+++ b/internal/fetcher/linkedin_typeahead.go
@@ -34,12 +34,31 @@ type linkedInTypeaheadCacheEntry struct {
 
 type linkedInTypeaheadCache map[string]linkedInTypeaheadCacheEntry
 
-var linkedInTypeaheadMemoryCache = struct {
-	sync.Mutex
+type linkedinTypeaheadMemoryCache struct {
+	mu     sync.Mutex
 	path   string
 	loaded bool
 	cache  linkedInTypeaheadCache
-}{}
+}
+
+var linkedInTypeaheadMemoryCache = &linkedinTypeaheadMemoryCache{}
+
+func (c *linkedinTypeaheadMemoryCache) Get(cachePath string) (linkedInTypeaheadCache, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.loaded && c.path == cachePath {
+		return cloneLinkedInTypeaheadCache(c.cache), true
+	}
+	return nil, false
+}
+
+func (c *linkedinTypeaheadMemoryCache) Set(cachePath string, cache linkedInTypeaheadCache) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.path = cachePath
+	c.loaded = true
+	c.cache = cloneLinkedInTypeaheadCache(cache)
+}
 
 func refreshLinkedInCriteriaHints(ctx context.Context, criteria *CriteriaConfig) error {
 	if criteria == nil {
@@ -140,19 +159,15 @@ func loadLinkedInTypeaheadCache() (linkedInTypeaheadCache, error) {
 		return linkedInTypeaheadCache{}, nil
 	}
 
-	linkedInTypeaheadMemoryCache.Lock()
-	if linkedInTypeaheadMemoryCache.loaded && linkedInTypeaheadMemoryCache.path == cachePath {
-		cache := cloneLinkedInTypeaheadCache(linkedInTypeaheadMemoryCache.cache)
-		linkedInTypeaheadMemoryCache.Unlock()
+	if cache, ok := linkedInTypeaheadMemoryCache.Get(cachePath); ok {
 		return cache, nil
 	}
-	linkedInTypeaheadMemoryCache.Unlock()
 
 	data, err := os.ReadFile(cachePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			cache := linkedInTypeaheadCache{}
-			storeLinkedInTypeaheadMemoryCache(cachePath, cache)
+			linkedInTypeaheadMemoryCache.Set(cachePath, cache)
 			return cache, nil
 		}
 		return nil, err
@@ -164,7 +179,7 @@ func loadLinkedInTypeaheadCache() (linkedInTypeaheadCache, error) {
 	if cache == nil {
 		cache = linkedInTypeaheadCache{}
 	}
-	storeLinkedInTypeaheadMemoryCache(cachePath, cache)
+	linkedInTypeaheadMemoryCache.Set(cachePath, cache)
 	return cache, nil
 }
 
@@ -183,16 +198,8 @@ func saveLinkedInTypeaheadCache(cache linkedInTypeaheadCache) error {
 	if err := os.WriteFile(cachePath, data, 0600); err != nil {
 		return err
 	}
-	storeLinkedInTypeaheadMemoryCache(cachePath, cache)
+	linkedInTypeaheadMemoryCache.Set(cachePath, cache)
 	return nil
-}
-
-func storeLinkedInTypeaheadMemoryCache(cachePath string, cache linkedInTypeaheadCache) {
-	linkedInTypeaheadMemoryCache.Lock()
-	linkedInTypeaheadMemoryCache.path = cachePath
-	linkedInTypeaheadMemoryCache.loaded = true
-	linkedInTypeaheadMemoryCache.cache = cloneLinkedInTypeaheadCache(cache)
-	linkedInTypeaheadMemoryCache.Unlock()
 }
 
 func cloneLinkedInTypeaheadCache(cache linkedInTypeaheadCache) linkedInTypeaheadCache {

--- a/internal/fetcher/llm_hooks.go
+++ b/internal/fetcher/llm_hooks.go
@@ -8,7 +8,12 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-const llmTaskJobSearch = "llm_job_search"
+const (
+	LLMTaskJobSearch     = "llm_job_search"
+	LLMTaskWebSearch     = "llm_web_search"
+	LLMTaskJobEnrichment = "llm_job_enrichment"
+)
+
 const llmTaskJobIdentity = "job_identity"
 
 type InitLLMFunc func(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error)
@@ -78,7 +83,7 @@ func (fallbackLLMService) ExecuteWebSearch(ctx context.Context, appCfg *AppConfi
 	if fetchAllJobsInitConfiguredLLM == nil || fetchAllJobsExecuteLLMSearch == nil {
 		return nil, fmt.Errorf("LLM web search hook not configured")
 	}
-	llm, restoreAuth, err := fetchAllJobsInitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
+	llm, restoreAuth, err := fetchAllJobsInitConfiguredLLM(ctx, appCfg, LLMTaskJobSearch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize: %w", err)
 	}
@@ -94,13 +99,13 @@ func (fallbackLLMService) EnrichJobIdentity(ctx context.Context, llm llms.Model,
 }
 
 func (fallbackLLMService) IsAvailable(ctx context.Context, task string) bool {
-	if task == "llm_web_search" {
+	if task == LLMTaskWebSearch {
 		return fetchAllJobsExecuteLLMWebSearch != nil || (fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsExecuteLLMSearch != nil)
 	}
-	if task == "llm_job_search" {
+	if task == LLMTaskJobSearch {
 		return fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsExecuteLLMSearch != nil
 	}
-	if task == "llm_job_enrichment" {
+	if task == LLMTaskJobEnrichment {
 		return fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsEnrichJobIdentity != nil
 	}
 	return false

--- a/internal/fetcher/llm_hooks.go
+++ b/internal/fetcher/llm_hooks.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	"github.com/tmc/langchaingo/llms"
 )
@@ -13,6 +15,96 @@ type InitLLMFunc func(ctx context.Context, appCfg *AppConfig, task string) (llms
 type ExecuteLLMSearchFunc func(ctx context.Context, llm llms.Model, prompt string) ([]Job, error)
 type ExecuteLLMWebSearchFunc func(ctx context.Context, appCfg *AppConfig, prompt string) ([]Job, error)
 type EnrichJobIdentityFunc func(ctx context.Context, llm llms.Model, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error)
+
+type LLMService interface {
+	InitConfiguredLLM(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error)
+	ExecuteSearch(ctx context.Context, llm llms.Model, prompt string) ([]Job, error)
+	ExecuteWebSearch(ctx context.Context, appCfg *AppConfig, prompt string) ([]Job, error)
+	EnrichJobIdentity(ctx context.Context, llm llms.Model, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error)
+	IsAvailable(ctx context.Context, task string) bool
+}
+
+type llmServiceContextKey struct{}
+
+var contextKey = llmServiceContextKey{}
+
+func WithLLMService(ctx context.Context, service LLMService) context.Context {
+	return context.WithValue(ctx, contextKey, service)
+}
+
+var (
+	globalServiceMutex sync.RWMutex
+	globalLLMService   LLMService
+)
+
+func RegisterLLMService(service LLMService) {
+	globalServiceMutex.Lock()
+	defer globalServiceMutex.Unlock()
+	globalLLMService = service
+}
+
+func getLLMService(ctx context.Context) LLMService {
+	if svc, ok := ctx.Value(contextKey).(LLMService); ok {
+		return svc
+	}
+	globalServiceMutex.RLock()
+	defer globalServiceMutex.RUnlock()
+	if globalLLMService != nil {
+		return globalLLMService
+	}
+	return fallbackLLMService{}
+}
+
+type fallbackLLMService struct{}
+
+func (fallbackLLMService) InitConfiguredLLM(ctx context.Context, appCfg *AppConfig, task string) (llms.Model, func(), error) {
+	if fetchAllJobsInitConfiguredLLM != nil {
+		return fetchAllJobsInitConfiguredLLM(ctx, appCfg, task)
+	}
+	return nil, nil, fmt.Errorf("LLM init hook not configured")
+}
+
+func (fallbackLLMService) ExecuteSearch(ctx context.Context, llm llms.Model, prompt string) ([]Job, error) {
+	if fetchAllJobsExecuteLLMSearch != nil {
+		return fetchAllJobsExecuteLLMSearch(ctx, llm, prompt)
+	}
+	return nil, fmt.Errorf("LLM search hook not configured")
+}
+
+func (fallbackLLMService) ExecuteWebSearch(ctx context.Context, appCfg *AppConfig, prompt string) ([]Job, error) {
+	if fetchAllJobsExecuteLLMWebSearch != nil {
+		return fetchAllJobsExecuteLLMWebSearch(ctx, appCfg, prompt)
+	}
+	if fetchAllJobsInitConfiguredLLM == nil || fetchAllJobsExecuteLLMSearch == nil {
+		return nil, fmt.Errorf("LLM web search hook not configured")
+	}
+	llm, restoreAuth, err := fetchAllJobsInitConfiguredLLM(ctx, appCfg, llmTaskJobSearch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize: %w", err)
+	}
+	defer restoreAuth()
+	return fetchAllJobsExecuteLLMSearch(ctx, llm, prompt)
+}
+
+func (fallbackLLMService) EnrichJobIdentity(ctx context.Context, llm llms.Model, job Job, page JobIdentityPage) (*JobIdentityEnrichment, LLMTokenUsage, error) {
+	if fetchAllJobsEnrichJobIdentity != nil {
+		return fetchAllJobsEnrichJobIdentity(ctx, llm, job, page)
+	}
+	return nil, LLMTokenUsage{}, fmt.Errorf("LLM identity enrichment hook not configured")
+}
+
+func (fallbackLLMService) IsAvailable(ctx context.Context, task string) bool {
+	if task == "llm_web_search" {
+		return fetchAllJobsExecuteLLMWebSearch != nil || (fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsExecuteLLMSearch != nil)
+	}
+	if task == "llm_job_search" {
+		return fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsExecuteLLMSearch != nil
+	}
+	if task == "llm_job_enrichment" {
+		return fetchAllJobsInitConfiguredLLM != nil && fetchAllJobsEnrichJobIdentity != nil
+	}
+	return false
+}
 
 var (
 	fetchAllJobsInitConfiguredLLM   InitLLMFunc

--- a/internal/jobscout/cli.go
+++ b/internal/jobscout/cli.go
@@ -125,8 +125,7 @@ func runFetchDryRun(options appruntime.Options, stores appruntime.Stores, jsonOu
 		existing = []domain.Job{}
 	}
 
-	fetcher.ConfigureLLM(llmpkg.InitConfiguredLLMForTask, llmpkg.ExecuteLLMSearch, llmpkg.EnrichJobIdentityWithLLMUsage)
-	fetcher.ConfigureLLMWebSearch(llmpkg.ExecuteLLMWebSearch)
+	fetcher.RegisterLLMService(llmpkg.NewLLMService())
 	newJobs, summary, err := fetcher.FetchAllJobsSkippingExisting(ctx, appCfg, criteriaCfg, existing, nil)
 	if err != nil {
 		if !jsonOutput {
@@ -224,8 +223,7 @@ func runRepairJobIdentityCLI(options appruntime.Options, stores appruntime.Store
 	repairJobs, repairIndexes := domain.IdentityRepairTargets(jobs)
 	fmt.Printf("Repairing identity data for %d of %d jobs.\n", len(repairJobs), len(jobs))
 	if len(repairJobs) > 0 {
-		fetcher.ConfigureLLM(llmpkg.InitConfiguredLLMForTask, llmpkg.ExecuteLLMSearch, llmpkg.EnrichJobIdentityWithLLMUsage)
-		fetcher.ConfigureLLMWebSearch(llmpkg.ExecuteLLMWebSearch)
+		fetcher.RegisterLLMService(llmpkg.NewLLMService())
 		repairJobs = fetcher.EnrichJobsFromApplyPagesWithConfigStoreAndProgress(ctx, repairJobs, appCfg, stores.CompanyIdentity, func(message string) {
 			fmt.Println(message)
 		}, nil)

--- a/internal/llm/llm_service.go
+++ b/internal/llm/llm_service.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"context"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/wallentx/jobscout/internal/fetcher"
+)
+
+type defaultLLMService struct{}
+
+func NewLLMService() fetcher.LLMService {
+	return defaultLLMService{}
+}
+
+func (defaultLLMService) InitConfiguredLLM(ctx context.Context, appCfg *fetcher.AppConfig, task string) (llms.Model, func(), error) {
+	return InitConfiguredLLMForTask(ctx, appCfg, task)
+}
+
+func (defaultLLMService) ExecuteSearch(ctx context.Context, llm llms.Model, prompt string) ([]fetcher.Job, error) {
+	return ExecuteLLMSearch(ctx, llm, prompt)
+}
+
+func (defaultLLMService) ExecuteWebSearch(ctx context.Context, appCfg *fetcher.AppConfig, prompt string) ([]fetcher.Job, error) {
+	return ExecuteLLMWebSearch(ctx, appCfg, prompt)
+}
+
+func (defaultLLMService) EnrichJobIdentity(ctx context.Context, llm llms.Model, job fetcher.Job, page fetcher.JobIdentityPage) (*fetcher.JobIdentityEnrichment, fetcher.LLMTokenUsage, error) {
+	return EnrichJobIdentityWithLLMUsage(ctx, llm, job, page)
+}
+
+func (defaultLLMService) IsAvailable(ctx context.Context, task string) bool {
+	return true
+}

--- a/internal/tuiapp/background_task.go
+++ b/internal/tuiapp/background_task.go
@@ -319,8 +319,7 @@ func enrichAcceptedFetchCmd(taskID int, disableLLM bool, jobs []Job, progressCh 
 			appCfg = sessionFetchConfig(disableLLM, appCfg)
 		}
 
-		fetcher.ConfigureLLM(llmpkg.InitConfiguredLLMForTask, llmpkg.ExecuteLLMSearch, llmpkg.EnrichJobIdentityWithLLMUsage)
-		fetcher.ConfigureLLMWebSearch(llmpkg.ExecuteLLMWebSearch)
+		fetcher.RegisterLLMService(llmpkg.NewLLMService())
 		reportAcceptedFetchProgress(progressCh, "Enriching accepted jobs in the background...")
 		enriched := fetcher.EnrichJobsFromApplyPagesWithConfigStoreAndProgress(ctx, append([]Job(nil), jobs...), appCfg, runtimeCompanyIdentityStore, func(message string) {
 			reportAcceptedFetchProgress(progressCh, message)

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -219,8 +219,7 @@ func applyOptionalLLMJobFilteringWithFreshTimeout(appCfg *AppConfig, criteriaCfg
 }
 
 func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, existingJobs []Job, progress func(string)) ([]Job, FetchSummary, error) {
-	fetcher.ConfigureLLM(llmpkg.InitConfiguredLLMForTask, llmpkg.ExecuteLLMSearch, llmpkg.EnrichJobIdentityWithLLMUsage)
-	fetcher.ConfigureLLMWebSearch(llmpkg.ExecuteLLMWebSearch)
+	fetcher.RegisterLLMService(llmpkg.NewLLMService())
 	return fetcher.FetchAllJobsSkippingExistingWithCandidateCache(ctx, appCfg, criteriaCfg, existingJobs, progress, runtimeCandidateStore)
 }
 


### PR DESCRIPTION
1. LinkedIn Typeahead Cache Encapsulation:
   - Define a named `linkedinTypeaheadMemoryCache` struct and implement safe `Get()` and `Set()` helpers to hide mutex operations and direct map mutations.
2. Salary Heuristic Optimization:
   - Update `extractAndCheckSalary` in  job_filter.go  to keep competitive, unlisted, and "DOE" jobs intact (returning `true`), only filtering out jobs that explicitly list compensation completely below the user's minimum base threshold.
5. Context-Scoped LLM Service:
    - Define a context-injectable `LLMService` interface alongside context injectors and getters.
    - Implement `defaultLLMService` to call the real, production LLM engines.
    - Implement a thread-safe `fallbackLLMService` adapter which perfectly routes to the legacy hook functions. This maintains absolute backward compatibility for all existing mock-heavy tests without changing
their structures.
    - Introduce an `IsAvailable(ctx, task)` interface method to dynamically determine availability for standard LLM searches, web searches, and identity enrichment targets depending on the configured context.
    - Update fetcher routines, CLI setup, TUI apps, and background tasks to register and use the modern, context-scoped service.