### PR TITLE
feat(fetch): Add company-specific job search capabilities

### DIFF
--- a/internal/fetcher/company_names.go
+++ b/internal/fetcher/company_names.go
@@ -7,7 +7,7 @@ func cleanCompanyName(name string) string {
 	n = strings.ReplaceAll(n, ",", "")
 	for _, suffix := range []string{
 		" inc", " inc.", " corp", " corp.", " corporation", " co", " co.",
-		" ltd", " ltd.", " limited", " plc", " ag", " sa", " se", " holdings", " group",
+		" ltd", " ltd.", " limited", " llc", " llc.", " plc", " ag", " sa", " se", " holdings", " group",
 	} {
 		if strings.HasSuffix(n, suffix) {
 			n = strings.TrimSpace(strings.TrimSuffix(n, suffix))

--- a/internal/fetcher/job_fetcher.go
+++ b/internal/fetcher/job_fetcher.go
@@ -20,6 +20,50 @@ const (
 	maxConcurrentBrowserSearch   = 1
 )
 
+type CompanyFetchOptions struct {
+	Company       string
+	Aliases       []string
+	Website       string
+	MatchCriteria bool
+}
+
+type companyFetchScope struct {
+	Company       string
+	Aliases       []string
+	Website       string
+	MatchCriteria bool
+}
+
+func (s companyFetchScope) active() bool {
+	return strings.TrimSpace(s.Company) != ""
+}
+
+func (s companyFetchScope) names() []string {
+	names := make([]string, 0, 1+len(s.Aliases))
+	names = appendUniqueCompanyTargetName(names, s.Company)
+	for _, alias := range s.Aliases {
+		names = appendUniqueCompanyTargetName(names, alias)
+	}
+	return names
+}
+
+func (s companyFetchScope) websiteDomain() string {
+	return companyWebsiteDomainForSearch(normalizeCompanyTargetWebsite(s.Website))
+}
+
+func appendUniqueCompanyTargetName(names []string, name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return names
+	}
+	for _, existing := range names {
+		if strings.EqualFold(existing, name) {
+			return names
+		}
+	}
+	return append(names, name)
+}
+
 func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, progress func(string), existingJobs ...[]Job) ([]Job, FetchSummary, error) {
 	var existing []Job
 	if len(existingJobs) > 0 {
@@ -29,11 +73,21 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 }
 
 func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, progress func(string), existingJobs []Job, candidateStore storage.CandidateStore) ([]Job, FetchSummary, error) {
+	return fetchAllJobsWithCandidateCacheAndScope(ctx, appCfg, criteriaCfg, progress, existingJobs, candidateStore, companyFetchScope{})
+}
+
+func fetchAllJobsWithCandidateCacheAndScope(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, progress func(string), existingJobs []Job, candidateStore storage.CandidateStore, companyScope companyFetchScope) ([]Job, FetchSummary, error) {
 	fetchStart := time.Now()
 	var allFetched []Job
 	summary := newFetchSummary()
 	existing := existingJobs
 	existingIndex := newExistingJobIndex(existing)
+	sourceCriteria := criteriaCfg
+	filterCriteria := criteriaCfg
+	if companyScope.active() && !companyScope.MatchCriteria {
+		sourceCriteria = nil
+		filterCriteria = nil
+	}
 	defer func() {
 		logDebug(
 			"fetch complete: total=%d filtered=%d rejected=%d notices=%d duration=%s",
@@ -51,7 +105,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		return allFetched, summary, nil
 	}
 	pruneCandidateCache(ctx, candidateStore, appCfg)
-	if err := refreshLinkedInCriteriaHints(ctx, criteriaCfg); err != nil {
+	if err := refreshLinkedInCriteriaHints(ctx, sourceCriteria); err != nil {
 		logDebug("linkedin criteria hint refresh failed: %v", err)
 	}
 	policy := fetchPolicyFromConfig(appCfg)
@@ -61,7 +115,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		fetches, hits, htmlEntries, probeEntries := urlVisits.Stats()
 		logDebug("url visit registry summary: fetches=%d hits=%d html_entries=%d probe_entries=%d", fetches, hits, htmlEntries, probeEntries)
 	}()
-	effectiveSources := resolveEffectiveSources(appCfg, criteriaCfg)
+	effectiveSources := resolveEffectiveSources(appCfg, sourceCriteria)
 	randomizeResolvedSources(&effectiveSources)
 	logDebug(
 		"fetch start: llm_enabled=%t llm_job_search=%t llm_job_filtering=%t llm_company_health=%t sources_enabled=%t rss_enabled=%t rss_feeds=%d api_sources=%d site_enabled=%t site_targets=%d llm_web_enabled=%t llm_web_targets=%d",
@@ -78,7 +132,10 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		appCfg.Sources.LLMWeb.Enabled,
 		len(effectiveSources.LLMWebTargets),
 	)
-	logDebug("source resolution: role_families=%s", debugRoleFamilies(effectiveRoleFamilies(appCfg, criteriaCfg)))
+	if companyScope.active() {
+		logDebug("company fetch: company=%q aliases=%s website=%q match_criteria=%t", companyScope.Company, debugStringList(companyScope.Aliases), companyScope.Website, companyScope.MatchCriteria)
+	}
+	logDebug("source resolution: role_families=%s", debugRoleFamilies(effectiveRoleFamilies(appCfg, sourceCriteria)))
 	logDebug("source resolution: rss=%s", debugRSSSources(effectiveSources.RSSFeeds))
 	logDebug("source resolution: api=%s", debugAPISources(effectiveSources.APISources))
 	logDebug("source resolution: site_targets=%s", debugStringList(effectiveSources.SiteTargets))
@@ -103,15 +160,23 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 			llm, restoreAuth, initErr := llmSvc.InitConfiguredLLM(ctx, appCfg, LLMTaskJobSearch)
 			if initErr == nil {
 				defer restoreAuth()
-				promptBytes, err := fetchAllJobsReadFile(runtimeSearchPromptPath)
-				if err != nil {
-					mu.Lock()
-					summary.Notices = append(summary.Notices, fmt.Sprintf("Could not read SEARCH_PROMPT.md: %v", err))
-					setFetchSearchStatus(&summary, fetchSearchLLM, fmt.Sprintf("failed before execution: %v", err))
-					mu.Unlock()
+				prompt := ""
+				if companyScope.active() {
+					prompt = buildCompanyLLMSearchPrompt(sourceCriteria, companyScope, companyScope.MatchCriteria)
 				} else {
+					promptBytes, err := fetchAllJobsReadFile(runtimeSearchPromptPath)
+					if err != nil {
+						mu.Lock()
+						summary.Notices = append(summary.Notices, fmt.Sprintf("Could not read SEARCH_PROMPT.md: %v", err))
+						setFetchSearchStatus(&summary, fetchSearchLLM, fmt.Sprintf("failed before execution: %v", err))
+						mu.Unlock()
+					} else {
+						prompt = string(promptBytes)
+					}
+				}
+				if strings.TrimSpace(prompt) != "" {
 					reportFetchProgress(progress, "Running LLM job search...")
-					jobs, err := llmSvc.ExecuteSearch(ctx, llm, string(promptBytes))
+					jobs, err := llmSvc.ExecuteSearch(ctx, llm, prompt)
 					if err != nil {
 						mu.Lock()
 						summary.Notices = append(summary.Notices, fmt.Sprintf("LLM job search failed: %v", err))
@@ -161,7 +226,10 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 		case len(effectiveSources.LLMWebTargets) == 0:
 			setFetchSearchStatus(&summary, fetchSearchLLMWeb, "enabled, but no llm_web targets were configured or resolved")
 		default:
-			prompt, queries := buildLLMWebSearchPrompt(criteriaCfg, effectiveSources.LLMWebTargets)
+			prompt, queries := buildLLMWebSearchPrompt(sourceCriteria, effectiveSources.LLMWebTargets)
+			if companyScope.active() {
+				prompt, queries = buildCompanyLLMWebSearchPrompt(sourceCriteria, effectiveSources.LLMWebTargets, companyScope, companyScope.MatchCriteria)
+			}
 			if strings.TrimSpace(prompt) == "" {
 				setFetchSearchStatus(&summary, fetchSearchLLMWeb, "enabled, but no llm_web queries could be built")
 				break
@@ -185,7 +253,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 			var dropped map[string][]string
 			var filtered map[string][]Job
 			markLLMWebJobsForValidation(jobs)
-			jobs, filtered = filterLLMWebJobsBeforeEnrichment(jobs, criteriaCfg)
+			jobs, filtered = filterLLMWebJobsBeforeEnrichment(jobs, filterCriteria)
 			jobs = enrichLLMWebJobsBeforeValidation(ctx, appCfg, jobs, progress)
 			jobs, dropped = validateFetchedJobs(ctx, jobs)
 			mu.Lock()
@@ -225,7 +293,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if appCfg.Sources.RSS.Enabled {
+		if appCfg.Sources.RSS.Enabled && !companyScope.active() {
 			if len(effectiveSources.RSSFeeds) == 0 {
 				mu.Lock()
 				setFetchSearchStatus(&summary, fetchSearchRSS, "enabled, but no RSS feeds were configured or resolved")
@@ -236,7 +304,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 				runBounded(ctx, len(effectiveSources.RSSFeeds), maxConcurrentRSSFetch, func(i int) {
 					source := effectiveSources.RSSFeeds[i]
 					reportFetchProgress(progress, "Checking RSS feed: %s", source.Name)
-					jobs, filtered, err := fetchRSS(ctx, source, criteriaCfg)
+					jobs, filtered, err := fetchRSS(ctx, source, filterCriteria)
 					if err != nil {
 						results[i].err = err
 						results[i].notice = fmt.Sprintf("Failed to fetch RSS %s: %v", source.Name, err)
@@ -279,7 +347,11 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 			}
 		} else {
 			mu.Lock()
-			setFetchSearchStatus(&summary, fetchSearchRSS, "disabled in config")
+			if companyScope.active() {
+				setFetchSearchStatus(&summary, fetchSearchRSS, "disabled for company fetch")
+			} else {
+				setFetchSearchStatus(&summary, fetchSearchRSS, "disabled in config")
+			}
 			mu.Unlock()
 		}
 	}()
@@ -299,13 +371,16 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 				apiSources = append(apiSources, source)
 			}
 		}
+		if companyScope.active() {
+			apiSources = nil
+		}
 		apiSourceCount = len(apiSources)
 		logDebug("api search: fetching %d sources with concurrency=%d", len(apiSources), maxConcurrentAPIFetch)
 		results := make([]sourceFetchResult, len(apiSources))
 		runBounded(ctx, len(apiSources), maxConcurrentAPIFetch, func(i int) {
 			source := apiSources[i]
 			reportFetchProgress(progress, "Checking configured source: %s", source.Name)
-			jobs, filtered, err := fetchJobsFromAPISource(ctx, source, criteriaCfg)
+			jobs, filtered, err := fetchJobsFromAPISource(ctx, source, filterCriteria)
 			if err != nil {
 				results[i].err = err
 				results[i].notice = fmt.Sprintf("Failed to fetch configured source %s: %v", source.Name, err)
@@ -337,6 +412,8 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 
 		mu.Lock()
 		switch {
+		case companyScope.active():
+			setFetchSearchStatus(&summary, fetchSearchAPI, "disabled for company fetch")
 		case len(appCfg.Sources.APIs) == 0:
 			setFetchSearchStatus(&summary, fetchSearchAPI, "enabled, but no configured sources were available")
 		case apiSourceCount == 0:
@@ -400,7 +477,10 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 				}
 
 				sourceName := formatSearchSource(fetchSearchSite, strings.TrimSpace(site))
-				targetURLs := siteSearchURLsForCriteria(site, criteriaCfg)
+				targetURLs := siteSearchURLsForCriteria(site, sourceCriteria)
+				if companyScope.active() {
+					targetURLs = siteSearchURLsForCompany(site, sourceCriteria, companyScope, companyScope.MatchCriteria)
+				}
 				logDebug("site search target %d/%d %s: target URLs %s", i+1, len(effectiveSources.SiteTargets), site, debugStringList(targetURLs))
 				if len(targetURLs) == 0 {
 					logDebug("site search %s: skipped because no searchable target URL could be resolved", site)
@@ -427,7 +507,7 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 			runBounded(ctx, len(tasks), maxConcurrentSiteSearchFetch, func(i int) {
 				task := tasks[i]
 				reportFetchProgress(progress, "Searching site target: %s", strings.TrimSpace(task.site))
-				results[i] = fetchSiteSearchTask(ctx, task, criteriaCfg, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches, blockedSiteDetails, candidateLimiter, candidateStore)
+				results[i] = fetchSiteSearchTask(ctx, task, filterCriteria, ensureSiteBrowser, browserSem, builtInDetails, builtInProfiles, existingIndex, blockedSiteSearches, blockedSiteDetails, candidateLimiter, candidateStore)
 			})
 
 			for i, result := range results {
@@ -471,12 +551,29 @@ func fetchAllJobsWithCandidateCache(ctx context.Context, appCfg *AppConfig, crit
 
 	if candidateStore != nil {
 		allFetched = hydrateJobsFromCandidateCache(ctx, candidateStore, allFetched)
+	}
+
+	if companyScope.active() {
+		var companyFiltered []Job
+		allFetched, companyFiltered = filterJobsByCompanyTarget(allFetched, companyScope)
+		if len(companyFiltered) > 0 {
+			mu.Lock()
+			if summary.Filtered == nil {
+				summary.Filtered = make(map[string][]Job)
+			}
+			summary.Filtered["company target"] = append(summary.Filtered["company target"], companyFiltered...)
+			mu.Unlock()
+			logDebug("company fetch: filtered %d jobs that did not match company=%q", len(companyFiltered), companyScope.Company)
+		}
+	}
+
+	if candidateStore != nil {
 		upsertJobCandidates(ctx, candidateStore, allFetched)
 		for _, jobs := range summary.Filtered {
 			upsertJobCandidates(ctx, candidateStore, jobs)
 		}
-		allFetched = applyCachedDeterministicRejects(ctx, candidateStore, criteriaCfg, allFetched, &summary)
-		recordDeterministicCandidateDecisions(ctx, candidateStore, criteriaCfg, allFetched, summary.Filtered)
+		allFetched = applyCachedDeterministicRejects(ctx, candidateStore, filterCriteria, allFetched, &summary)
+		recordDeterministicCandidateDecisions(ctx, candidateStore, filterCriteria, allFetched, summary.Filtered)
 	}
 
 	var skippedExisting []Job
@@ -533,6 +630,112 @@ func markLLMJobsForValidation(jobs []Job) {
 		}
 		jobs[i].Source = formatSearchSource(fetchSearchLLM, source)
 	}
+}
+
+func buildCompanyLLMSearchPrompt(criteria *CriteriaConfig, company companyFetchScope, matchCriteria bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Find current public job openings where the employer is %s.\n", strings.TrimSpace(company.Company))
+	if len(company.Aliases) > 0 {
+		fmt.Fprintf(&b, "Also treat these names as the same employer: %s.\n", strings.Join(company.Aliases, ", "))
+	}
+	if domain := company.websiteDomain(); domain != "" {
+		fmt.Fprintf(&b, "The company's official website domain is %s. Exclude roles whose source evidence points to a different company website.\n", domain)
+	}
+	b.WriteString("\n")
+	if matchCriteria {
+		b.WriteString("Only include roles that match the candidate criteria below.\n\n")
+		writeLLMWebCriteria(&b, criteria)
+	} else {
+		b.WriteString("Return all current public roles for this company. Do not filter by candidate criteria.\n")
+	}
+	b.WriteString("\nOutput Instructions\n")
+	b.WriteString("- Return current opportunities only.\n")
+	b.WriteString("- Only include roles where the employer is the requested company.\n")
+	b.WriteString("- Prefer direct application links.\n")
+	b.WriteString("- If available, include the actual company's website, not the job board or application host.\n")
+	b.WriteString("- If available, include a brief factual summary of what the company does.\n")
+	b.WriteString("- If available, include the company's industry.\n")
+	b.WriteString("- Include enough detail to explain why each role matches.\n")
+	b.WriteString("- Return each result with company, title, remote, compensation, apply_url, description, company_website, company_summary, company_industry, and why_matches fields.\n")
+	return b.String()
+}
+
+func filterJobsByCompanyTarget(jobs []Job, company companyFetchScope) ([]Job, []Job) {
+	if !company.active() || len(jobs) == 0 {
+		return jobs, nil
+	}
+	kept := make([]Job, 0, len(jobs))
+	filtered := make([]Job, 0)
+	for _, job := range jobs {
+		if jobMatchesCompanyTarget(job, company) {
+			kept = append(kept, job)
+			continue
+		}
+		filtered = append(filtered, job)
+	}
+	return kept, filtered
+}
+
+func jobMatchesCompanyTarget(job Job, company companyFetchScope) bool {
+	if !company.active() {
+		return true
+	}
+	if strings.TrimSpace(company.Website) != "" && strings.TrimSpace(job.CompanyWebsite) != "" && !companyWebsitesMatch(job.CompanyWebsite, company.Website) {
+		logDebug("company fetch: rejected %s - %s because discovered website %q conflicts with requested website %q", job.Company, job.Title, job.CompanyWebsite, company.Website)
+		return false
+	}
+	for _, name := range company.names() {
+		targetKey := companyTargetMatchKey(name)
+		if targetKey == "" {
+			continue
+		}
+		jobKey := companyTargetMatchKey(job.Company)
+		if jobKey != "" && jobKey == targetKey {
+			return true
+		}
+		if strings.TrimSpace(job.CompanyWebsite) != "" && candidateWebsiteMatchesCompany(job.CompanyWebsite, name) {
+			return true
+		}
+	}
+	if strings.TrimSpace(company.Website) != "" && strings.TrimSpace(job.CompanyWebsite) != "" && companyWebsitesMatch(job.CompanyWebsite, company.Website) {
+		return true
+	}
+	return false
+}
+
+func companyTargetMatchKey(company string) string {
+	return strings.ReplaceAll(Slugify(CleanCompanyName(company)), "-", "")
+}
+
+func companyWebsitesMatch(candidate string, expected string) bool {
+	candidate = normalizeCompanyTargetWebsite(candidate)
+	expected = normalizeCompanyTargetWebsite(expected)
+	candidateURL, err := url.Parse(strings.TrimSpace(candidate))
+	if err != nil || candidateURL.Host == "" {
+		return false
+	}
+	expectedURL, err := url.Parse(strings.TrimSpace(expected))
+	if err != nil || expectedURL.Host == "" {
+		return false
+	}
+	return companyHostRoot(candidateURL.Hostname()) == companyHostRoot(expectedURL.Hostname())
+}
+
+func normalizeCompanyTargetWebsite(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(raw); err == nil && parsed.Host != "" {
+		return normalizeCompanyWebsiteURL(raw)
+	}
+	if !strings.Contains(raw, "://") {
+		withScheme := "https://" + raw
+		if parsed, err := url.Parse(withScheme); err == nil && parsed.Host != "" {
+			return normalizeCompanyWebsiteURL(withScheme)
+		}
+	}
+	return raw
 }
 
 func filterLLMWebJobsBeforeEnrichment(jobs []Job, criteria *CriteriaConfig) ([]Job, map[string][]Job) {
@@ -645,6 +848,29 @@ func FetchAllJobsSkippingExisting(ctx context.Context, appCfg *AppConfig, criter
 
 func FetchAllJobsSkippingExistingWithCandidateCache(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, existingJobs []Job, progress func(string), candidateStore storage.CandidateStore) ([]Job, FetchSummary, error) {
 	return fetchAllJobsWithCandidateCache(ctx, appCfg, criteriaCfg, progress, existingJobs, candidateStore)
+}
+
+func FetchCompanyJobsSkippingExistingWithCandidateCache(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, options CompanyFetchOptions, existingJobs []Job, progress func(string), candidateStore storage.CandidateStore) ([]Job, FetchSummary, error) {
+	company := strings.TrimSpace(options.Company)
+	if company == "" {
+		return nil, newFetchSummary(), fmt.Errorf("company fetch requires a company")
+	}
+	cfg := appCfg
+	if cfg != nil {
+		cfgCopy := *cfg
+		cfgCopy.Sources.RSS.Enabled = false
+		cfgCopy.Sources.APIs = append([]APISource(nil), cfgCopy.Sources.APIs...)
+		for i := range cfgCopy.Sources.APIs {
+			cfgCopy.Sources.APIs[i].Enabled = false
+		}
+		cfg = &cfgCopy
+	}
+	return fetchAllJobsWithCandidateCacheAndScope(ctx, cfg, criteriaCfg, progress, existingJobs, candidateStore, companyFetchScope{
+		Company:       company,
+		Aliases:       append([]string(nil), options.Aliases...),
+		Website:       normalizeCompanyTargetWebsite(options.Website),
+		MatchCriteria: options.MatchCriteria,
+	})
 }
 
 type sourceFetchResult struct {

--- a/internal/fetcher/job_fetcher_test.go
+++ b/internal/fetcher/job_fetcher_test.go
@@ -2338,3 +2338,21 @@ func TestFetchAllJobsCombinesLLMAndRSSSources(t *testing.T) {
 		t.Fatalf("jobs[1].Company = %q; want Unknown", jobs[1].Company)
 	}
 }
+
+func TestJobMatchesCompanyTargetUsesWebsiteAndAliases(t *testing.T) {
+	scope := companyFetchScope{
+		Company: "GitHub",
+		Aliases: []string{"GitHub Inc"},
+		Website: "https://github.com",
+	}
+
+	if !jobMatchesCompanyTarget(Job{Company: "GitHub Inc"}, scope) {
+		t.Fatal("jobMatchesCompanyTarget() rejected alias company without website")
+	}
+	if !jobMatchesCompanyTarget(Job{Company: "Other", CompanyWebsite: "https://github.com/about"}, scope) {
+		t.Fatal("jobMatchesCompanyTarget() rejected matching provided website")
+	}
+	if jobMatchesCompanyTarget(Job{Company: "GitHub", CompanyWebsite: "https://gitlab.com"}, scope) {
+		t.Fatal("jobMatchesCompanyTarget() accepted conflicting discovered website")
+	}
+}

--- a/internal/fetcher/llm_web_search.go
+++ b/internal/fetcher/llm_web_search.go
@@ -48,6 +48,46 @@ func buildLLMWebSearchPrompt(criteria *CriteriaConfig, targets []string) (string
 	return b.String(), queries
 }
 
+func buildCompanyLLMWebSearchPrompt(criteria *CriteriaConfig, targets []string, company companyFetchScope, matchCriteria bool) (string, []string) {
+	queries := llmWebSearchQueriesForCompany(criteria, targets, company, matchCriteria, maxLLMWebSearchQueries)
+	if len(queries) == 0 {
+		return "", nil
+	}
+
+	var b strings.Builder
+	b.WriteString("Use provider-backed web search, if available, to find current public job postings.\n")
+	b.WriteString("If web search is not available in this runtime, return exactly [] with no explanation.\n")
+	b.WriteString("Do not answer with prose, caveats, markdown, or citations outside the JSON array.\n")
+	b.WriteString("When a provider web search tool is available, use it before deciding there are no matching jobs.\n")
+	fmt.Fprintf(&b, "Only include roles where the employer is %s.\n", strings.TrimSpace(company.Company))
+	if len(company.Aliases) > 0 {
+		fmt.Fprintf(&b, "Also treat these names as the same employer: %s.\n", strings.Join(company.Aliases, ", "))
+	}
+	if domain := company.websiteDomain(); domain != "" {
+		fmt.Fprintf(&b, "The company's official website domain is %s. Exclude roles whose source evidence points to a different company website.\n", domain)
+	}
+	b.WriteString("Search only these public-web queries:\n")
+	for _, query := range queries {
+		fmt.Fprintf(&b, "- %s\n", query)
+	}
+	if domains := llmWebSearchDomains(targets); len(domains) > 0 {
+		b.WriteString("\nAllowed source domains for providers that support domain filters:\n")
+		for _, domain := range domains {
+			fmt.Fprintf(&b, "- %s\n", domain)
+		}
+	}
+	if matchCriteria {
+		b.WriteString("\nOnly include roles that match the criteria below. Prefer direct employer or ATS application pages. Exclude stale, closed, unrelated, senior/lead/manager roles when those are excluded by criteria.\n")
+		b.WriteString("For each job, include the actual company website, a brief factual company summary, and the company industry when available.\n\n")
+		writeLLMWebCriteria(&b, criteria)
+	} else {
+		b.WriteString("\nReturn all current public roles for this company. Do not filter by candidate criteria.\n")
+		b.WriteString("Prefer direct employer or ATS application pages. For each job, include the actual company website, a brief factual company summary, and the company industry when available.\n")
+	}
+
+	return b.String(), queries
+}
+
 func llmWebSearchQueries(criteria *CriteriaConfig, targets []string, limit int) []string {
 	titleQueries := targetedSiteSearchQueries(criteria)
 	if len(titleQueries) == 0 {
@@ -66,6 +106,41 @@ func llmWebSearchQueries(criteria *CriteriaConfig, targets []string, limit int) 
 	for _, titleQuery := range titleQueries {
 		for _, target := range normalizedTargets {
 			query := strings.TrimSpace(target + " " + strings.TrimSpace(titleQuery))
+			if query == "" {
+				continue
+			}
+			key := strings.ToLower(query)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			queries = append(queries, query)
+			if limit > 0 && len(queries) >= limit {
+				return queries
+			}
+		}
+	}
+	return queries
+}
+
+func llmWebSearchQueriesForCompany(criteria *CriteriaConfig, targets []string, company companyFetchScope, matchCriteria bool, limit int) []string {
+	searches := companyTargetSearchQueries(company, criteria, matchCriteria)
+	if len(searches) == 0 {
+		return nil
+	}
+
+	queries := make([]string, 0)
+	seen := make(map[string]bool)
+	normalizedTargets := make([]string, 0, len(targets))
+	for _, rawTarget := range targets {
+		if target := llmWebSearchTarget(rawTarget); target != "" {
+			normalizedTargets = append(normalizedTargets, target)
+		}
+	}
+
+	for _, search := range searches {
+		for _, target := range normalizedTargets {
+			query := strings.TrimSpace(target + " " + strings.TrimSpace(search))
 			if query == "" {
 				continue
 			}

--- a/internal/fetcher/llm_web_search_test.go
+++ b/internal/fetcher/llm_web_search_test.go
@@ -52,6 +52,32 @@ func TestBuildLLMWebSearchPromptIncludesProviderWebInstruction(t *testing.T) {
 	}
 }
 
+func TestBuildCompanyLLMWebSearchPromptTargetsCompany(t *testing.T) {
+	criteria := &CriteriaConfig{}
+	criteria.Filters.TitleIncludes = []string{"Software Engineer"}
+
+	scope := companyFetchScope{Company: "GitHub", Website: "https://github.com"}
+	prompt, queries := buildCompanyLLMWebSearchPrompt(criteria, []string{"site:jobs.ashbyhq.com"}, scope, true)
+	wantQueries := []string{"site:jobs.ashbyhq.com GitHub github.com Software Engineer"}
+	if strings.Join(queries, "\x00") != strings.Join(wantQueries, "\x00") {
+		t.Fatalf("buildCompanyLLMWebSearchPrompt(match criteria) queries = %#v; want %#v", queries, wantQueries)
+	}
+	for _, want := range []string{"Only include roles where the employer is GitHub", "github.com", "GitHub github.com Software Engineer"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("buildCompanyLLMWebSearchPrompt(match criteria) prompt missing %q in:\n%s", want, prompt)
+		}
+	}
+
+	prompt, queries = buildCompanyLLMWebSearchPrompt(criteria, []string{"site:jobs.ashbyhq.com"}, scope, false)
+	wantQueries = []string{"site:jobs.ashbyhq.com GitHub github.com"}
+	if strings.Join(queries, "\x00") != strings.Join(wantQueries, "\x00") {
+		t.Fatalf("buildCompanyLLMWebSearchPrompt(all) queries = %#v; want %#v", queries, wantQueries)
+	}
+	if strings.Contains(prompt, "Target titles: Software Engineer") {
+		t.Fatalf("buildCompanyLLMWebSearchPrompt(all) prompt includes criteria title:\n%s", prompt)
+	}
+}
+
 func TestLLMWebSearchDomainsNormalizesTargets(t *testing.T) {
 	got := llmWebSearchDomains([]string{
 		"site:job-boards.greenhouse.io",

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -1085,7 +1085,7 @@ func companyTargetSearchQueries(company companyFetchScope, criteria *CriteriaCon
 	if len(titleQueries) == 0 {
 		return baseQueries
 	}
-	queries := make([]string, 0, len(baseQueries)*len(titleQueries))
+	queries := make([]string, 0)
 	seen := make(map[string]bool)
 	for _, baseQuery := range baseQueries {
 		for _, titleQuery := range titleQueries {

--- a/internal/fetcher/site_search_browser.go
+++ b/internal/fetcher/site_search_browser.go
@@ -912,6 +912,108 @@ func siteSearchURLsForCriteria(target string, criteria *CriteriaConfig) []string
 	return []string{u.String()}
 }
 
+func siteSearchURLsForCompany(target string, criteria *CriteriaConfig, company companyFetchScope, matchCriteria bool) []string {
+	targetURL := siteSearchURL(target)
+	if targetURL == "" {
+		return nil
+	}
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return []string{targetURL}
+	}
+
+	searches := companyTargetSearchQueries(company, criteria, matchCriteria)
+	if len(searches) == 0 {
+		return nil
+	}
+	searchCriteria := criteria
+	if !matchCriteria {
+		searchCriteria = nil
+	}
+	searchKey := ""
+	switch {
+	case isBuiltInHost(u.Hostname()):
+		if u.Path == "" || u.Path == "/" {
+			u.Path = "/jobs"
+		}
+		query := u.Query()
+		if query.Get("search") == "" {
+			searchKey = "search"
+		}
+		if query.Get("country") == "" {
+			if country := builtInCountryParam(searchCriteria); country != "" {
+				query.Set("country", country)
+			}
+		}
+		if searchCriteria != nil && searchCriteria.Filters.WorkSettings.Remote && isBuiltInNationalHost(u.Hostname()) && query.Get("allLocations") == "" {
+			query.Set("allLocations", "true")
+		}
+		u.RawQuery = query.Encode()
+	case isIndeedHost(u.Hostname()):
+		if u.Path == "" || u.Path == "/" {
+			u.Path = "/jobs"
+		}
+		query := u.Query()
+		if query.Get("q") == "" {
+			searchKey = "q"
+		}
+		if query.Get("l") == "" {
+			if location := siteSearchLocation(searchCriteria); location != "" {
+				query.Set("l", location)
+			}
+		}
+		u.RawQuery = query.Encode()
+	case isLinkedInHost(u.Hostname()):
+		if u.Path == "" || u.Path == "/" || u.Path == "/jobs" {
+			u.Path = "/jobs/search"
+		}
+		query := u.Query()
+		if query.Get("keywords") == "" {
+			searchKey = "keywords"
+		}
+		if query.Get("location") == "" {
+			if location := linkedInLocationQuery(searchCriteria); location != "" {
+				query.Set("location", location)
+			}
+		}
+		if query.Get("f_PP") == "" {
+			if geoID := linkedInGeoID(searchCriteria); geoID != "" {
+				query.Set("f_PP", geoID)
+			}
+		}
+		if query.Get("f_WT") == "" {
+			if workplaceTypes := linkedInWorkplaceTypes(searchCriteria); workplaceTypes != "" {
+				query.Set("f_WT", workplaceTypes)
+			}
+		}
+		if query.Get("f_E") == "" {
+			if experienceLevels := linkedInExperienceLevels(searchCriteria); experienceLevels != "" {
+				query.Set("f_E", experienceLevels)
+			}
+		}
+		if query.Get("f_SB2") == "" {
+			if salaryBucket := linkedInSalaryBucket(searchCriteria); salaryBucket != "" {
+				query.Set("f_SB2", salaryBucket)
+			}
+		}
+		u.RawQuery = query.Encode()
+	default:
+		return []string{u.String()}
+	}
+	var urls []string
+	if searchKey != "" {
+		urls = siteSearchURLsWithQueryValues(u, searchKey, searches)
+	} else {
+		urls = []string{u.String()}
+	}
+	if isIndeedHost(u.Hostname()) {
+		for _, companyURL := range indeedCompanySearchURLs(company) {
+			urls = appendUniqueString(urls, companyURL)
+		}
+	}
+	return urls
+}
+
 func siteSearchURLsWithQueryValues(base *url.URL, key string, values []string) []string {
 	if base == nil {
 		return nil
@@ -960,6 +1062,69 @@ func targetedSiteSearchQueries(criteria *CriteriaConfig) []string {
 		}
 	}
 	return queries
+}
+
+func companyTargetSearchQueries(company companyFetchScope, criteria *CriteriaConfig, matchCriteria bool) []string {
+	names := company.names()
+	if len(names) == 0 {
+		return nil
+	}
+	domain := company.websiteDomain()
+	baseQueries := make([]string, 0, len(names))
+	for _, name := range names {
+		query := strings.TrimSpace(name)
+		if domain != "" {
+			query = strings.TrimSpace(query + " " + domain)
+		}
+		baseQueries = appendUniqueString(baseQueries, query)
+	}
+	if !matchCriteria {
+		return baseQueries
+	}
+	titleQueries := targetedSiteSearchQueries(criteria)
+	if len(titleQueries) == 0 {
+		return baseQueries
+	}
+	queries := make([]string, 0, len(baseQueries)*len(titleQueries))
+	seen := make(map[string]bool)
+	for _, baseQuery := range baseQueries {
+		for _, titleQuery := range titleQueries {
+			query := strings.TrimSpace(baseQuery + " " + strings.TrimSpace(titleQuery))
+			if query == "" {
+				continue
+			}
+			key := strings.ToLower(query)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			queries = append(queries, query)
+		}
+	}
+	if len(queries) == 0 {
+		return baseQueries
+	}
+	return queries
+}
+
+func indeedCompanySearchURLs(company companyFetchScope) []string {
+	names := company.names()
+	if len(names) == 0 {
+		return nil
+	}
+	urls := make([]string, 0, len(names))
+	for _, name := range names {
+		u := url.URL{
+			Scheme: "https",
+			Host:   "www.indeed.com",
+			Path:   "/companies/search",
+		}
+		query := u.Query()
+		query.Set("q", name)
+		u.RawQuery = query.Encode()
+		urls = appendUniqueString(urls, u.String())
+	}
+	return urls
 }
 
 func combinedTitleSearchQuery(prefix string, title string) string {

--- a/internal/fetcher/site_search_browser_test.go
+++ b/internal/fetcher/site_search_browser_test.go
@@ -190,7 +190,6 @@ func TestSiteSearchURLForCriteriaBuildsAggregatorSearchURLs(t *testing.T) {
 	criteria.Filters.TitleIncludes = []string{"Software Engineer"}
 	criteria.Filters.WorkSettings.Remote = true
 	criteria.Filters.WorkSettings.Hybrid = true
-	criteria.Filters.WorkSettings.Hybrid = true
 	criteria.Candidate.YearsOfExperience = 5
 	criteria.Filters.MinBaseUSD = 120000
 

--- a/internal/fetcher/site_search_browser_test.go
+++ b/internal/fetcher/site_search_browser_test.go
@@ -190,6 +190,7 @@ func TestSiteSearchURLForCriteriaBuildsAggregatorSearchURLs(t *testing.T) {
 	criteria.Filters.TitleIncludes = []string{"Software Engineer"}
 	criteria.Filters.WorkSettings.Remote = true
 	criteria.Filters.WorkSettings.Hybrid = true
+	criteria.Filters.WorkSettings.Hybrid = true
 	criteria.Candidate.YearsOfExperience = 5
 	criteria.Filters.MinBaseUSD = 120000
 
@@ -216,6 +217,36 @@ func TestSiteSearchURLForCriteriaBuildsAggregatorSearchURLs(t *testing.T) {
 				t.Fatalf("siteSearchURLForCriteria(%q) = %q; want %q", tt.target, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSiteSearchURLsForCompanyBuildsCompanyQueries(t *testing.T) {
+	criteria := &CriteriaConfig{}
+	criteria.Candidate.City = "Seattle"
+	criteria.Candidate.State = "WA"
+	criteria.Candidate.CountryCode = "US"
+	criteria.Filters.TitleRequires = []string{"Senior"}
+	criteria.Filters.TitleIncludes = []string{"Software Engineer"}
+	criteria.Filters.WorkSettings.Remote = true
+	criteria.Filters.WorkSettings.Hybrid = true
+
+	scope := companyFetchScope{Company: "GitHub", Website: "https://github.com"}
+	got := siteSearchURLsForCompany("https://www.indeed.com/jobs", criteria, scope, true)
+	want := []string{
+		"https://www.indeed.com/jobs?l=Seattle%2C+WA&q=GitHub+github.com+Senior+Software+Engineer",
+		"https://www.indeed.com/companies/search?q=GitHub",
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("siteSearchURLsForCompany(match criteria) = %#v; want %#v", got, want)
+	}
+
+	got = siteSearchURLsForCompany("https://www.indeed.com/jobs", criteria, scope, false)
+	want = []string{
+		"https://www.indeed.com/jobs?q=GitHub+github.com",
+		"https://www.indeed.com/companies/search?q=GitHub",
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("siteSearchURLsForCompany(all) = %#v; want %#v", got, want)
 	}
 }
 

--- a/internal/tuiapp/command_mode.go
+++ b/internal/tuiapp/command_mode.go
@@ -2,10 +2,7 @@ package tuiapp
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
-
-	"github.com/wallentx/jobscout/internal/config"
 )
 
 type operatorCommandResult struct {
@@ -16,11 +13,10 @@ type operatorCommandResult struct {
 }
 
 type operatorFetchOptions struct {
-	SourceSelectionSet      bool
-	SourceSelection         []string
-	CandidateLimitPerSource *int
-	AcceptedLimit           *int
-	DisableLLM              bool
+	Company string
+	Aliases []string
+	Website string
+	All     bool
 }
 
 type operatorCommandSpec struct {
@@ -38,21 +34,6 @@ type operatorCommandCompletionSpec struct {
 type operatorCommandCompletion struct {
 	Label string
 	Value string
-}
-
-type fetchCommandHintDefaults struct {
-	CandidateLimitPerSource string
-	AcceptedLimit           string
-}
-
-var defaultFetchCommandHintValues = newFetchCommandHintDefaults()
-
-func newFetchCommandHintDefaults() fetchCommandHintDefaults {
-	fetch := config.DefaultAppConfig().Fetch
-	return fetchCommandHintDefaults{
-		CandidateLimitPerSource: strconv.Itoa(fetch.CandidateLimitPerSource),
-		AcceptedLimit:           strconv.Itoa(fetch.AcceptedLimit),
-	}
 }
 
 var operatorCommandSpecs = []operatorCommandSpec{
@@ -73,16 +54,6 @@ var operatorCommandSpecs = []operatorCommandSpec{
 	{
 		Name:    "fetch",
 		Execute: executeFetchCommand,
-	},
-	{
-		Name:    "help",
-		Aliases: []string{"?"},
-		Execute: operatorCommandHelp,
-		Completions: []operatorCommandCompletionSpec{
-			{Label: "debug", Insert: "debug"},
-			{Label: "fetch", Insert: "fetch"},
-			{Label: "health", Insert: "health"},
-		},
 	},
 }
 
@@ -192,29 +163,24 @@ func fetchCommandCompletions(input string) []operatorCommandCompletion {
 		return nil
 	}
 	rest = strings.TrimLeft(rest, " \t")
-
-	if base, prefix, ok := fetchCommandSourceValueCompletionContext(rest); ok {
-		return fetchCommandSourceCompletions(base, prefix)
-	}
-	if fetchCommandAwaitingNonSourceValue(rest) {
+	if strings.TrimSpace(rest) == "" || fetchCommandAwaitingFlagValue(rest) || commandCurrentTokenRequiresValue(rest, fetchFlagRequiresValue) {
 		return nil
 	}
 
 	base, prefix, ok := commandFlagCompletionContext(rest)
-	if !ok {
+	if !ok || !fetchRestHasCompany(rest) {
 		return nil
 	}
 
 	flags := []operatorCommandCompletionSpec{
-		{Label: "--sources", Insert: "--sources"},
-		{Label: "--candidate-limit", Insert: "--candidate-limit"},
-		{Label: "--accepted-limit", Insert: "--accepted-limit"},
-		{Label: "--no-llm", Insert: "--no-llm"},
+		{Label: "--aka", Insert: "--aka"},
+		{Label: "--website", Insert: "--website"},
+		{Label: "--all", Insert: "--all"},
 	}
 	usedFlags := fetchCommandUsedFlags(rest)
 	completions := make([]operatorCommandCompletion, 0, len(flags))
 	for _, flag := range flags {
-		if flag.Label != "--sources" && usedFlags[flag.Label] {
+		if flag.Label != "--aka" && usedFlags[flag.Label] {
 			continue
 		}
 		if matchOperatorCommandCompletion(prefix, flag.Label, flag.Insert) {
@@ -225,38 +191,6 @@ func fetchCommandCompletions(input string) []operatorCommandCompletion {
 		}
 	}
 	return completions
-}
-
-func fetchCommandSourceCompletions(base string, prefix string) []operatorCommandCompletion {
-	sources := []string{"rss", "site", "llm", "llm_web", "all"}
-	completions := make([]operatorCommandCompletion, 0, len(sources))
-	for _, source := range sources {
-		if !matchOperatorCommandCompletion(prefix, source, source) {
-			continue
-		}
-		completions = append(completions, operatorCommandCompletion{
-			Label: source,
-			Value: "fetch " + base + source,
-		})
-	}
-	return completions
-}
-
-func fetchCommandSourceValueCompletionContext(rest string) (base string, prefix string, ok bool) {
-	base, valuePrefix, flag, ok := commandValueCompletionContext(rest)
-	if !ok || flag != "--sources" {
-		return "", "", false
-	}
-	comma := strings.LastIndex(valuePrefix, ",")
-	if comma == -1 {
-		return base, valuePrefix, true
-	}
-	return base + valuePrefix[:comma+1], valuePrefix[comma+1:], true
-}
-
-func fetchCommandAwaitingNonSourceValue(rest string) bool {
-	_, _, flag, ok := commandValueCompletionContext(rest)
-	return ok && flag != "--sources"
 }
 
 func commandFlagCompletionContext(rest string) (base string, prefix string, ok bool) {
@@ -293,51 +227,15 @@ func commandCurrentTokenRequiresValue(rest string, requiresValue func(string) bo
 	return requiresValue(last)
 }
 
-func commandValueCompletionContext(rest string) (base string, prefix string, flag string, ok bool) {
-	trimmedRight := strings.TrimRight(rest, " \t")
-	args, err := parseOperatorCommandLine(rest)
-	if err != nil || len(args) == 0 {
-		return "", "", "", false
-	}
-
-	if strings.HasSuffix(rest, " ") || strings.HasSuffix(rest, "\t") {
-		lastFlag, _, _ := strings.Cut(args[len(args)-1], "=")
-		if !fetchFlagRequiresValue(lastFlag) {
-			return "", "", "", false
-		}
-		return rest, "", lastFlag, true
-	}
-
-	last := args[len(args)-1]
-	flag, value, hasValue := strings.Cut(last, "=")
-	if hasValue && fetchFlagRequiresValue(flag) {
-		start := strings.LastIndex(trimmedRight, last)
-		if start == -1 {
-			return "", "", "", false
-		}
-		return trimmedRight[:start] + flag + "=", value, flag, true
-	}
-	if fetchFlagRequiresValue(last) {
-		return trimmedRight + " ", "", last, true
-	}
-	if strings.HasPrefix(last, "-") {
-		return "", "", "", false
-	}
-	if len(args) < 2 {
-		return "", "", "", false
-	}
-	previousFlag, _, _ := strings.Cut(args[len(args)-2], "=")
-	if !fetchFlagRequiresValue(previousFlag) {
-		return "", "", "", false
-	}
-	start := strings.LastIndex(trimmedRight, last)
-	if start == -1 {
-		return "", "", "", false
-	}
-	return trimmedRight[:start], last, previousFlag, true
+func healthCommandAwaitingFlagValue(rest string) bool {
+	return commandAwaitingFlagValue(rest, healthFlagRequiresValue)
 }
 
-func healthCommandAwaitingFlagValue(rest string) bool {
+func fetchCommandAwaitingFlagValue(rest string) bool {
+	return commandAwaitingFlagValue(rest, fetchFlagRequiresValue)
+}
+
+func commandAwaitingFlagValue(rest string, requiresValue func(string) bool) bool {
 	if !strings.HasSuffix(rest, " ") && !strings.HasSuffix(rest, "\t") {
 		return false
 	}
@@ -349,10 +247,26 @@ func healthCommandAwaitingFlagValue(rest string) bool {
 	if hasValue && strings.TrimSpace(value) != "" {
 		return false
 	}
-	return healthFlagRequiresValue(flag)
+	return requiresValue(flag)
 }
 
 func healthRestHasCompany(rest string) bool {
+	args, err := parseOperatorCommandLine(rest)
+	if err != nil {
+		return false
+	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--") {
+			return false
+		}
+		if strings.TrimSpace(arg) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchRestHasCompany(rest string) bool {
 	args, err := parseOperatorCommandLine(rest)
 	if err != nil {
 		return false
@@ -381,7 +295,7 @@ func healthFlagRequiresValue(flag string) bool {
 func fetchFlagRequiresValue(flag string) bool {
 	flag, _, _ = strings.Cut(strings.TrimSpace(flag), "=")
 	switch flag {
-	case "--sources", "--candidate-limit", "--accepted-limit":
+	case "--aka", "--website":
 		return true
 	default:
 		return false
@@ -416,7 +330,7 @@ func fetchCommandUsedFlags(rest string) map[string]bool {
 		}
 		flag, _, _ := strings.Cut(arg, "=")
 		switch flag {
-		case "--sources", "--candidate-limit", "--accepted-limit", "--no-llm":
+		case "--aka", "--website", "--all":
 			used[flag] = true
 		}
 	}
@@ -523,6 +437,12 @@ func (m *model) resetOperatorCommandPrompt() {
 	m.resetOperatorCommandCompletion()
 }
 
+func (m *model) clearOperatorCommandResult() {
+	m.commandResultTitle = ""
+	m.commandResultMessage = ""
+	m.commandResultError = false
+}
+
 func (m *model) prepareOperatorCommandTyping() {
 	if m.commandCompletionActive {
 		m.commandTypedInput = m.commandInput.Value()
@@ -563,7 +483,13 @@ func operatorCommandGhostHint(input string) string {
 	}
 	rest = strings.TrimLeft(rest, " \t")
 	if strings.EqualFold(command, "fetch") {
-		return fetchCommandValueHint(rest)
+		if strings.TrimSpace(rest) == "" {
+			return "<company>"
+		}
+		if hint := fetchCommandValueHint(rest); hint != "" {
+			return hint
+		}
+		return ""
 	}
 	if !strings.EqualFold(command, "health") {
 		return ""
@@ -577,25 +503,21 @@ func operatorCommandGhostHint(input string) string {
 	return ""
 }
 
-func fetchCommandValueHint(rest string) string {
-	_, prefix, flag, ok := commandValueCompletionContext(rest)
-	if !ok {
-		return ""
-	}
-	if strings.TrimSpace(prefix) != "" {
-		return ""
-	}
-	switch flag {
-	case "--candidate-limit":
-		return commandValueHintText(rest, defaultFetchCommandHintValues.CandidateLimitPerSource)
-	case "--accepted-limit":
-		return commandValueHintText(rest, defaultFetchCommandHintValues.AcceptedLimit)
-	default:
-		return ""
-	}
+func healthCommandValueHint(rest string) string {
+	return commandFlagValueHint(rest, healthFlagRequiresValue, map[string]string{
+		"--aka":     "<name>",
+		"--website": "<url>",
+	})
 }
 
-func healthCommandValueHint(rest string) string {
+func fetchCommandValueHint(rest string) string {
+	return commandFlagValueHint(rest, fetchFlagRequiresValue, map[string]string{
+		"--aka":     "<name>",
+		"--website": "<url>",
+	})
+}
+
+func commandFlagValueHint(rest string, requiresValue func(string) bool, hints map[string]string) string {
 	args, err := parseOperatorCommandLine(rest)
 	if err != nil || len(args) == 0 {
 		return ""
@@ -605,17 +527,14 @@ func healthCommandValueHint(rest string) string {
 	if hasValue && strings.TrimSpace(value) != "" {
 		return ""
 	}
-	if !healthFlagRequiresValue(flag) {
+	if !requiresValue(flag) {
 		return ""
 	}
-	switch flag {
-	case "--aka":
-		return commandValueHintText(rest, "<name>")
-	case "--website":
-		return commandValueHintText(rest, "<url>")
-	default:
+	hint := hints[flag]
+	if hint == "" {
 		return ""
 	}
+	return commandValueHintText(rest, hint)
 }
 
 func commandValueHintText(rest string, hint string) string {
@@ -684,51 +603,6 @@ func isOperatorCommandSpace(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 }
 
-func operatorCommandHelp(args []string) (operatorCommandResult, error) {
-	if len(args) > 0 && strings.EqualFold(args[0], "debug") {
-		return operatorCommandResult{
-			Title: "Command Help",
-			Message: strings.Join([]string{
-				"debug status",
-				"debug on",
-				"debug off",
-				"debug path \"./debug.log\"",
-			}, "\n"),
-		}, nil
-	}
-	if len(args) > 0 && strings.EqualFold(args[0], "health") {
-		return operatorCommandResult{
-			Title: "Command Help",
-			Message: strings.Join([]string{
-				"health <company> [--aka <name>] [--website <url>]",
-				"Fetch company health info for any company name.",
-				"Use repeated --aka values for alternate company names.",
-			}, "\n"),
-		}, nil
-	}
-	if len(args) > 0 && strings.EqualFold(args[0], "fetch") {
-		return operatorCommandResult{
-			Title: "Command Help",
-			Message: strings.Join([]string{
-				"fetch [--sources <list>] [--candidate-limit <n>] [--accepted-limit <n>] [--no-llm]",
-				"Run a one-shot job fetch with optional source and limit overrides.",
-				"Sources: rss, site, llm, llm_web, all.",
-			}, "\n"),
-		}, nil
-	}
-	return operatorCommandResult{
-		Title: "Commands",
-		Message: strings.Join([]string{
-			"debug status  Show debug state",
-			"debug on      Enable debug output",
-			"debug off     Disable debug output",
-			"debug path    Set debug log path",
-			"fetch         Fetch jobs with optional overrides",
-			"health        Fetch company health info",
-		}, "\n"),
-	}, nil
-}
-
 func executeFetchCommand(args []string) (operatorCommandResult, error) {
 	options, err := parseFetchCommandOptions(args)
 	if err != nil {
@@ -739,132 +613,77 @@ func executeFetchCommand(args []string) (operatorCommandResult, error) {
 
 func parseFetchCommandOptions(args []string) (operatorFetchOptions, error) {
 	var options operatorFetchOptions
+	var companyParts []string
+	seenOption := false
+	websiteSet := false
 	for i := 0; i < len(args); i++ {
 		arg := strings.TrimSpace(args[i])
 		if arg == "" {
 			continue
 		}
+		if !strings.HasPrefix(arg, "--") {
+			if seenOption {
+				return operatorFetchOptions{}, fmt.Errorf("unexpected fetch argument %q after options", arg)
+			}
+			companyParts = append(companyParts, arg)
+			continue
+		}
+
+		seenOption = true
 		flag, value, hasValue := strings.Cut(arg, "=")
 		switch flag {
-		case "--sources":
+		case "--aka":
 			if !hasValue {
 				i++
 				if i >= len(args) {
-					return operatorFetchOptions{}, fmt.Errorf("usage: fetch [--sources <list>] [--candidate-limit <n>] [--accepted-limit <n>] [--no-llm]")
+					return operatorFetchOptions{}, fmt.Errorf("usage: fetch <company> [--aka <name>] [--website <url>] [--all]")
 				}
 				value = args[i]
 			}
-			sources, allSources, err := parseFetchCommandSources(value)
-			if err != nil {
-				return operatorFetchOptions{}, err
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return operatorFetchOptions{}, fmt.Errorf("--aka cannot be empty")
 			}
-			options.SourceSelectionSet = true
-			if allSources {
-				options.SourceSelection = nil
-			} else {
-				options.SourceSelection = appendFetchCommandSources(options.SourceSelection, sources...)
+			options.Aliases = appendUniqueFetchAlias(options.Aliases, value)
+		case "--website":
+			if websiteSet {
+				return operatorFetchOptions{}, fmt.Errorf("--website can only be provided once")
 			}
-		case "--candidate-limit":
-			limit, err := parseFetchCommandNonNegativeInt(flag, value, hasValue, args, &i)
-			if err != nil {
-				return operatorFetchOptions{}, err
+			if !hasValue {
+				i++
+				if i >= len(args) {
+					return operatorFetchOptions{}, fmt.Errorf("usage: fetch <company> [--aka <name>] [--website <url>] [--all]")
+				}
+				value = args[i]
 			}
-			options.CandidateLimitPerSource = &limit
-		case "--accepted-limit":
-			limit, err := parseFetchCommandNonNegativeInt(flag, value, hasValue, args, &i)
-			if err != nil {
-				return operatorFetchOptions{}, err
+			options.Website = strings.TrimSpace(value)
+			if options.Website == "" {
+				return operatorFetchOptions{}, fmt.Errorf("--website cannot be empty")
 			}
-			options.AcceptedLimit = &limit
-		case "--no-llm":
+			websiteSet = true
+		case "--all":
 			if hasValue {
-				return operatorFetchOptions{}, fmt.Errorf("--no-llm does not accept a value")
+				return operatorFetchOptions{}, fmt.Errorf("--all does not accept a value")
 			}
-			options.DisableLLM = true
+			options.All = true
 		default:
-			if strings.HasPrefix(arg, "-") {
-				return operatorFetchOptions{}, fmt.Errorf("unknown fetch option %q", flag)
-			}
-			return operatorFetchOptions{}, fmt.Errorf("unexpected fetch argument %q", arg)
+			return operatorFetchOptions{}, fmt.Errorf("unknown fetch option %q", flag)
 		}
 	}
-	if options.DisableLLM && fetchCommandSourcesRequireLLM(options.SourceSelection) {
-		return operatorFetchOptions{}, fmt.Errorf("--no-llm cannot be combined with llm or llm_web sources")
+	options.Company = strings.TrimSpace(strings.Join(companyParts, " "))
+	if options.Company == "" {
+		return operatorFetchOptions{}, fmt.Errorf("usage: fetch <company> [--aka <name>] [--website <url>] [--all]")
 	}
 	return options, nil
 }
 
-func parseFetchCommandNonNegativeInt(flag string, value string, hasValue bool, args []string, idx *int) (int, error) {
-	if !hasValue {
-		*idx = *idx + 1
-		if *idx >= len(args) {
-			return 0, fmt.Errorf("%s requires a non-negative integer", flag)
-		}
-		value = args[*idx]
-	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0, fmt.Errorf("%s requires a non-negative integer", flag)
-	}
-	parsed, err := strconv.Atoi(value)
-	if err != nil || parsed < 0 {
-		return 0, fmt.Errorf("%s requires a non-negative integer", flag)
-	}
-	return parsed, nil
-}
-
-func parseFetchCommandSources(value string) ([]string, bool, error) {
-	raw := strings.TrimSpace(value)
-	if raw == "" {
-		return nil, false, fmt.Errorf("--sources requires a comma-separated source list")
-	}
-	var sources []string
-	for _, part := range strings.Split(raw, ",") {
-		source := strings.TrimSpace(strings.ToLower(strings.ReplaceAll(part, "-", "_")))
-		if source == "" {
-			continue
-		}
-		switch source {
-		case "rss", "site", "llm", "llm_web":
-			sources = appendFetchCommandSources(sources, source)
-		case "all":
-			return nil, true, nil
-		default:
-			return nil, false, fmt.Errorf("--sources includes unsupported source %q; valid sources are rss, site, llm, llm_web, all", strings.TrimSpace(part))
+func appendUniqueFetchAlias(aliases []string, alias string) []string {
+	for _, existing := range aliases {
+		if strings.EqualFold(existing, alias) {
+			return aliases
 		}
 	}
-	if len(sources) == 0 {
-		return nil, false, fmt.Errorf("--sources requires at least one source")
-	}
-	return sources, false, nil
-}
-
-func appendFetchCommandSources(sources []string, additions ...string) []string {
-	for _, source := range additions {
-		if source == "all" {
-			return nil
-		}
-		seen := false
-		for _, existing := range sources {
-			if existing == source {
-				seen = true
-				break
-			}
-		}
-		if !seen {
-			sources = append(sources, source)
-		}
-	}
-	return sources
-}
-
-func fetchCommandSourcesRequireLLM(sources []string) bool {
-	for _, source := range sources {
-		if source == "llm" || source == "llm_web" {
-			return true
-		}
-	}
-	return false
+	return append(aliases, alias)
 }
 
 func executeHealthCommand(args []string) (operatorCommandResult, error) {

--- a/internal/tuiapp/command_mode.go
+++ b/internal/tuiapp/command_mode.go
@@ -251,22 +251,14 @@ func commandAwaitingFlagValue(rest string, requiresValue func(string) bool) bool
 }
 
 func healthRestHasCompany(rest string) bool {
-	args, err := parseOperatorCommandLine(rest)
-	if err != nil {
-		return false
-	}
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "--") {
-			return false
-		}
-		if strings.TrimSpace(arg) != "" {
-			return true
-		}
-	}
-	return false
+	return restHasPositionalArg(rest)
 }
 
 func fetchRestHasCompany(rest string) bool {
+	return restHasPositionalArg(rest)
+}
+
+func restHasPositionalArg(rest string) bool {
 	args, err := parseOperatorCommandLine(rest)
 	if err != nil {
 		return false

--- a/internal/tuiapp/command_mode_test.go
+++ b/internal/tuiapp/command_mode_test.go
@@ -127,28 +127,33 @@ func TestExecuteOperatorHealthCommandRequiresCompany(t *testing.T) {
 	}
 }
 
-func TestExecuteOperatorFetchCommandParsesOverrides(t *testing.T) {
-	result, err := executeOperatorCommand(`fetch --sources rss,site --sources llm --candidate-limit 7 --accepted-limit=3 --no-llm`)
-	if err == nil {
-		t.Fatal("executeOperatorCommand(fetch) error = nil; want --no-llm source conflict")
-	}
-
-	result, err = executeOperatorCommand(`fetch --sources rss,site --candidate-limit 7 --accepted-limit=3`)
+func TestExecuteOperatorFetchCommandTargetsCompany(t *testing.T) {
+	result, err := executeOperatorCommand(`fetch "Acme Cloud" --website https://acme.example --aka Acme --aka "Acme Inc" --all`)
 	if err != nil {
 		t.Fatalf("executeOperatorCommand(fetch) error = %v", err)
 	}
 	if result.FetchOptions == nil {
-		t.Fatal("FetchOptions = nil; want parsed fetch options")
+		t.Fatal("FetchOptions = nil; want company fetch options")
 	}
 	options := result.FetchOptions
-	if !options.SourceSelectionSet || strings.Join(options.SourceSelection, ",") != "rss,site" {
-		t.Fatalf("SourceSelection = set:%t %#v; want rss,site", options.SourceSelectionSet, options.SourceSelection)
+	if options.Company != "Acme Cloud" {
+		t.Fatalf("Company = %q; want Acme Cloud", options.Company)
 	}
-	if options.CandidateLimitPerSource == nil || *options.CandidateLimitPerSource != 7 {
-		t.Fatalf("CandidateLimitPerSource = %#v; want 7", options.CandidateLimitPerSource)
+	if options.Website != "https://acme.example" {
+		t.Fatalf("Website = %q; want https://acme.example", options.Website)
 	}
-	if options.AcceptedLimit == nil || *options.AcceptedLimit != 3 {
-		t.Fatalf("AcceptedLimit = %#v; want 3", options.AcceptedLimit)
+	if strings.Join(options.Aliases, "\x00") != "Acme\x00Acme Inc" {
+		t.Fatalf("Aliases = %#v; want Acme and Acme Inc", options.Aliases)
+	}
+	if !options.All {
+		t.Fatal("All = false; want true")
+	}
+
+	if _, err := executeOperatorCommand(`fetch`); err == nil || !strings.Contains(err.Error(), "usage: fetch <company> [--aka <name>] [--website <url>] [--all]") {
+		t.Fatalf("executeOperatorCommand(fetch) error = %v; want usage guidance", err)
+	}
+	if _, err := executeOperatorCommand(`fetch GitHub --sources site`); err == nil || !strings.Contains(err.Error(), "unknown fetch option") {
+		t.Fatalf("executeOperatorCommand(fetch --sources) error = %v; want old option rejected", err)
 	}
 }
 
@@ -250,8 +255,19 @@ func TestCommandModeShowsCommandPoolByDefault(t *testing.T) {
 	m.commandInput.Focus()
 
 	rendered := ansi.Strip(m.View())
-	if !strings.Contains(rendered, "debug") || !strings.Contains(rendered, "health") || !strings.Contains(rendered, "help") {
+	if !strings.Contains(rendered, "debug") || !strings.Contains(rendered, "health") || !strings.Contains(rendered, "fetch") {
 		t.Fatalf("command mode view missing default command pool:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "help") || strings.Contains(rendered, "?") {
+		t.Fatalf("command mode view includes removed help command:\n%s", rendered)
+	}
+}
+
+func TestCommandModeHelpCommandIsNotCallable(t *testing.T) {
+	for _, input := range []string{"help", "?"} {
+		if _, err := executeOperatorCommand(input); err == nil {
+			t.Fatalf("executeOperatorCommand(%q) error = nil; want unknown command", input)
+		}
 	}
 }
 
@@ -451,7 +467,7 @@ func TestCommandModeHealthPoolShowsSelectableFlagsAfterCompany(t *testing.T) {
 	}
 }
 
-func TestCommandModeFetchPoolShowsSelectableFlagsAfterDash(t *testing.T) {
+func TestCommandModeFetchCompanyHintAndOptionCompletion(t *testing.T) {
 	m := model{
 		termWidth:     100,
 		termHeight:    30,
@@ -461,64 +477,46 @@ func TestCommandModeFetchPoolShowsSelectableFlagsAfterDash(t *testing.T) {
 		isCommanding:  true,
 	}
 	m.commandInput.Focus()
-	m.commandInput.SetValue("fetch -")
-	m.commandTypedInput = "fetch -"
 
-	labels := commandCompletionLabels(m.operatorCommandPool())
-	want := []string{"--sources", "--candidate-limit", "--accepted-limit", "--no-llm"}
-	if strings.Join(labels, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("operatorCommandPool labels = %#v; want %#v", labels, want)
+	m.commandInput.SetValue("fetch ")
+	m.commandTypedInput = "fetch "
+	if labels := commandCompletionLabels(m.operatorCommandPool()); len(labels) != 0 {
+		t.Fatalf("operatorCommandPool labels = %#v; want no company placeholder completion", labels)
 	}
-	if hint := m.operatorCommandGhostHint(); hint != "" {
-		t.Fatalf("operatorCommandGhostHint() = %q; want no hint while completions are available", hint)
+	if hint := m.operatorCommandGhostHint(); hint != "<company>" {
+		t.Fatalf("operatorCommandGhostHint() = %q; want company hint", hint)
 	}
-}
 
-func TestCommandModeFetchSourceValueCompletion(t *testing.T) {
-	m := model{
-		termWidth:     100,
-		termHeight:    30,
-		tableHeight:   calculateTableHeight(30),
-		activeFilters: filterValuesFromStatuses(nil),
-		commandInput:  newOperatorCommandInput(),
-		isCommanding:  true,
+	m.commandInput.SetValue("fetch GitHub ")
+	m.commandTypedInput = "fetch GitHub "
+	if labels := commandCompletionLabels(m.operatorCommandPool()); strings.Join(labels, "\x00") != "--aka\x00--website\x00--all" {
+		t.Fatalf("operatorCommandPool labels = %#v; want fetch identity flags", labels)
 	}
-	m.commandInput.Focus()
-	m.commandInput.SetValue("fetch --sources si")
-	m.commandTypedInput = "fetch --sources si"
 
-	labels := commandCompletionLabels(m.operatorCommandPool())
-	if strings.Join(labels, "\x00") != "site" {
-		t.Fatalf("operatorCommandPool labels = %#v; want site", labels)
+	m.commandInput.SetValue("fetch GitHub --website ")
+	m.commandTypedInput = "fetch GitHub --website "
+	if hint := m.operatorCommandGhostHint(); hint != "<url>" {
+		t.Fatalf("operatorCommandGhostHint() = %q; want website URL hint", hint)
 	}
-}
 
-func TestCommandModeFetchLimitHintsOnlyForMissingValues(t *testing.T) {
-	if hint := operatorCommandGhostHint("fetch --candidate-limit"); hint != " 15" {
-		t.Fatalf("operatorCommandGhostHint(candidate flag) = %q; want default limit hint", hint)
-	}
-	if hint := operatorCommandGhostHint("fetch --candidate-limit "); hint != "15" {
-		t.Fatalf("operatorCommandGhostHint(candidate flag space) = %q; want default limit hint", hint)
-	}
-	if hint := operatorCommandGhostHint("fetch --candidate-limit 1"); hint != "" {
-		t.Fatalf("operatorCommandGhostHint(candidate value typed) = %q; want no hint", hint)
-	}
-	if hint := operatorCommandGhostHint("fetch --sources "); hint != "" {
-		t.Fatalf("operatorCommandGhostHint(sources) = %q; want source completions instead of hint", hint)
+	m.commandInput.SetValue("fetch GitHub --website https://github.com ")
+	m.commandTypedInput = "fetch GitHub --website https://github.com "
+	if labels := commandCompletionLabels(m.operatorCommandPool()); strings.Join(labels, "\x00") != "--aka\x00--all" {
+		t.Fatalf("operatorCommandPool labels = %#v; want --aka and --all after website", labels)
 	}
 }
 
 func TestCommandInputInlineViewSuppressesGhostWhenCursorInsideValue(t *testing.T) {
 	m := model{commandInput: newOperatorCommandInput()}
 	m.commandInput.Focus()
-	m.commandInput.SetValue("fetch --candidate-limit 15")
-	m.commandInput.SetCursor(len([]rune("fetch --candidate-limit ")))
+	m.commandInput.SetValue("health GitHub --website https://github.com")
+	m.commandInput.SetCursor(len([]rune("health GitHub --website ")))
 
-	rendered := ansi.Strip(m.commandInputInlineView("15", lipgloss.NewStyle()))
-	if strings.Contains(rendered, "fetch --candidate-limit 1515") {
+	rendered := ansi.Strip(m.commandInputInlineView("https://github.com", lipgloss.NewStyle()))
+	if strings.Contains(rendered, "health GitHub --website https://github.comhttps://github.com") {
 		t.Fatalf("commandInputInlineView duplicated ghost inside value: %q", rendered)
 	}
-	if !strings.Contains(rendered, "fetch --candidate-limit 15") {
+	if !strings.Contains(rendered, "health GitHub --website https://github.com") {
 		t.Fatalf("commandInputInlineView() = %q; want original input text", rendered)
 	}
 }
@@ -704,6 +702,101 @@ func TestCommandModeResultLineDoesNotChangeViewHeight(t *testing.T) {
 	}
 }
 
+func TestCommandModeFooterPlacesControlsOnBottomLine(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("debug ")
+	m.commandTypedInput = "debug "
+
+	lines := strings.Split(strings.TrimRight(ansi.Strip(m.View()), "\n"), "\n")
+	if got := strings.TrimSpace(lines[len(lines)-1]); !strings.Contains(got, "Tab Select/Cycle") {
+		t.Fatalf("bottom command line = %q; want controls", got)
+	}
+	if len(lines) < 2 || !strings.Contains(lines[len(lines)-2], "status") {
+		t.Fatalf("line above controls = %q; want command completion pool", lines[len(lines)-2])
+	}
+}
+
+func TestCommandModeFooterReservesCompletionLine(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("debug statusx")
+	m.commandTypedInput = "debug statusx"
+
+	lines := strings.Split(strings.TrimRight(ansi.Strip(m.View()), "\n"), "\n")
+	if got := strings.TrimSpace(lines[len(lines)-1]); !strings.Contains(got, "Tab Select/Cycle") {
+		t.Fatalf("bottom command line = %q; want controls", got)
+	}
+	if got := strings.TrimSpace(lines[len(lines)-2]); got != "" {
+		t.Fatalf("reserved completion line = %q; want blank", got)
+	}
+	if got := strings.TrimSpace(lines[len(lines)-3]); !strings.Contains(got, ": debug statusx") {
+		t.Fatalf("line above reserved completion line = %q; want command input", got)
+	}
+}
+
+func TestCommandModeViewStaysWithinTerminalHeight(t *testing.T) {
+	m := model{
+		termWidth:     100,
+		termHeight:    30,
+		tableHeight:   calculateTableHeight(30),
+		activeFilters: filterValuesFromStatuses(nil),
+		commandInput:  newOperatorCommandInput(),
+		isCommanding:  true,
+	}
+	m.commandInput.Focus()
+
+	lines := strings.Split(strings.TrimRight(ansi.Strip(m.View()), "\n"), "\n")
+	if len(lines) > m.termHeight {
+		t.Fatalf("command mode rendered %d lines; want at most terminal height %d", len(lines), m.termHeight)
+	}
+}
+
+func TestCommandModeResultClearsOnNextInput(t *testing.T) {
+	m := model{
+		termWidth:               100,
+		termHeight:              30,
+		tableHeight:             calculateTableHeight(30),
+		activeFilters:           filterValuesFromStatuses(nil),
+		commandInput:            newOperatorCommandInput(),
+		isCommanding:            true,
+		commandResultTitle:      "Debug",
+		commandResultMessage:    "Debug is off.",
+		commandResultError:      false,
+		commandTypedInput:       "d",
+		commandCompletionActive: false,
+	}
+	m.commandInput.Focus()
+	m.commandInput.SetValue("d")
+
+	updated, cmd := m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyTab})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatalf("handleKeyMsg(tab) cmd = %v; want nil", cmd)
+	}
+	if got.commandResultMessage != "" || got.commandResultTitle != "" || got.commandResultError {
+		t.Fatalf("command result = %q/%q/%t; want cleared", got.commandResultTitle, got.commandResultMessage, got.commandResultError)
+	}
+	if got.commandInput.Value() != "debug" {
+		t.Fatalf("commandInput.Value() = %q; want tab completion to still run", got.commandInput.Value())
+	}
+}
+
 func TestCommandModeControlsDoNotShareInputLine(t *testing.T) {
 	m := model{
 		termWidth:     100,
@@ -718,7 +811,7 @@ func TestCommandModeControlsDoNotShareInputLine(t *testing.T) {
 
 	rendered := ansi.Strip(m.View())
 	for _, line := range strings.Split(rendered, "\n") {
-		if strings.Contains(line, "Tab Complete") && strings.Contains(line, "debug status") {
+		if strings.Contains(line, "Tab Select/Cycle") && strings.Contains(line, "debug status") {
 			t.Fatalf("command controls share input line:\n%s", line)
 		}
 	}

--- a/internal/tuiapp/fetch_flow.go
+++ b/internal/tuiapp/fetch_flow.go
@@ -26,6 +26,10 @@ type fetchRunOptions struct {
 	SourceSelection         []string
 	CandidateLimitPerSource *int
 	AcceptedLimit           *int
+	Company                 string
+	Aliases                 []string
+	Website                 string
+	MatchCriteria           bool
 }
 
 func defaultFetchRunOptions(disableLLM bool) fetchRunOptions {
@@ -35,22 +39,21 @@ func defaultFetchRunOptions(disableLLM bool) fetchRunOptions {
 		SourceSelection:         append([]string(nil), runtimeSourceSelection...),
 		CandidateLimitPerSource: cloneRuntimeIntPtr(runtimeCandidateLimitPerSource),
 		AcceptedLimit:           cloneRuntimeIntPtr(runtimeAcceptedLimit),
+		MatchCriteria:           true,
 	}
 }
 
 func commandFetchRunOptions(sessionDisableLLM bool, commandOptions operatorFetchOptions) fetchRunOptions {
-	runOptions := defaultFetchRunOptions(sessionDisableLLM || commandOptions.DisableLLM)
-	if commandOptions.SourceSelectionSet {
-		runOptions.SourceSelectionSet = true
-		runOptions.SourceSelection = append([]string(nil), commandOptions.SourceSelection...)
-	}
-	if commandOptions.CandidateLimitPerSource != nil {
-		runOptions.CandidateLimitPerSource = cloneRuntimeIntPtr(commandOptions.CandidateLimitPerSource)
-	}
-	if commandOptions.AcceptedLimit != nil {
-		runOptions.AcceptedLimit = cloneRuntimeIntPtr(commandOptions.AcceptedLimit)
-	}
+	runOptions := defaultFetchRunOptions(sessionDisableLLM)
+	runOptions.Company = strings.TrimSpace(commandOptions.Company)
+	runOptions.Aliases = append([]string(nil), commandOptions.Aliases...)
+	runOptions.Website = strings.TrimSpace(commandOptions.Website)
+	runOptions.MatchCriteria = !commandOptions.All
 	return runOptions
+}
+
+func (o fetchRunOptions) companyTargeted() bool {
+	return strings.TrimSpace(o.Company) != ""
 }
 
 func sessionFetchConfig(disableLLM bool, appCfg *AppConfig) *AppConfig {
@@ -72,6 +75,21 @@ func fetchConfigForRun(appCfg *AppConfig, runOptions fetchRunOptions) *AppConfig
 		cfgCopy.LLM.JobFiltering = false
 		cfgCopy.LLM.CompanyHealth = false
 	}
+	if runOptions.companyTargeted() {
+		cfgCopy.Sources.RSS.Enabled = false
+		cfgCopy.Sources.APIs = append([]config.APISource(nil), cfgCopy.Sources.APIs...)
+		for i := range cfgCopy.Sources.APIs {
+			cfgCopy.Sources.APIs[i].Enabled = false
+		}
+		cfgCopy.Sources.Remotive.Enabled = false
+		cfgCopy.Sources.Enabled = cfgCopy.Sources.SiteSearch.Enabled
+		cfgCopy.Sources.BuiltinsEnabled = cfgCopy.Sources.SiteSearch.Enabled
+		if !cfgCopy.LLM.Enabled {
+			cfgCopy.LLM.JobSearch = false
+			cfgCopy.LLM.JobFiltering = false
+			cfgCopy.Sources.LLMWeb.Enabled = false
+		}
+	}
 	return &cfgCopy
 }
 
@@ -80,6 +98,12 @@ func fetchStartMessage(disableLLM bool) string {
 }
 
 func fetchStartMessageForOptions(runOptions fetchRunOptions) string {
+	if runOptions.companyTargeted() {
+		if runOptions.MatchCriteria {
+			return fmt.Sprintf("Searching %s openings that match your criteria...", strings.TrimSpace(runOptions.Company))
+		}
+		return fmt.Sprintf("Searching all public openings at %s...", strings.TrimSpace(runOptions.Company))
+	}
 	appCfg, err := config.LoadAppConfig(runtimeConfigPath)
 	if err != nil {
 		return "Fetching jobs with your current configuration..."
@@ -223,6 +247,19 @@ func fetchAllJobs(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaC
 	return fetcher.FetchAllJobsSkippingExistingWithCandidateCache(ctx, appCfg, criteriaCfg, existingJobs, progress, runtimeCandidateStore)
 }
 
+func fetchJobsForRun(ctx context.Context, appCfg *AppConfig, criteriaCfg *CriteriaConfig, existingJobs []Job, progress func(string), runOptions fetchRunOptions) ([]Job, FetchSummary, error) {
+	fetcher.RegisterLLMService(llmpkg.NewLLMService())
+	if runOptions.companyTargeted() {
+		return fetcher.FetchCompanyJobsSkippingExistingWithCandidateCache(ctx, appCfg, criteriaCfg, fetcher.CompanyFetchOptions{
+			Company:       runOptions.Company,
+			Aliases:       append([]string(nil), runOptions.Aliases...),
+			Website:       runOptions.Website,
+			MatchCriteria: runOptions.MatchCriteria,
+		}, existingJobs, progress, runtimeCandidateStore)
+	}
+	return fetcher.FetchAllJobsSkippingExistingWithCandidateCache(ctx, appCfg, criteriaCfg, existingJobs, progress, runtimeCandidateStore)
+}
+
 func setupPreviewNotice(existingCount int, previewCount int, added int) string {
 	switch {
 	case previewCount == 0 && existingCount > 0:
@@ -286,7 +323,7 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 		}
 
 		sourceFetchStart := time.Now()
-		newJobs, summary, err := fetchAllJobs(ctx, appCfg, criteriaCfg, existingJobs, func(message string) {
+		newJobs, summary, err := fetchJobsForRun(ctx, appCfg, criteriaCfg, existingJobs, func(message string) {
 			if strings.TrimSpace(message) == "" {
 				return
 			}
@@ -294,7 +331,7 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 			case progressCh <- message:
 			default:
 			}
-		})
+		}, runOptions)
 		if err != nil {
 			return fetchJobsMsg{err: err}
 		}
@@ -307,33 +344,41 @@ func fetchJobsWithOptionsCmd(runOptions fetchRunOptions, existingJobs []Job, pro
 			time.Since(sourceFetchStart).Round(time.Millisecond),
 		)
 
-		newJobs = fetcher.ApplyCachedLLMFilterDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, newJobs, &summary)
-		if llmJobFilteringShouldRun(appCfg, newJobs) {
-			select {
-			case progressCh <- "Running LLM job filtering before review...":
-			default:
-			}
-		} else {
+		if runOptions.companyTargeted() && !runOptions.MatchCriteria {
 			select {
 			case progressCh <- "Preparing fetch results for review...":
 			default:
 			}
+			logDebug("fetch finalization: skipped LLM job filtering for company fetch --all")
+		} else {
+			newJobs = fetcher.ApplyCachedLLMFilterDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, newJobs, &summary)
+			if llmJobFilteringShouldRun(appCfg, newJobs) {
+				select {
+				case progressCh <- "Running LLM job filtering before review...":
+				default:
+				}
+			} else {
+				select {
+				case progressCh <- "Preparing fetch results for review...":
+				default:
+				}
+			}
+			beforeLLMFilter := append([]Job(nil), newJobs...)
+			recordLLMJobFilteringBypassReasons(appCfg, criteriaCfg, &summary, beforeLLMFilter)
+			llmFilterStart := time.Now()
+			newJobs, notices := applyOptionalLLMJobFilteringWithFreshTimeout(appCfg, criteriaCfg, newJobs)
+			fetcher.RecordLLMFilterCandidateDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, beforeLLMFilter, newJobs, notices)
+			recordLLMJobFilteringOutcome(appCfg, &summary, beforeLLMFilter, newJobs, notices)
+			summary.Notices = append(summary.Notices, notices...)
+			logDebug(
+				"fetch finalization: llm filtering complete before=%d after=%d dropped=%d notices=%d duration=%s",
+				len(beforeLLMFilter),
+				len(newJobs),
+				len(beforeLLMFilter)-len(newJobs),
+				len(notices),
+				time.Since(llmFilterStart).Round(time.Millisecond),
+			)
 		}
-		beforeLLMFilter := append([]Job(nil), newJobs...)
-		recordLLMJobFilteringBypassReasons(appCfg, criteriaCfg, &summary, beforeLLMFilter)
-		llmFilterStart := time.Now()
-		newJobs, notices := applyOptionalLLMJobFilteringWithFreshTimeout(appCfg, criteriaCfg, newJobs)
-		fetcher.RecordLLMFilterCandidateDecisions(ctx, runtimeCandidateStore, appCfg, criteriaCfg, beforeLLMFilter, newJobs, notices)
-		recordLLMJobFilteringOutcome(appCfg, &summary, beforeLLMFilter, newJobs, notices)
-		summary.Notices = append(summary.Notices, notices...)
-		logDebug(
-			"fetch finalization: llm filtering complete before=%d after=%d dropped=%d notices=%d duration=%s",
-			len(beforeLLMFilter),
-			len(newJobs),
-			len(beforeLLMFilter)-len(newJobs),
-			len(notices),
-			time.Since(llmFilterStart).Round(time.Millisecond),
-		)
 		newJobs = removeExistingJobsBeforeReview(newJobs, existingJobs, &summary)
 		logDebug("fetch finalization: review handoff jobs=%d total_duration=%s", len(newJobs), time.Since(fetchStart).Round(time.Millisecond))
 

--- a/internal/tuiapp/update_keys.go
+++ b/internal/tuiapp/update_keys.go
@@ -149,14 +149,12 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.isCommanding {
+		m.clearOperatorCommandResult()
 		switch msg.String() {
 		case "esc":
 			m.isCommanding = false
 			m.resetOperatorCommandPrompt()
 			m.commandInput.Blur()
-			m.commandResultTitle = ""
-			m.commandResultMessage = ""
-			m.commandResultError = false
 			return m, nil
 		case "tab":
 			m.applyOperatorCommandCompletion()
@@ -169,9 +167,6 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			var cmd2 tea.Cmd
 			m.commandInput, cmd2 = m.commandInput.Update(msg)
 			m.updateOperatorCommandTypedInput()
-			m.commandResultTitle = ""
-			m.commandResultMessage = ""
-			m.commandResultError = false
 			return m, cmd2
 		case "enter":
 			input := m.commandInput.Value()
@@ -188,9 +183,6 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				identity.Company = company
 				m.isCommanding = false
 				m.commandInput.Blur()
-				m.commandResultTitle = ""
-				m.commandResultMessage = ""
-				m.commandResultError = false
 				m.openCompanyHealthIdentityOverlay(identity, true, fmt.Sprintf("Loading health for %s...", company), nil, "")
 				return m, tea.Batch(loadCompanyHealthWithIdentity(identity, false), m.restartLoadingIndicator())
 			}
@@ -207,9 +199,6 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.fetchProgress = progressCh
 				m.isCommanding = false
 				m.commandInput.Blur()
-				m.commandResultTitle = ""
-				m.commandResultMessage = ""
-				m.commandResultError = false
 				m.activeFetch = activeFetchState{
 					expanded:     true,
 					animProgress: 1.0,
@@ -227,9 +216,6 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.prepareOperatorCommandTyping()
 			m.commandInput, cmd2 = m.commandInput.Update(msg)
 			m.updateOperatorCommandTypedInput()
-			m.commandResultTitle = ""
-			m.commandResultMessage = ""
-			m.commandResultError = false
 			return m, cmd2
 		}
 	}

--- a/internal/tuiapp/view.go
+++ b/internal/tuiapp/view.go
@@ -100,44 +100,7 @@ func (m model) View() string {
 
 	var helpView string
 	if m.isCommanding {
-		commandStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true)
-		commandHintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-		commandResultTitleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Bold(true)
-		commandResultBodyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-		if m.commandResultError {
-			commandResultTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-		}
-		lines := []string{}
-		if m.commandResultMessage != "" {
-			resultBody := strings.ReplaceAll(m.commandResultMessage, "\n", " • ")
-			lines = append(lines, commandResultTitleStyle.Render(m.commandResultTitle)+helpValueStyle.Render(" ")+commandResultBodyStyle.Render(resultBody))
-		} else {
-			lines = append(lines, " ")
-		}
-		commandLine := commandStyle.Render(":") + " " + m.commandInputInlineView(m.operatorCommandGhostHint(), commandHintStyle)
-		lines = append(lines, commandLine)
-		lines = append(lines, commandHintStyle.Render("Tab Select/Cycle • Space Confirm • Enter Run • Esc Cancel"))
-		if pool := m.operatorCommandPool(); len(pool) > 0 {
-			commandPoolSelectedStyle := lipgloss.NewStyle().
-				Foreground(lipgloss.Color("230")).
-				Background(lipgloss.Color("60")).
-				Bold(true)
-			parts := make([]string, 0, len(pool))
-			for i, completion := range pool {
-				label := completion.Label
-				if m.commandCompletionActive && i == m.commandCompletionIdx {
-					label = commandPoolSelectedStyle.Render(label)
-				} else {
-					label = commandHintStyle.Render(label)
-				}
-				parts = append(parts, label)
-			}
-			lines = append(lines, strings.Join(parts, "  "))
-		}
-		helpText := strings.Join(lines, "\n")
-		helpView = helpStyle.
-			Width(m.termWidth - 4).
-			Render(helpText)
+		helpView = m.commandFooterView()
 	} else if m.isFiltering {
 		searchStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Bold(true)
 		helpText := searchStyle.Render("Search: ") + m.textInput.View() + "  (Enter: Apply • Esc: Clear)"
@@ -187,7 +150,7 @@ func (m model) View() string {
 		helpView = helpStyle.Width(m.termWidth - 4).Render(helpText)
 	}
 
-	baseView := tableView + "\n" + helpView + "\n"
+	baseView := composeTableAndHelpView(tableView, helpView, m.termHeight, m.isCommanding)
 	if activity := m.backgroundTaskActivityView(); activity != "" {
 		baseView = placeOverlay(0, 0, activity, baseView)
 	}
@@ -227,6 +190,68 @@ func (m model) View() string {
 	}
 
 	return viewWithOverlays
+}
+
+func (m model) commandFooterView() string {
+	commandStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true)
+	commandHintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	commandResultTitleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Bold(true)
+	commandResultBodyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	if m.commandResultError {
+		commandResultTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	}
+
+	lines := []string{}
+	if m.commandResultMessage != "" {
+		resultBody := strings.ReplaceAll(m.commandResultMessage, "\n", " • ")
+		lines = append(lines, commandResultTitleStyle.Render(m.commandResultTitle)+helpValueStyle.Render(" ")+commandResultBodyStyle.Render(resultBody))
+	}
+
+	commandLine := commandStyle.Render(":") + " " + m.commandInputInlineView(m.operatorCommandGhostHint(), commandHintStyle)
+	lines = append(lines, commandLine)
+	completionLine := ""
+	if pool := m.operatorCommandPool(); len(pool) > 0 {
+		commandPoolSelectedStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("230")).
+			Background(lipgloss.Color("60")).
+			Bold(true)
+		parts := make([]string, 0, len(pool))
+		for i, completion := range pool {
+			label := completion.Label
+			if m.commandCompletionActive && i == m.commandCompletionIdx {
+				label = commandPoolSelectedStyle.Render(label)
+			} else {
+				label = commandHintStyle.Render(label)
+			}
+			parts = append(parts, label)
+		}
+		completionLine = strings.Join(parts, "  ")
+	}
+	lines = append(lines, completionLine)
+	lines = append(lines, strings.Join([]string{
+		formatHelpItem("Tab", "Select/Cycle"),
+		formatHelpItem("Space", "Confirm"),
+		formatHelpItem("Enter", "Run"),
+		formatHelpItem("Esc", "Cancel"),
+	}, " • "))
+
+	return helpStyle.
+		Width(m.termWidth - 4).
+		Render(strings.Join(lines, "\n"))
+}
+
+func composeTableAndHelpView(tableView string, helpView string, termHeight int, pinHelpToBottom bool) string {
+	if !pinHelpToBottom {
+		return tableView + "\n" + helpView + "\n"
+	}
+	gap := 1
+	if termHeight > 0 {
+		gap = termHeight - lipgloss.Height(tableView) - lipgloss.Height(helpView) + 1
+		if gap < 1 {
+			gap = 1
+		}
+	}
+	return tableView + strings.Repeat("\n", gap) + helpView
 }
 
 func (m model) commandInputInlineView(ghost string, ghostStyle lipgloss.Style) string {


### PR DESCRIPTION
This pull request introduces a new capability for targeted company job searches, allowing the system to fetch jobs specifically for a given company, with support for company aliases and website verification. It adds a new API for company-specific job fetching, refines the job filtering logic to ensure accurate company matches, and adapts job source selection and prompt generation accordingly. Several changes also ensure that RSS and API sources are excluded from company-targeted searches, and comprehensive tests are added to validate the new matching logic.

**Company-targeted job fetching and filtering:**

* Added `CompanyFetchOptions` and `companyFetchScope` types, along with logic to activate company-specific fetches, aggregate company names/aliases, and match company websites. Introduced `filterJobsByCompanyTarget` and `jobMatchesCompanyTarget` to filter results by company name, aliases, and website, ensuring only relevant jobs are returned. [[1]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R23-R66) [[2]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R635-R740)
* Implemented the `FetchCompanyJobsSkippingExistingWithCandidateCache` function, which disables RSS and API sources for company fetches and invokes the new scoped job fetching logic.
* Modified the main job fetching pipeline to apply company filtering after all jobs are fetched, and to record filtered-out jobs in the summary.

**Source selection and prompt adaptation:**

* Adjusted source resolution and fetching logic to use company-specific criteria when a company fetch is active, including disabling RSS and API sources, customizing LLM prompts, and generating site search URLs for the target company. [[1]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R76-R90) [[2]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R163-R179) [[3]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8L164-R232) [[4]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8L228-R296) [[5]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R350-R354) [[6]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8R374-R383) [[7]](diffhunk://#diff-545097d439d78c2893029e1b67153bf05f406c0a2f66a67e9fbbedf0cf1559d8L403-R483)
* Added `buildCompanyLLMSearchPrompt` to generate LLM prompts tailored to company-targeted searches, including company details, aliases, website, and candidate criteria as needed.

**Testing and company name normalization:**

* Added a unit test (`TestJobMatchesCompanyTargetUsesWebsiteAndAliases`) to verify company matching by name, alias, and website.
* Updated `cleanCompanyName` to recognize "llc" and "llc." as company suffixes for improved normalization.